### PR TITLE
Restore debug light count shader

### DIFF
--- a/DebugCellShaders.h
+++ b/DebugCellShaders.h
@@ -125,17 +125,16 @@ _declspec(naked) void DebugShaderHook965B40()
 
 
 // TODO - Wall
-// Attach bAutoPreview to some button or a hotkey
+// Attach bAutoLightWarnings to some button or a hotkey
 // Finish Lighting30Shader variant
 
-static bool bAutoPreview = false;
 static bool bRenderModeChanged = false;
 static DebugRenderModes eLastRenderMode = DEBUG_NONE;
 
 void inline HandleDebugRender(DWORD* pShader, DWORD* pShaderProperty, DWORD* pRenderPass, DWORD* pGeometry, DWORD* pMaterialProperty, bool bIs30Shader) {
 	UInt32 uiLightCount = ThisStdCall(0x925830, pShaderProperty); // GetActiveLightCount
 
-	static bool bAutoColor = bAutoPreview && (uiLightCount > 6) && eDebugRenderMode != DEBUG_LIGHT_COUNT;
+	bool bAutoColor = bAutoLightWarnings && (uiLightCount > 6) && eDebugRenderMode != DEBUG_LIGHT_COUNT;
 
 	if (eLastRenderMode != eDebugRenderMode) {
 		bRenderModeChanged = true;

--- a/DebugCellShaders.h
+++ b/DebugCellShaders.h
@@ -1,5 +1,34 @@
 #pragma once
 
+enum DebugRenderModes {
+	DEBUG_NONE = 0,
+	DEBUG_LIGHT_COUNT = 1,
+	DEBUG_PASS_COUNT = 2,
+	DEBUG_TEXTURE_COUNT = 4,
+};
+
+#define LightingFlags *(UInt32*)0xF23C28
+#define eDebugRenderMode *(DebugRenderModes*)0xF23C04
+#define ShaderConstant_AmbientColor (*(NiColorAlpha*)0xF244E0)
+#define ShaderConstant_AmbientColor30 (*(NiColorAlpha*)0xF2B988)
+
+
+
+static const NiColorAlpha LightCountDebugColors[] = {
+	NiColorAlpha(0.0f, 1.0f, 0.0f, 1.0f),
+	NiColorAlpha(0.0f, 0.8f, 0.2f, 1.0f),
+	NiColorAlpha(0.0f, 0.6f, 0.4f, 1.0f),
+	NiColorAlpha(0.0f, 0.4f, 0.6f, 1.0f),
+	NiColorAlpha(0.0f, 0.2f, 0.8f, 1.0f),
+	NiColorAlpha(0.0f, 0.0f, 1.0f, 1.0f),
+	NiColorAlpha(0.2f, 0.0f, 0.8f, 1.0f),
+	NiColorAlpha(0.4f, 0.0f, 0.6f, 1.0f),
+	NiColorAlpha(0.6f, 0.0f, 0.4f, 1.0f),
+	NiColorAlpha(0.8f, 0.0f, 0.2f, 1.0f),
+	NiColorAlpha(1.0f, 0.0f, 0.0f, 1.0f),
+};
+
+
 _declspec(naked) void DebugShaderHook925E80()
 {
 	static const UInt32 debugAddr = 0x925E8D;
@@ -52,7 +81,6 @@ _declspec(naked) void DebugShaderHook952F60()
 	}
 }
 
-
 _declspec(naked) void DebugShaderHook965B40()
 {
 	static const UInt32 retnAddr = 0x965B78;
@@ -95,45 +123,82 @@ _declspec(naked) void DebugShaderHook965B40()
 	}
 }
 
-_declspec(naked) void DebugShaderHook9661C0()
-{
-	_asm
-	{
-		mov eax, [0xF23C04] // g_renderWindowShaderDebugFlags
-		cmp eax, 1
-		je shader1
-		cmp eax, 2
-		je shader2
-		cmp eax, 4
-		je shader4
-		cmp eax, 5
-		je shader5
-	shader1:
 
-	shader2:
+// TODO - Wall
+// Attach bAutoPreview to some button or a hotkey
+// Finish Lighting30Shader variant
 
-	shader4:
+static bool bAutoPreview = false;
+static bool bRenderModeChanged = false;
+static DebugRenderModes eLastRenderMode = DEBUG_NONE;
 
-	shader5:
+void inline HandleDebugRender(DWORD* pShader, DWORD* pShaderProperty, DWORD* pRenderPass, DWORD* pGeometry, DWORD* pMaterialProperty, bool bIs30Shader) {
+	UInt32 uiLightCount = ThisStdCall(0x925830, pShaderProperty); // GetActiveLightCount
 
-		//	done
-		add esp, 0x10
-		ret 8
+	static bool bAutoColor = bAutoPreview && (uiLightCount > 6) && eDebugRenderMode != DEBUG_LIGHT_COUNT;
+
+	if (eLastRenderMode != eDebugRenderMode) {
+		bRenderModeChanged = true;
+		eLastRenderMode = eDebugRenderMode;
 	}
+
+	if (eDebugRenderMode == 1 || bAutoColor) {
+		uiLightCount = max(min(uiLightCount, 10), 0);
+		static NiColorAlpha* pAmbientColor = bIs30Shader ? &ShaderConstant_AmbientColor30 : &ShaderConstant_AmbientColor;
+		*pAmbientColor = LightCountDebugColors[uiLightCount];
+
+		if (bAutoColor) {
+			pAmbientColor->Scale(3.0f);
+		}
+
+		if (eDebugRenderMode == 1 && bRenderModeChanged) {
+			LightingFlags = 1;
+			bRenderModeChanged = false;
+		}
+	}
+	else {
+		if (bIs30Shader) {
+			StdCall(0x9661C0, pMaterialProperty, pShaderProperty); // Lighting30Shader::UpdateAmbientColor
+		}
+		else {
+			StdCall(0x94DA90, pShaderProperty, pRenderPass, pGeometry, pMaterialProperty); // ShadowLightShader::UpdateAmbientColor
+		}
+		if (bRenderModeChanged) {
+			LightingFlags |= (1 | 2 | 8 | 20);
+			bRenderModeChanged = false;
+		}
+	}
+}
+
+void __stdcall ShadowLightShader_UpdateAmbientColorEx(DWORD* pShaderProperty, DWORD* pRenderPass, DWORD* pGeometry, DWORD* pMaterialProperty) {
+	HandleDebugRender(nullptr, pShaderProperty, pRenderPass, pGeometry, pMaterialProperty, false);
+}
+
+void __stdcall Lighting30Shader_UpdateAmbientColor30Ex(DWORD* pMaterialProperty, DWORD* pShaderProperty) {
+	HandleDebugRender(nullptr, pShaderProperty, nullptr, nullptr, pMaterialProperty, true);
 }
 
 void RestoreRenderWindowDebugShaders()
 {
-	WriteRelJump(0x925EC8, UInt32(DebugShaderHook925E80));
-	WriteRelJump(0x926223, UInt32(DebugShaderHook9261D0));
-	WriteRelJump(0x953744, UInt32(DebugShaderHook952F60));
-	WriteRelJump(0x965B6C, UInt32(DebugShaderHook965B40));
-	WriteRelJump(0x965B6C, UInt32(DebugShaderHook965B40));
+	// Needs more decoding. They are for 3.0 shaders which are not that important for now - Wall
+	//WriteRelJump(0x925EC8, UInt32(DebugShaderHook925E80));
+	//WriteRelJump(0x926223, UInt32(DebugShaderHook9261D0));
+	//WriteRelJump(0x953744, UInt32(DebugShaderHook952F60));
+	//WriteRelJump(0x965B6C, UInt32(DebugShaderHook965B40));
 
-	// add in switch statements
-	WriteRelJump(0x9663C0, UInt32(DebugShaderHook9661C0));
-	WriteRelJump(0x9663D0, UInt32(DebugShaderHook9661C0));
-	WriteRelJump(0x966336, UInt32(DebugShaderHook9661C0));
-	// still need to add the two switch statements in sub_94DA90 and sub_9661C0
+	WriteRelCall(0x94FBAB, UInt32(ShadowLightShader_UpdateAmbientColorEx));
+	//WriteRelCall(0x966625, UInt32(Lighting30Shader_UpdateAmbientColor30Ex));
+
+#define RES_HACKER_ADDR_TO_ACTUAL 0x4CF800
+
+	// Set WS_VISIBLE on debug shader buttons - Stewie
+	SafeWrite8(RES_HACKER_ADDR_TO_ACTUAL + 0xC2DD97, 0x50);
+	SafeWrite8(RES_HACKER_ADDR_TO_ACTUAL + 0xC2DD97 + 0x30, 0x50);
+	SafeWrite8(RES_HACKER_ADDR_TO_ACTUAL + 0xC2DD97 + 0x60, 0x50);
+	SafeWrite8(RES_HACKER_ADDR_TO_ACTUAL + 0xC2DD97 + 0x90, 0x50);
+	SafeWrite8(RES_HACKER_ADDR_TO_ACTUAL + 0xC2DD97 + 0xC0, 0x50);
+	SafeWrite8(RES_HACKER_ADDR_TO_ACTUAL + 0xC2DD97 + 0x100, 0x50);
+	SafeWrite8(RES_HACKER_ADDR_TO_ACTUAL + 0xC2DD97 + 0x134, 0x50);
+	SafeWrite8(RES_HACKER_ADDR_TO_ACTUAL + 0xC2DD97 + 0x16C, 0x50);
+	SafeWrite8(RES_HACKER_ADDR_TO_ACTUAL + 0xC2DD97 + 0x1A4, 0x50);
 }
-

--- a/ZeGaryHax.cpp
+++ b/ZeGaryHax.cpp
@@ -673,6 +673,8 @@ bool NVSEPlugin_Load(const NVSEInterface* nvse)
 	// allow Telekinesis in base effect archtype dropdown
 	SafeWrite8(0xEA8EE8, 0x0);
 
+	RestoreRenderWindowDebugShaders();
+
 	WriteRelCall(0x596581, UInt32(ExportDialogueEndPlaySound));
 	return true;
 }

--- a/ZeGaryHax.cpp
+++ b/ZeGaryHax.cpp
@@ -95,6 +95,7 @@ bool NVSEPlugin_Load(const NVSEInterface* nvse)
 	bObjectWindowOnlyShowEditedByDefault = GetOrCreateINIInt("General", "bObjectWindowOnlyShowEditedForms", 0, iniName);
 	bPreventFaceAndBodyModExports = GetOrCreateINIInt("General", "bFaceBodyExportPreventTGAFiles", 0, iniName);
 	bIgnoreD3D9 = GetOrCreateINIInt("General", "bIgnoreD3D9", 1, iniName);
+	bAutoLightWarnings = GetOrCreateINIInt("General", "bAutoLightWarnings", 0, iniName);
 
 	bPatchScriptEditorFont = GetOrCreateINIInt("Script", "bPatchEditorFont", 1, iniName);
 	bScriptCompileWarningPopup = GetOrCreateINIInt("Script", "bScriptCompileWarningPopup", 0, iniName);

--- a/ZeGaryHax.h
+++ b/ZeGaryHax.h
@@ -110,6 +110,7 @@ int bObjectWindowOnlyShowEditedByDefault = 0;
 int bDisableTextureMirroring = 1;
 int bPreventFaceAndBodyModExports = 0;
 int bIgnoreD3D9 = 1;
+int bAutoLightWarnings = 0;
 int bRemoveDialogSoundFilter = 0;
 int bCacheComboboxes = 0;
 

--- a/nvse/NiTypes.h
+++ b/nvse/NiTypes.h
@@ -97,6 +97,15 @@ struct NiColorAlpha
 	float	g;
 	float	b;
 	float	a;
+
+	NiColorAlpha(float r, float g, float b, float a) : r(r), g(g), b(b), a(a) {};
+
+	void Scale(float fScale) {
+		r *= fScale;
+		g *= fScale;
+		b *= fScale;
+		a *= fScale;
+	};
 };
 
 // 10

--- a/nvse/Utilities.h
+++ b/nvse/Utilities.h
@@ -213,3 +213,9 @@ __forceinline UInt32 ThisStdCall(UInt32 _f, void* _t, T1 a1, T2 a2, T3 a3, T4 a4
 	class T {}; union { UInt32 x; UInt32(T::*m)(T1, T2, T3, T4, T5, T6, T7); } u = { _f };
 	return ((T*)_t->*u.m)(a1, a2, a3, a4, a5, a6, a7);
 }
+
+template <typename T_Ret = void, typename ...Args>
+__forceinline T_Ret StdCall(UInt32 _addr, Args ...args)
+{
+	return ((T_Ret(__stdcall*)(Args...))_addr)(std::forward<Args>(args)...);
+}


### PR DESCRIPTION
DebugShaderHook965B40 was removed since it was just adding a switch for this, and only in the Lighting30Shader variant.