### PR TITLE
Nav mesh pick preventer

### DIFF
--- a/BetterFloatingFormList.cpp
+++ b/BetterFloatingFormList.cpp
@@ -1,3 +1,4 @@
+#include "BetterFloatingFormList.h"
 #include <commctrl.h>
 #include "GameObjects.h"
 #include "GECKUtility.h"
@@ -81,6 +82,7 @@ namespace BetterFloatingFormList
 			{
 				tList<TESForm> formsList;
 				formsList.Init();
+				int numItemsAdded = 0;
 				do
 				{
 					if (auto form = selectedFormIter->ref)
@@ -88,15 +90,22 @@ namespace BetterFloatingFormList
 						if (!IsFormInListView(listView, form))
 						{
 							formsList.Insert(form);
+							++numItemsAdded;
 						}
 					}
 				} while (selectedFormIter = selectedFormIter->next);
 
-				SetDeferListUpdate(listView, true);
-				CdeclCall(0x47E410, listView, &formsList, nullptr, nullptr);
-				SetDeferListUpdate(listView, false);
+				if (numItemsAdded)
+				{
+					SetDeferListUpdate(listView, true);
+					CdeclCall(0x47E410, listView, &formsList, nullptr, nullptr);
 
-				formsList.RemoveAll();
+					SendMessageA(listView, BFL_ADDED_ITEMS, (WPARAM)&formsList, numItemsAdded);
+
+					SetDeferListUpdate(listView, false);
+
+					formsList.RemoveAll();
+				}
 			}
 			break;
 		}

--- a/BetterFloatingFormList.h
+++ b/BetterFloatingFormList.h
@@ -1,5 +1,10 @@
 #pragma once
 namespace BetterFloatingFormList
 {
+	enum Messages
+	{
+		BFL_ADDED_ITEMS = WM_USER + 1000 // WPARAM (tList<TESForm>* modifiedForms) LPARAM (itemCount)
+	};
+
 	void Init();
 }

--- a/CustomRenderWindowHotkeys.cpp
+++ b/CustomRenderWindowHotkeys.cpp
@@ -3,6 +3,8 @@
 #include "GameData.h"
 #include "GameSettings.h"
 #include "GECKUtility.h"
+#include "NavMeshPickPreventer.h"
+
 #include <CommCtrl.h>
 
 namespace CustomRenderWindowHotkeys
@@ -80,7 +82,9 @@ namespace CustomRenderWindowHotkeys
 		kHotkey_FIRST,
 		kHotkey_ToggleShowLightMarkers = kHotkey_FIRST,
 		kHotkey_SetAllObjectsVisible,
-		kHotkey_PlaceXMarker
+		kHotkey_PlaceXMarker,
+		kHotkey_NavMeshIgnoreLastPick,
+		kHotkey_NavMeshIgnoreSelectedPicks,
 	};
 
 	static RenderWindowHotkey CustomHotkeys[] =
@@ -88,6 +92,8 @@ namespace CustomRenderWindowHotkeys
 		RenderWindowHotkey("Toggle Show Light Markers", "ToggleShowLightMarkers", 'I', RenderWindowHotkey::kRenderWindowPreferenceFlag_NONE, RenderWindowHotkey::kRenderHotkeyCategory_Visibility),
 		RenderWindowHotkey("Set All Objects Visible", "SetAllObjectsVisible", VK_OEM_4, RenderWindowHotkey::kRenderWindowPreferenceFlag_NONE, RenderWindowHotkey::kRenderHotkeyCategory_Visibility),
 		RenderWindowHotkey("Place XMarker", "PlaceXMarker", 'O'),
+		RenderWindowHotkey("Navmesh: Ignore Last Picked Form", "NavMeshIgnoreLastPick", 'K', RenderWindowHotkey::kRenderWindowPreferenceFlag_Navmesh, RenderWindowHotkey::kRenderHotkeyCategory_Navmesh),
+		RenderWindowHotkey("Navmesh: Ignore Selected Forms", "NavMeshIgnoreSelectedPicks", 'K', RenderWindowHotkey::kRenderWindowPreferenceFlag_Shift, RenderWindowHotkey::kRenderHotkeyCategory_Navmesh),
 	};
 
 	void HandleHotkey(UInt32 hotkey)
@@ -104,6 +110,14 @@ namespace CustomRenderWindowHotkeys
 
 		case kHotkey_SetAllObjectsVisible:
 			SetAllObjectsVisible();
+			break;
+
+		case kHotkey_NavMeshIgnoreLastPick:
+			NavMeshPickPreventer::OnKeyDown(false);
+			break;
+
+		case kHotkey_NavMeshIgnoreSelectedPicks:
+			NavMeshPickPreventer::OnKeyDown(true);
 			break;
 		}
 	}

--- a/ExtensionsMenu.cpp
+++ b/ExtensionsMenu.cpp
@@ -6,6 +6,7 @@
 #include "FormSearch.h"
 #include "ModifiedFormViewer.h"
 #include "Settings.h"
+#include "NavMeshPickPreventer.h"
 
 #define UI_EXTMENU_ID			51001
 #define UI_EXTMENU_SHOWLOG		51002
@@ -27,6 +28,7 @@
 #define UI_EXTMENU_TOGGLENAVEMESHBISECT 51018
 #define UI_EXTMENU_LOOKUPFORM 51019
 #define UI_EXTMENU_VIEW_MODIFIED_FORMS 51020
+#define UI_EXTMENU_VIEW_NAVMESH_IGNORED_FORMS 51021
 #define MAIN_WINDOW_CALLBACK 0xFEED
 
 // unused button in vanilla menu
@@ -112,7 +114,7 @@ bool EditorUI_CreateExtensionMenu(HWND MainWindow, HMENU MainMenu)
 	result = result && InsertMenu(g_ExtensionMenu, -1, MF_BYPOSITION | MF_SEPARATOR, (UINT_PTR)UI_EXTMENU_SPACER, "");
 	result = result && InsertMenu(g_ExtensionMenu, -1, MF_BYPOSITION | MF_STRING, (UINT_PTR)UI_EXTMENU_LOOKUPFORM, "Lookup Form");
 	result = result && InsertMenu(g_ExtensionMenu, -1, MF_BYPOSITION | MF_STRING, (UINT_PTR)UI_EXTMENU_VIEW_MODIFIED_FORMS, "View Modified Forms");
-
+	result = result && InsertMenu(g_ExtensionMenu, -1, MF_BYPOSITION | MF_STRING, (UINT_PTR)UI_EXTMENU_VIEW_NAVMESH_IGNORED_FORMS, "View Navmesh Ignored Forms");
 
 	MENUITEMINFO menuInfo;
 	memset(&menuInfo, 0, sizeof(MENUITEMINFO));
@@ -390,6 +392,12 @@ LRESULT CALLBACK MainWindowCallback(HWND Hwnd, UINT Message, WPARAM wParam, LPAR
 		case UI_EXTMENU_VIEW_MODIFIED_FORMS:
 		{
 			ModifiedFormViewer::Show();
+		}
+		return 0;
+
+		case UI_EXTMENU_VIEW_NAVMESH_IGNORED_FORMS:
+		{
+			NavMeshPickPreventer::ShowList();
 		}
 		return 0;
 

--- a/Main.cpp
+++ b/Main.cpp
@@ -37,6 +37,7 @@
 #include "OutOfMemoryHelper.h"
 #include "BetterFloatingFormList.h"
 #include "Settings.h"
+#include "NavMeshPickPreventer.h"
 #include "CustomRenderWindowHotkeys.h"
 
 #include "Events/EventManager.h"
@@ -796,6 +797,8 @@ bool NVSEPlugin_Load(const NVSEInterface* nvse)
 
 	CustomRenderWindowHotkeys::Init();
 
+	NavMeshPickPreventer::Init();
+	DataLoadEvent::RegisterCallback(NavMeshPickPreventer::PostLoadPlugins);
 	if (config.bPlaySoundEndOfLoading)
 	{
 		DataLoadEvent::RegisterCallback(PlayMouseClickSound);

--- a/Main.cpp
+++ b/Main.cpp
@@ -83,6 +83,8 @@ bool NVSEPlugin_Load(const NVSEInterface* nvse)
 	ReadAllSettings();
 	EventManager::InitHooks();
 
+	DisableProcessWindowsGhosting();
+
 	//	stop geck crash with bUseMultibounds = 0 in exterior cells with multibounds - credit to roy
 	WriteRelCall(0x004CA48F, (UInt32)FixMultiBounds);
 	XUtil::PatchMemoryNop(0x004CA494, 0x05);

--- a/Main.h
+++ b/Main.h
@@ -13,6 +13,7 @@
 #include "GameSettings.h"
 #include "FormSearch.h"
 #include "Settings.h"
+#include "NavMeshPickPreventer.h"
 
 #define GH_NAME				"ZeGaryHax"		// this is the string for IsPluginInstalled and GetPluginVersion (also shows in nvse.log)
 #define GH_VERSION			0.41
@@ -2191,21 +2192,6 @@ int __stdcall OnMasterFileNotMatchedPopupSkipIfVersionControlDisabled(HWND hWnd,
 bool bSelectedFormsListInUse;
 tList<TESForm> selectedForms;
 
-TESForm* GetNthListItem(HWND hWnd, int n)
-{
-	if (n == -1)
-	{
-		return 0;
-	}
-
-	LVITEMA itemA;
-	memset(&itemA, 0, sizeof(itemA));
-	itemA.iItem = n;
-	itemA.mask = LVIS_CUT;
-	SendMessageA(hWnd, LVM_GETITEMA, 0, (LPARAM)&itemA);
-	return (TESForm*)itemA.lParam;
-}
-
 TESForm* __cdecl OnCloseSelectFormsDialogPopulateList(HWND hWnd)
 {
 	if (!hWnd)
@@ -2214,7 +2200,7 @@ TESForm* __cdecl OnCloseSelectFormsDialogPopulateList(HWND hWnd)
 	}
 	unsigned int index = SendMessageA(hWnd, LVM_GETNEXTITEM, 0xFFFFFFFF, LVIS_SELECTED);
 
-	auto result = GetNthListItem(hWnd, index);
+	auto result = GetNthListForm(hWnd, index);
 	if (result && bSelectedFormsListInUse)
 	{
 		selectedForms.AddAt(result, -2);
@@ -2223,7 +2209,7 @@ TESForm* __cdecl OnCloseSelectFormsDialogPopulateList(HWND hWnd)
 			auto startIndex = index;
 			index = SendMessageA(hWnd, LVM_GETNEXTITEM, startIndex, LVIS_SELECTED);
 
-			if (auto form = GetNthListItem(hWnd, index))
+			if (auto form = GetNthListForm(hWnd, index))
 			{
 				selectedForms.AddAt(form, -2);
 			}
@@ -2753,7 +2739,7 @@ void CopySelectedListViewItemData(HWND listView, std::function<void(std::string&
 	// Iterate over all selected items
 	while ((index = SendMessageA(listView, LVM_GETNEXTITEM, index, LVNI_SELECTED)) != -1)
 	{
-		if (auto form = GetNthListItem(listView, index))
+		if (auto form = GetNthListForm(listView, index))
 		{
 			aggregator(aggregatedText, form);
 		}

--- a/Main.h
+++ b/Main.h
@@ -1154,6 +1154,10 @@ BOOL __stdcall RenderWindowCallbackHook(HWND hWnd, UINT msg, WPARAM wParam, LPAR
 		case VK_LWIN:
 			SetFlycamMode(0);
 			break;
+
+		case 'K':
+			NavMeshPickPreventer::OnKeyDown(GetAsyncKeyState(VK_SHIFT) < 0);
+			break;
 		}
 	}
 	else if (msg == WM_RBUTTONDOWN) {

--- a/Main.h
+++ b/Main.h
@@ -1154,10 +1154,6 @@ BOOL __stdcall RenderWindowCallbackHook(HWND hWnd, UINT msg, WPARAM wParam, LPAR
 		case VK_LWIN:
 			SetFlycamMode(0);
 			break;
-
-		case 'K':
-			NavMeshPickPreventer::OnKeyDown(GetAsyncKeyState(VK_SHIFT) < 0);
-			break;
 		}
 	}
 	else if (msg == WM_RBUTTONDOWN) {

--- a/NavMeshPickPreventer.cpp
+++ b/NavMeshPickPreventer.cpp
@@ -262,7 +262,9 @@ namespace NavMeshPickPreventer
 			else
 			{
 				failedToResolveIds.push_back(id);
+#ifdef _DEBUG
 				Console_Print("NavMeshPickPreventer: Failed to find form: %s", id.c_str());
+#endif
 			}
 		}
 	}

--- a/NavMeshPickPreventer.cpp
+++ b/NavMeshPickPreventer.cpp
@@ -17,6 +17,7 @@ namespace NavMeshPickPreventer
 	void WriteINI();
 
 	tList<UInt32> ignoredRefs;
+	std::vector<std::string> failedToResolveIds; // editorIDs not found in the loaded plugins
 	UInt32 lastPickedRefID;
 	UInt32 lastPickedBaseFormID;
 	bool __fastcall OnPickNavMeshNodeGetShouldSkip(TESObjectREFR* ref)
@@ -184,6 +185,16 @@ namespace NavMeshPickPreventer
 			}
 		} while (iter = iter->next);
 
+		for (const std::string& id : failedToResolveIds)
+		{
+			if (!isFirstItem)
+			{
+				concatenatedIDs << ',';
+			}
+			isFirstItem = false;
+			concatenatedIDs << id;
+		}
+
 		return concatenatedIDs.str();
 	}
 
@@ -213,6 +224,7 @@ namespace NavMeshPickPreventer
 	void ReadINI()
 	{
 		ignoredRefs.RemoveAll();
+		failedToResolveIds.clear();
 
 		auto ids = ReadIDs();
 		for (const std::string& id : ids)
@@ -223,6 +235,7 @@ namespace NavMeshPickPreventer
 			}
 			else
 			{
+				failedToResolveIds.push_back(id);
 				Console_Print("NavMeshPickPreventer: Failed to find form: %s", id.c_str());
 			}
 		}

--- a/NavMeshPickPreventer.cpp
+++ b/NavMeshPickPreventer.cpp
@@ -1,0 +1,143 @@
+#include "GameTypes.h"
+#include "GameObjects.h"
+#include "GameAPI.h"
+
+#include <windows.h>
+#include <string>
+#include <vector>
+#include <sstream>
+
+namespace NavMeshPickPreventer
+{
+	char IniPath[MAX_PATH];
+
+	tList<UInt32> ignoredRefs;
+	UInt32 lastPickedRefID;
+	UInt32 lastPickedBaseFormID;
+	bool __fastcall OnPickNavMeshNodeGetShouldSkip(TESObjectREFR* ref)
+	{
+		if (ThisCall<bool>(0x44FEB0, ref) || (ref->baseForm && ref->baseForm->typeID == kFormType_Activator)) return true;
+
+		bool bIsIgnoredRef = ignoredRefs.IsInList((UInt32*)ref->refID);
+		bool bIsIgnoredBaseForm = ref->baseForm && ignoredRefs.IsInList((UInt32*)ref->baseForm->refID);
+		if (bIsIgnoredRef || bIsIgnoredBaseForm)
+		{
+#ifdef _DEBUG
+			EditorUI_Log("Ignored %s (%08X)", ref->GetEditorID(), ref->refID);
+#endif
+			return true;
+		}
+
+		if (lastPickedRefID != ref->refID)
+		{
+#ifdef _DEBUG
+			EditorUI_Log("Picked %s (%08X)", ref->GetEditorID(), ref->refID);
+#endif
+			lastPickedRefID = ref->refID;
+			lastPickedBaseFormID = ref->baseForm ? ref->baseForm->refID : 0;
+		}
+		return false;
+	}
+
+	void AddLastRefToIgnoredList()
+	{
+		if (auto ref = LookupFormByID(lastPickedBaseFormID))
+		{
+			if (!ignoredRefs.IsInList((UInt32*)lastPickedRefID))
+			{
+				ignoredRefs.AddAt((UInt32*)lastPickedRefID, 0);
+				Console_Print("Added %s (%08X) to ignored base forms list", ref->GetEditorID(), ref->refID);
+			}
+		}
+		else if (auto ref = LookupFormByID(lastPickedRefID))
+		{
+			if (!ignoredRefs.IsInList((UInt32*)lastPickedRefID))
+			{
+				ignoredRefs.AddAt((UInt32*)lastPickedRefID, 0);
+				Console_Print("Added %s (%08X) to ignored refs list", ref->GetEditorID(), ref->refID);
+			}
+		}
+	}
+
+	std::string ConcatenateIDs()
+	{
+		std::stringstream concatenatedIDs;
+
+		auto iter = ignoredRefs.Head();
+		bool isFirstItem = true;
+		do
+		{
+			if (auto form = LookupFormByID((UInt32)iter->item))
+			{
+				if (!isFirstItem)
+				{
+					concatenatedIDs << ',';
+				}
+				isFirstItem = false;
+				concatenatedIDs << (form->GetEditorID());
+			}
+		} while (iter = iter->next);
+
+		return concatenatedIDs.str();
+	}
+
+	constexpr const char* INI_SECTION = "NavMesh";
+	constexpr const char* INI_KEY = "sIgnoredPickEditorIDs";
+	std::vector<std::string> ReadIDs()
+	{
+		char buffer[0x1000];
+		int len = GetPrivateProfileStringA(INI_SECTION, INI_KEY, "", buffer, sizeof(buffer), IniPath);
+
+		std::vector<std::string> ids;
+		std::string idsStr = std::string(buffer);
+		std::stringstream ss(idsStr);
+		std::string id;
+		while (getline(ss, id, ',')) {
+			ids.push_back(id);
+		}
+
+		return ids;
+	}
+
+	void WriteINI()
+	{
+		WritePrivateProfileStringA(INI_SECTION, INI_KEY, ConcatenateIDs().c_str(), IniPath);
+	}
+
+	void ReadINI()
+	{
+		ignoredRefs.RemoveAll();
+
+		auto ids = ReadIDs();
+		for (const std::string& id : ids)
+		{
+			if (auto form = LookupFormByName(id.c_str()))
+			{
+				ignoredRefs.AddAt((UInt32*)form->refID, 0);
+			}
+			else
+			{
+				Console_Print("NavMeshPickPreventer: Failed to find form: %s", id.c_str());
+			}
+		}
+	}
+
+	void Init()
+	{
+		WriteRelCall(0x45C5B7, UInt32(OnPickNavMeshNodeGetShouldSkip));
+
+		GetModuleFileNameA(NULL, IniPath, MAX_PATH);
+		strcpy((char*)(strrchr(IniPath, '\\') + 1), "Data\\nvse\\plugins\\GeckExtender\\NavMeshIgnore\\config.ini");
+	}
+
+	void PostLoadPlugins()
+	{
+		ReadINI();
+	}
+
+	void OnKeyDown()
+	{
+		AddLastRefToIgnoredList();
+		WriteINI();
+	}
+}

--- a/NavMeshPickPreventer.h
+++ b/NavMeshPickPreventer.h
@@ -4,4 +4,5 @@ namespace NavMeshPickPreventer
 	void Init();
 	void OnKeyDown();
 	void PostLoadPlugins();
+	void ShowList();
 }

--- a/NavMeshPickPreventer.h
+++ b/NavMeshPickPreventer.h
@@ -2,7 +2,7 @@
 namespace NavMeshPickPreventer
 {
 	void Init();
-	void OnKeyDown();
+	void OnKeyDown(bool bShiftHeld);
 	void PostLoadPlugins();
 	void ShowList();
 }

--- a/NavMeshPickPreventer.h
+++ b/NavMeshPickPreventer.h
@@ -1,0 +1,7 @@
+#pragma once
+namespace NavMeshPickPreventer
+{
+	void Init();
+	void OnKeyDown();
+	void PostLoadPlugins();
+}

--- a/ZeGaryHax.vcxproj
+++ b/ZeGaryHax.vcxproj
@@ -157,6 +157,7 @@ copy "$(TargetPath)" "$(FalloutNVPath)\Data\nvse\plugins\$(TargetFileName)"
       <SubType>
       </SubType>
     </ClCompile>
+    <ClCompile Include="NavMeshPickPreventer.cpp" />
     <ClCompile Include="nvse\GameAPI.cpp" />
     <ClCompile Include="nvse\GameBSExtraData.cpp">
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</ExcludedFromBuild>
@@ -247,6 +248,7 @@ copy "$(TargetPath)" "$(FalloutNVPath)\Data\nvse\plugins\$(TargetFileName)"
       <SubType>
       </SubType>
     </ClInclude>
+    <ClInclude Include="NavMeshPickPreventer.h" />
     <ClInclude Include="nvse\CommandTable.h" />
     <ClInclude Include="nvse\GameAPI.h" />
     <ClInclude Include="nvse\GameBSExtraData.h" />

--- a/ZeGaryHax.vcxproj.filters
+++ b/ZeGaryHax.vcxproj.filters
@@ -75,6 +75,7 @@
       <Filter>Events</Filter>
     </ClCompile>
     <ClCompile Include="CustomRenderWindowHotkeys.cpp" />
+    <ClCompile Include="NavMeshPickPreventer.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="Main.h" />
@@ -170,6 +171,7 @@
       <Filter>Events</Filter>
     </ClInclude>
     <ClInclude Include="CustomRenderWindowHotkeys.h" />
+    <ClInclude Include="NavMeshPickPreventer.h" />
   </ItemGroup>
   <ItemGroup>
     <None Include="exports.def" />

--- a/nvse/Utilities.cpp
+++ b/nvse/Utilities.cpp
@@ -611,6 +611,21 @@ void SelectAllItemsInListView(HWND listView)
 	}
 }
 
+TESForm* GetNthListForm(HWND hWnd, int n)
+{
+	if (n == -1)
+	{
+		return 0;
+	}
+
+	LVITEMA itemA;
+	memset(&itemA, 0, sizeof(itemA));
+	itemA.iItem = n;
+	itemA.mask = LVIS_CUT;
+	SendMessageA(hWnd, LVM_GETITEMA, 0, (LPARAM)&itemA);
+	return (TESForm*)itemA.lParam;
+}
+
 void SetDeferListUpdate(HWND hWnd, bool bDefer)
 {
 	if (bDefer)

--- a/nvse/Utilities.h
+++ b/nvse/Utilities.h
@@ -275,6 +275,7 @@ char* GameHeapStrdup(const char* src);
 BOOL CopyTextToClipboard(const char* text);
 
 void SelectAllItemsInListView(HWND listView);
+TESForm* GetNthListForm(HWND hWnd, int n);
 void SetDeferListUpdate(HWND hWnd, bool bDefer = true);
 bool IsDialog(HWND hWnd);
 


### PR DESCRIPTION
Add a blacklist of forms to ignore while navmeshing, stored in `Data\\nvse\\plugins\\GeckExtender\\NavMeshIgnore\\config.ini` by EditorID.

Add a hotkey for adding the last form that was picked when raycasting for placing a navmesh vertex to the blacklist, and a hotkey for adding all selected forms to the list.

Add a 'View Navmesh Ignored Forms' menubar action to open a floating form list containing all loaded ignored forms. Forms may be click-and-dragged from the object window to add them to the blacklist. Forms may also be removed by selecting the rows and pressing the Delete key. 

Finally calls DisableProcessWindowsGhosting to disable the 'Geck is not responding' popup after 5 seconds of processing.