### PR TITLE
Extended plugin support

### DIFF
--- a/ZeGaryHax.h
+++ b/ZeGaryHax.h
@@ -4,6 +4,8 @@
 #include "Editor.h"
 #include "resource.h"
 #include <Psapi.h>
+#include <filesystem>
+#include <unordered_set>
 
 #define GH_NAME				"ZeGaryHax"		// this is the string for IsPluginInstalled and GetPluginVersion (also shows in nvse.log)
 #define GH_VERSION			0				// set this to 0 to enable log output from _DMESSAGE (useful for debug traces)

--- a/ZeGaryHax.vcxproj
+++ b/ZeGaryHax.vcxproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|Win32">
@@ -26,7 +26,7 @@
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
-    <PlatformToolset>v120</PlatformToolset>
+    <PlatformToolset>v142</PlatformToolset>
     <CharacterSet>MultiByte</CharacterSet>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
@@ -68,6 +68,7 @@
       <WarningLevel>Level3</WarningLevel>
       <DebugInformationFormat>EditAndContinue</DebugInformationFormat>
       <ForcedIncludeFiles>nvse/prefix.h;%(ForcedIncludeFiles)</ForcedIncludeFiles>
+      <LanguageStandard>stdcpp17</LanguageStandard>
     </ClCompile>
     <Link>
       <ModuleDefinitionFile>exports.def</ModuleDefinitionFile>
@@ -77,14 +78,13 @@
       <DataExecutionPrevention />
       <TargetMachine>MachineX86</TargetMachine>
       <ImageHasSafeExceptionHandlers>false</ImageHasSafeExceptionHandlers>
-      <AdditionalDependencies>kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;xinput9_1_0.lib;Winmm.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;xinput9_1_0.lib;Winmm.lib;Psapi.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <GenerateMapFile>true</GenerateMapFile>
       <MapExports>true</MapExports>
     </Link>
     <PostBuildEvent>
       <Message>Installing DLL...</Message>
-      <Command>copy "$(TargetPath)" "C:\Games\steamapps\common\Fallout New Vegas\Data\nvse\plugins\$(TargetFileName)"
-C:\Modding\MO2\ModOrganizer.exe "moshortcut://Tale of Two Wastelands:x32dbg GECK"</Command>
+      <Command>copy "$(TargetPath)" "$(FalloutNVPath)\Data\nvse\plugins\$(TargetFileName)"</Command>
     </PostBuildEvent>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
@@ -97,7 +97,7 @@ C:\Modding\MO2\ModOrganizer.exe "moshortcut://Tale of Two Wastelands:x32dbg GECK
       <DebugInformationFormat>None</DebugInformationFormat>
       <ForcedIncludeFiles>nvse/prefix.h;%(ForcedIncludeFiles)</ForcedIncludeFiles>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <LanguageStandard>stdcpplatest</LanguageStandard>
+      <LanguageStandard>stdcpp17</LanguageStandard>
     </ClCompile>
     <Link>
       <ModuleDefinitionFile>exports.def</ModuleDefinitionFile>
@@ -113,8 +113,7 @@ C:\Modding\MO2\ModOrganizer.exe "moshortcut://Tale of Two Wastelands:x32dbg GECK
     </Link>
     <PostBuildEvent>
       <Message>Installing DLL...</Message>
-      <Command>copy "$(TargetPath)" "C:\Games\steamapps\common\Fallout New Vegas\Data\nvse\plugins\$(TargetFileName)"
-C:\Modding\MO2\ModOrganizer.exe "moshortcut://Tale of Two Wastelands:x32dbg GECK"</Command>
+      <Command>copy "$(TargetPath)" "$(FalloutNVPath)\Data\nvse\plugins\$(TargetFileName)"</Command>
     </PostBuildEvent>
   </ItemDefinitionGroup>
   <ItemGroup>

--- a/ZeLogWindow.h
+++ b/ZeLogWindow.h
@@ -24,6 +24,7 @@
 #define ID_RENDERWINDOW_SHOWWATER_CHECKBOX	51015
 #define ID_RENDERWINDOW_SHOWPORTALS_CHECKBOX	51016
 #define UI_EXTMENU_OBJECTWINDOW_TOGGLESHOWUNEDITED	51017
+#define MAIN_WINDOW_CALLBACK 0xFEED
 
 // unused button in vanilla menu
 #define MENUOPTION_RENDER_WINDOW 0x9D06
@@ -616,7 +617,16 @@ LRESULT CALLBACK EditorUI_WndProc(HWND Hwnd, UINT Message, WPARAM wParam, LPARAM
 			}
 		}
 		return 0;
+			
+		case MAIN_WINDOW_CALLBACK:
+		{
+			auto callback = reinterpret_cast<void(*)()>(lParam);
+			callback();
 		}
+		return 0;
+		}
+		
+		
 	}
 	else if (Message == WM_SETTEXT && Hwnd == g_MainHwnd)
 	{

--- a/ZeLogWindow.h
+++ b/ZeLogWindow.h
@@ -5,6 +5,7 @@
 #define UI_CMD_ADDLOGTEXT	(WM_APP + 1)
 #define UI_CMD_CLEARLOGTEXT (WM_APP + 2)
 #define UI_CMD_AUTOSCROLL	(WM_APP + 3)
+#define UI_CMD_ADDLOGTEXT_NOFREE (WM_APP + 4)
 
 #define UI_EXTMENU_ID			51001
 #define UI_EXTMENU_SHOWLOG		51002
@@ -664,6 +665,38 @@ LRESULT CALLBACK EditorUI_WndProc(HWND Hwnd, UINT Message, WPARAM wParam, LPARAM
 	return CallWindowProc(OldEditorUI_WndProc, Hwnd, Message, wParam, lParam);
 }
 
+void AddLogText(LPARAM lParam, HWND richEditHwnd, bool doFree)
+{
+	void* textData = (void*)lParam;
+
+	//	Save old position if not scrolling
+	POINT scrollRange;
+
+	if (!bAutoScroll)
+	{
+		SendMessageA(richEditHwnd, WM_SETREDRAW, FALSE, 0);
+		SendMessageA(richEditHwnd, EM_GETSCROLLPOS, 0, (WPARAM)&scrollRange);
+	}
+
+	//	Move caret to the end, then write
+	CHARRANGE range;
+	range.cpMin = LONG_MAX;
+	range.cpMax = LONG_MAX;
+
+	SendMessageA(richEditHwnd, EM_EXSETSEL, 0, (LPARAM)&range);
+	SendMessageA(richEditHwnd, EM_REPLACESEL, FALSE, (LPARAM)textData);
+
+	if (!bAutoScroll)
+	{
+		SendMessageA(richEditHwnd, EM_SETSCROLLPOS, 0, (WPARAM)&scrollRange);
+		SendMessageA(richEditHwnd, WM_SETREDRAW, TRUE, 0);
+		RedrawWindow(richEditHwnd, nullptr, nullptr, RDW_ERASE | RDW_INVALIDATE | RDW_NOCHILDREN);
+	}
+
+	if (doFree)
+		free(textData);
+}
+
 LRESULT CALLBACK EditorUI_LogWndProc(HWND Hwnd, UINT Message, WPARAM wParam, LPARAM lParam)
 {
 	static HWND richEditHwnd;
@@ -785,36 +818,18 @@ LRESULT CALLBACK EditorUI_LogWndProc(HWND Hwnd, UINT Message, WPARAM wParam, LPA
 
 	case UI_CMD_ADDLOGTEXT:
 	{
-		void* textData = (void*)lParam;
-
-		//	Save old position if not scrolling
-		POINT scrollRange;
-
-		if (!bAutoScroll)
-		{
-			SendMessageA(richEditHwnd, WM_SETREDRAW, FALSE, 0);
-			SendMessageA(richEditHwnd, EM_GETSCROLLPOS, 0, (WPARAM)&scrollRange);
-		}
-
-		//	Move caret to the end, then write
-		CHARRANGE range;
-		range.cpMin = LONG_MAX;
-		range.cpMax = LONG_MAX;
-
-		SendMessageA(richEditHwnd, EM_EXSETSEL, 0, (LPARAM)&range);
-		SendMessageA(richEditHwnd, EM_REPLACESEL, FALSE, (LPARAM)textData);
-
-		if (!bAutoScroll)
-		{
-			SendMessageA(richEditHwnd, EM_SETSCROLLPOS, 0, (WPARAM)&scrollRange);
-			SendMessageA(richEditHwnd, WM_SETREDRAW, TRUE, 0);
-			RedrawWindow(richEditHwnd, nullptr, nullptr, RDW_ERASE | RDW_INVALIDATE | RDW_NOCHILDREN);
-		}
-
-		free(textData);
+		AddLogText(lParam, richEditHwnd, true);
 	}
 	return 0;
 
+
+	case UI_CMD_ADDLOGTEXT_NOFREE:
+	{
+		AddLogText(lParam, richEditHwnd, false);
+	}
+	return 0;
+
+		
 	case UI_CMD_CLEARLOGTEXT:
 	{
 		char emptyString[1] = { '\0' };

--- a/common/common_vc9.vcxproj
+++ b/common/common_vc9.vcxproj
@@ -83,7 +83,7 @@
       <WarningLevel>Level3</WarningLevel>
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
       <ForcedIncludeFiles>common/IPrefix.h;%(ForcedIncludeFiles)</ForcedIncludeFiles>
-      <LanguageStandard>stdcpplatest</LanguageStandard>
+      <LanguageStandard>stdcpp17</LanguageStandard>
     </ClCompile>
   </ItemDefinitionGroup>
   <ItemGroup>

--- a/common/common_vc9.vcxproj
+++ b/common/common_vc9.vcxproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|Win32">
@@ -30,7 +30,7 @@
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <ConfigurationType>StaticLibrary</ConfigurationType>
-    <PlatformToolset>v120</PlatformToolset>
+    <PlatformToolset>v142</PlatformToolset>
     <CharacterSet>MultiByte</CharacterSet>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />


### PR DESCRIPTION
1. Adds a way to run callback from main window thread with param ID 0xFEED
```C++
void MainWindowCallback()
{
    ...
}

auto* window = FindWindow("Garden of Eden Creation Kit", nullptr);
if (window)
{
    SendMessage(window, WM_COMMAND, 0xFEED, reinterpret_cast<LPARAM>(MainWindowCallback));
}
```
2. Adds a way to log from a plugin with id 0x8004:
```C++
void GeckExtenderMessageLog(const char* fmt, ...)
{
	va_list args;
	va_start(args, fmt);

	auto* window = FindWindow("RTEDITLOG", nullptr);
	if (!window)
	{
		_MESSAGE("Failed to find GECK Extender Message Log window");
		return;
	}
	
	char buffer[0x400];
	vsprintf_s(buffer, 0x400, fmt, args);

	// Extender handles freeing buffer
	SendMessage(window, 0x8004, 0, reinterpret_cast<LPARAM>(buffer));
}
```