### PR TITLE
Floating form list save load

### DIFF
--- a/BetterFloatingFormList.cpp
+++ b/BetterFloatingFormList.cpp
@@ -204,7 +204,7 @@ namespace BetterFloatingFormList
 			}
 		}
 
-		file.close(); // Close the file when done
+		file.close();
 
 		if (!forms.IsEmpty())
 		{
@@ -307,14 +307,14 @@ namespace BetterFloatingFormList
 	void UpdateToolbarAndListviewPositions(HWND Hwnd)
 	{
 		RECT rcClient;
-		GetClientRect(Hwnd, &rcClient); // Get the dialog client area size
+		GetClientRect(Hwnd, &rcClient);
 
 		// Resize the toolbar and let it auto-adjust its height
 		auto hWndToolbar = GetDlgItem(Hwnd, IDC_TOOLBAR);
 		SendMessage(hWndToolbar, TB_AUTOSIZE, 0, 0);
 
 		RECT rcToolbar;
-		GetWindowRect(hWndToolbar, &rcToolbar); // Get the toolbar size
+		GetWindowRect(hWndToolbar, &rcToolbar);
 		int toolbarHeight = rcToolbar.bottom - rcToolbar.top;
 
 		// Calculate the new height and position for the list view

--- a/BetterFloatingFormList.cpp
+++ b/BetterFloatingFormList.cpp
@@ -331,6 +331,7 @@ namespace BetterFloatingFormList
 		{
 			CreateToolbar(Hwnd);
 			UpdateToolbarAndListviewPositions(Hwnd);
+			break;
 		}
 		case WM_COMMAND:
 		{

--- a/BetterFloatingFormList.cpp
+++ b/BetterFloatingFormList.cpp
@@ -142,8 +142,8 @@ namespace BetterFloatingFormList
 		ofn.nFilterIndex = 1;
 		ofn.lpstrFileTitle = NULL;
 		ofn.nMaxFileTitle = 0;
-		ofn.lpstrInitialDir = NULL;
-		ofn.Flags = OFN_PATHMUSTEXIST | (bSave ? OFN_OVERWRITEPROMPT : OFN_FILEMUSTEXIST);
+		ofn.lpstrInitialDir = "Data\\nvse\\plugins\\GeckExtender";
+		ofn.Flags = OFN_NOCHANGEDIR | OFN_PATHMUSTEXIST | (bSave ? OFN_OVERWRITEPROMPT : OFN_FILEMUSTEXIST);
 
 		return bSave ? GetSaveFileName(&ofn) : GetOpenFileName(&ofn);
 	}

--- a/BetterFloatingFormList.h
+++ b/BetterFloatingFormList.h
@@ -8,4 +8,5 @@ namespace BetterFloatingFormList
 	};
 
 	void Init();
+	LRESULT CALLBACK BaseWindowCallback(HWND Hwnd, UINT Message, WPARAM wParam, LPARAM lParam);
 }

--- a/FormSearch.cpp
+++ b/FormSearch.cpp
@@ -1,6 +1,7 @@
 #include "GameAPI.h"
 #include "GameForms.h"
 #include "GameData.h"
+#include "GeckUtility.h"
 #include <CommCtrl.h>
 extern HWND g_MainHwnd;
 
@@ -8,20 +9,6 @@ namespace FormSearch
 {
     constexpr int IDD_INPUTDIALOG = 101;
     constexpr int IDC_INPUTEDIT = 1001;
-
-    void GetCellCoords(NiPoint3& pos, TESObjectCELL* cell)
-    {
-        if (cell->IsInterior())
-        {
-            pos = NiPoint3::ZERO;
-        }
-        else
-        {
-            pos.x = 2048 + (cell->GetPosX() << 12);
-            pos.y = 2048 + (cell->GetPosY() << 12);
-            pos.z = 0;
-        }
-    }
 
     bool DoLookupForm(HWND hwndDlg)
     {
@@ -42,24 +29,7 @@ namespace FormSearch
 
             if (form)
             {
-                if (form->typeID == kFormType_Cell || form->typeID == kFormType_Land)
-                {
-                    TESObjectCELL* cell = form->typeID == kFormType_Land
-                        ? (TESObjectCELL*)(UInt32(form) + 0x34) : (TESObjectCELL*)form;
-
-                    NiPoint3 pos;
-                    GetCellCoords(pos, cell);
-                    CdeclCall(0x465490, &pos, cell);
-                    if (!cell->IsInterior())
-                    {
-                        cell->GetLandHeight(&pos, &pos.z);
-                        CdeclCall(0x4652D0, &pos);
-                    }
-                }
-                else
-                {
-					form->OpenDialog(g_MainHwnd, 0, 1);
-                }
+                OpenForm(form, g_MainHwnd);
             }
             else
             {

--- a/GECKUtility.h
+++ b/GECKUtility.h
@@ -365,3 +365,7 @@ struct RenderWindowHotkey
 		bIsEditAllowed(bIsEditAllowed), kDefaultCombo(defaultKey, defaultFlags), kCombo(defaultKey, defaultFlags) {};
 };
 STATIC_ASSERT(sizeof(RenderWindowHotkey) == 0x14);
+
+void AddFormsToListView(HWND listView, tList<TESForm>* forms, bool(__cdecl* filterFn)(TESForm*, void*) = nullptr, void* filterData = nullptr);
+
+void OpenForm(TESForm* form, HWND parentHwnd = nullptr);

--- a/ModifiedFormViewer.cpp
+++ b/ModifiedFormViewer.cpp
@@ -1,6 +1,7 @@
 #include "GECKUtility.h"
 #include "GameObjects.h"
 #include "Utilities.h"
+#include "BetterFloatingFormList.h"
 
 extern HWND g_MainHwnd;
 
@@ -29,10 +30,9 @@ namespace ModifiedFormViewer
 		SetWindowSubclass(hListView, SubclassedListViewProc, 0, 0);
 	}
 
-	WNDPROC originalWindowCallback;
 	LRESULT CALLBACK WindowCallback(HWND Hwnd, UINT Message, WPARAM wParam, LPARAM lParam)
 	{
-		auto result = CallWindowProc(originalWindowCallback, Hwnd, Message, wParam, lParam);
+		auto result = BetterFloatingFormList::BaseWindowCallback(Hwnd, Message, wParam, lParam);
 		if (Message == WM_INITDIALOG)
 		{
 			// prevent the delete button deleting items from the list as it's misleading if users expect it to actually remove modified forms
@@ -61,7 +61,6 @@ namespace ModifiedFormViewer
 			data.forms.Insert(modifiedForms->data[i]);
 		}
 
-		originalWindowCallback = *(WNDPROC*)0x44BB19;
 		HINSTANCE hInstance = (HINSTANCE)GetModuleHandle(nullptr);
 		auto hWnd = CreateDialogParamA(hInstance, (LPCSTR)189, g_MainHwnd, (DLGPROC)WindowCallback, (LPARAM)&data);
 		SendMessageA(hWnd, WM_SETTEXT, 0, (LPARAM)"Modified Forms");

--- a/NavMeshPickPreventer.cpp
+++ b/NavMeshPickPreventer.cpp
@@ -107,11 +107,9 @@ namespace NavMeshPickPreventer
 		return false;
 	}
 
-	WNDPROC originalWindowCallback;
 	LRESULT CALLBACK WindowCallback(HWND Hwnd, UINT Message, WPARAM wParam, LPARAM lParam)
 	{
-		auto result = CallWindowProc(originalWindowCallback, Hwnd, Message, wParam, lParam);
-
+		auto result = BetterFloatingFormList::BaseWindowCallback(Hwnd, Message, wParam, lParam);
 		if (Message == BetterFloatingFormList::BFL_ADDED_ITEMS)
 		{
 			auto formList = (tList<TESForm>*)wParam;
@@ -153,7 +151,6 @@ namespace NavMeshPickPreventer
 
 	void ShowList()
 	{
-		originalWindowCallback = *(WNDPROC*)0x44BB19;
 		HINSTANCE hInstance = (HINSTANCE)GetModuleHandle(nullptr);
 
 		tList<TESForm> ignoredForms;

--- a/nvse/GameTypes.h
+++ b/nvse/GameTypes.h
@@ -362,6 +362,10 @@ public:
 			return -1;
 	}
 
+	bool IsEmpty()
+	{
+		return !m_listHead.item && !m_listHead.next;
+	}
 };
 STATIC_ASSERT(sizeof(tList<void *>) == 0x8);
 


### PR DESCRIPTION
Adds Save/Load buttons for saving/loading floating form lists to/from INI files.
The lists support all form types (including References and Cells though they can't be dragged from the cell window at the moment and must be added to the INI file manually).