### PR TITLE
FaceGen texture export tweaks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,4 @@ Release/*
 common/Debug VC9/*
 common/Release VC9/*
 .vs/*
+/DirectXTex/DirectXTex/Lib

--- a/DirectXTex/DirectXTex/BC.cpp
+++ b/DirectXTex/DirectXTex/BC.cpp
@@ -1,0 +1,1141 @@
+//-------------------------------------------------------------------------------------
+// BC.cpp
+//
+// Block-compression (BC) functionality for BC1, BC2, BC3 (orginal DXTn formats)
+//
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+//
+// http://go.microsoft.com/fwlink/?LinkId=248926
+//-------------------------------------------------------------------------------------
+
+#include "DirectXTexP.h"
+
+// Experiemental encoding variants, not enabled by default
+//#define COLOR_WEIGHTS
+//#define COLOR_AVG_0WEIGHTS
+
+#include "BC.h"
+
+using namespace DirectX;
+using namespace DirectX::PackedVector;
+
+namespace
+{
+    //-------------------------------------------------------------------------------------
+    // Constants
+    //-------------------------------------------------------------------------------------
+
+    // Perceptual weightings for the importance of each channel.
+    const HDRColorA g_Luminance(0.2125f / 0.7154f, 1.0f, 0.0721f / 0.7154f, 1.0f);
+    const HDRColorA g_LuminanceInv(0.7154f / 0.2125f, 1.0f, 0.7154f / 0.0721f, 1.0f);
+
+    //-------------------------------------------------------------------------------------
+    // Decode/Encode RGB 5/6/5 colors
+    //-------------------------------------------------------------------------------------
+    inline void Decode565(_Out_ HDRColorA *pColor, _In_ const uint16_t w565) noexcept
+    {
+        pColor->r = static_cast<float>((w565 >> 11) & 31) * (1.0f / 31.0f);
+        pColor->g = static_cast<float>((w565 >> 5) & 63) * (1.0f / 63.0f);
+        pColor->b = static_cast<float>((w565 >> 0) & 31) * (1.0f / 31.0f);
+        pColor->a = 1.0f;
+    }
+
+    inline uint16_t Encode565(_In_ const HDRColorA *pColor) noexcept
+    {
+        HDRColorA Color;
+
+        Color.r = (pColor->r < 0.0f) ? 0.0f : (pColor->r > 1.0f) ? 1.0f : pColor->r;
+        Color.g = (pColor->g < 0.0f) ? 0.0f : (pColor->g > 1.0f) ? 1.0f : pColor->g;
+        Color.b = (pColor->b < 0.0f) ? 0.0f : (pColor->b > 1.0f) ? 1.0f : pColor->b;
+        Color.a = pColor->a;
+
+        uint16_t w;
+
+        w = static_cast<uint16_t>(
+            (static_cast<int32_t>(Color.r * 31.0f + 0.5f) << 11)
+            | (static_cast<int32_t>(Color.g * 63.0f + 0.5f) << 5)
+            | (static_cast<int32_t>(Color.b * 31.0f + 0.5f) << 0));
+
+        return w;
+    }
+
+
+    //-------------------------------------------------------------------------------------
+    void OptimizeRGB(
+        _Out_ HDRColorA *pX,
+        _Out_ HDRColorA *pY,
+        _In_reads_(NUM_PIXELS_PER_BLOCK) const HDRColorA *pPoints,
+        uint32_t cSteps,
+        uint32_t flags) noexcept
+    {
+        constexpr float fEpsilon = (0.25f / 64.0f) * (0.25f / 64.0f);
+        static const float pC3[] = { 2.0f / 2.0f, 1.0f / 2.0f, 0.0f / 2.0f };
+        static const float pD3[] = { 0.0f / 2.0f, 1.0f / 2.0f, 2.0f / 2.0f };
+        static const float pC4[] = { 3.0f / 3.0f, 2.0f / 3.0f, 1.0f / 3.0f, 0.0f / 3.0f };
+        static const float pD4[] = { 0.0f / 3.0f, 1.0f / 3.0f, 2.0f / 3.0f, 3.0f / 3.0f };
+
+        const float *pC = (3 == cSteps) ? pC3 : pC4;
+        const float *pD = (3 == cSteps) ? pD3 : pD4;
+
+        // Find Min and Max points, as starting point
+        HDRColorA X = (flags & BC_FLAGS_UNIFORM) ? HDRColorA(1.f, 1.f, 1.f, 1.f) : g_Luminance;
+        HDRColorA Y = HDRColorA(0.0f, 0.0f, 0.0f, 1.0f);
+
+        for (size_t iPoint = 0; iPoint < NUM_PIXELS_PER_BLOCK; iPoint++)
+        {
+        #ifdef COLOR_WEIGHTS
+            if (pPoints[iPoint].a > 0.0f)
+            #endif // COLOR_WEIGHTS
+            {
+                if (pPoints[iPoint].r < X.r)
+                    X.r = pPoints[iPoint].r;
+
+                if (pPoints[iPoint].g < X.g)
+                    X.g = pPoints[iPoint].g;
+
+                if (pPoints[iPoint].b < X.b)
+                    X.b = pPoints[iPoint].b;
+
+                if (pPoints[iPoint].r > Y.r)
+                    Y.r = pPoints[iPoint].r;
+
+                if (pPoints[iPoint].g > Y.g)
+                    Y.g = pPoints[iPoint].g;
+
+                if (pPoints[iPoint].b > Y.b)
+                    Y.b = pPoints[iPoint].b;
+            }
+        }
+
+        // Diagonal axis
+        const HDRColorA AB(Y.r - X.r, Y.g - X.g, Y.b - X.b, 0.0f);
+
+        const float fAB = AB.r * AB.r + AB.g * AB.g + AB.b * AB.b;
+
+        // Single color block.. no need to root-find
+        if (fAB < FLT_MIN)
+        {
+            pX->r = X.r; pX->g = X.g; pX->b = X.b; pX->a = 1.0f;
+            pY->r = Y.r; pY->g = Y.g; pY->b = Y.b; pY->a = 1.0f;
+            return;
+        }
+
+        // Try all four axis directions, to determine which diagonal best fits data
+        const float fABInv = 1.0f / fAB;
+
+        HDRColorA Dir(AB.r * fABInv, AB.g * fABInv, AB.b * fABInv, 0.0f);
+
+        const HDRColorA Mid(
+            (X.r + Y.r) * 0.5f,
+            (X.g + Y.g) * 0.5f,
+            (X.b + Y.b) * 0.5f,
+            0.0f);
+
+        float fDir[4] = {};
+
+        for (size_t iPoint = 0; iPoint < NUM_PIXELS_PER_BLOCK; iPoint++)
+        {
+            HDRColorA Pt;
+            Pt.r = (pPoints[iPoint].r - Mid.r) * Dir.r;
+            Pt.g = (pPoints[iPoint].g - Mid.g) * Dir.g;
+            Pt.b = (pPoints[iPoint].b - Mid.b) * Dir.b;
+            Pt.a = 0.0f;
+
+            float f;
+
+        #ifdef COLOR_WEIGHTS
+            f = Pt.r + Pt.g + Pt.b;
+            fDir[0] += pPoints[iPoint].a * f * f;
+
+            f = Pt.r + Pt.g - Pt.b;
+            fDir[1] += pPoints[iPoint].a * f * f;
+
+            f = Pt.r - Pt.g + Pt.b;
+            fDir[2] += pPoints[iPoint].a * f * f;
+
+            f = Pt.r - Pt.g - Pt.b;
+            fDir[3] += pPoints[iPoint].a * f * f;
+        #else
+            f = Pt.r + Pt.g + Pt.b;
+            fDir[0] += f * f;
+
+            f = Pt.r + Pt.g - Pt.b;
+            fDir[1] += f * f;
+
+            f = Pt.r - Pt.g + Pt.b;
+            fDir[2] += f * f;
+
+            f = Pt.r - Pt.g - Pt.b;
+            fDir[3] += f * f;
+        #endif // COLOR_WEIGHTS
+        }
+
+        float fDirMax = fDir[0];
+        size_t  iDirMax = 0;
+
+        for (size_t iDir = 1; iDir < 4; iDir++)
+        {
+            if (fDir[iDir] > fDirMax)
+            {
+                fDirMax = fDir[iDir];
+                iDirMax = iDir;
+            }
+        }
+
+        if (iDirMax & 2)
+        {
+            const float f = X.g; X.g = Y.g; Y.g = f;
+        }
+
+        if (iDirMax & 1)
+        {
+            const float f = X.b; X.b = Y.b; Y.b = f;
+        }
+
+
+        // Two color block.. no need to root-find
+        if (fAB < 1.0f / 4096.0f)
+        {
+            pX->r = X.r; pX->g = X.g; pX->b = X.b; pX->a = 1.0f;
+            pY->r = Y.r; pY->g = Y.g; pY->b = Y.b; pY->a = 1.0f;
+            return;
+        }
+
+        // Use Newton's Method to find local minima of sum-of-squares error.
+        auto const fSteps = static_cast<float>(cSteps - 1);
+
+        for (size_t iIteration = 0; iIteration < 8; iIteration++)
+        {
+            // Calculate new steps
+            HDRColorA pSteps[4];
+
+            for (size_t iStep = 0; iStep < cSteps; iStep++)
+            {
+                pSteps[iStep].r = X.r * pC[iStep] + Y.r * pD[iStep];
+                pSteps[iStep].g = X.g * pC[iStep] + Y.g * pD[iStep];
+                pSteps[iStep].b = X.b * pC[iStep] + Y.b * pD[iStep];
+                pSteps[iStep].a = 1.0f;
+            }
+
+
+            // Calculate color direction
+            Dir.r = Y.r - X.r;
+            Dir.g = Y.g - X.g;
+            Dir.b = Y.b - X.b;
+
+            const float fLen = (Dir.r * Dir.r + Dir.g * Dir.g + Dir.b * Dir.b);
+
+            if (fLen < (1.0f / 4096.0f))
+                break;
+
+            const float fScale = fSteps / fLen;
+
+            Dir.r *= fScale;
+            Dir.g *= fScale;
+            Dir.b *= fScale;
+
+
+            // Evaluate function, and derivatives
+            float d2X = 0.f;
+            float d2Y = 0.f;
+            HDRColorA dX = {};
+            HDRColorA dY = {};
+
+            for (size_t iPoint = 0; iPoint < NUM_PIXELS_PER_BLOCK; iPoint++)
+            {
+                const float fDot = (pPoints[iPoint].r - X.r) * Dir.r +
+                    (pPoints[iPoint].g - X.g) * Dir.g +
+                    (pPoints[iPoint].b - X.b) * Dir.b;
+
+
+                uint32_t iStep;
+                if (fDot <= 0.0f)
+                    iStep = 0;
+                else if (fDot >= fSteps)
+                    iStep = cSteps - 1;
+                else
+                    iStep = uint32_t(fDot + 0.5f);
+
+
+                HDRColorA Diff;
+                Diff.r = pSteps[iStep].r - pPoints[iPoint].r;
+                Diff.g = pSteps[iStep].g - pPoints[iPoint].g;
+                Diff.b = pSteps[iStep].b - pPoints[iPoint].b;
+                Diff.a = 0.0f;
+
+            #ifdef COLOR_WEIGHTS
+                const float fC = pC[iStep] * pPoints[iPoint].a * (1.0f / 8.0f);
+                const float fD = pD[iStep] * pPoints[iPoint].a * (1.0f / 8.0f);
+            #else
+                const float fC = pC[iStep] * (1.0f / 8.0f);
+                const float fD = pD[iStep] * (1.0f / 8.0f);
+            #endif // COLOR_WEIGHTS
+
+                d2X += fC * pC[iStep];
+                dX.r += fC * Diff.r;
+                dX.g += fC * Diff.g;
+                dX.b += fC * Diff.b;
+
+                d2Y += fD * pD[iStep];
+                dY.r += fD * Diff.r;
+                dY.g += fD * Diff.g;
+                dY.b += fD * Diff.b;
+            }
+
+            // Move endpoints
+            if (d2X > 0.0f)
+            {
+                const float f = -1.0f / d2X;
+
+                X.r += dX.r * f;
+                X.g += dX.g * f;
+                X.b += dX.b * f;
+            }
+
+            if (d2Y > 0.0f)
+            {
+                const float f = -1.0f / d2Y;
+
+                Y.r += dY.r * f;
+                Y.g += dY.g * f;
+                Y.b += dY.b * f;
+            }
+
+            if ((dX.r * dX.r < fEpsilon) && (dX.g * dX.g < fEpsilon) && (dX.b * dX.b < fEpsilon) &&
+                (dY.r * dY.r < fEpsilon) && (dY.g * dY.g < fEpsilon) && (dY.b * dY.b < fEpsilon))
+            {
+                break;
+            }
+        }
+
+        pX->r = X.r; pX->g = X.g; pX->b = X.b; pX->a = 1.0f;
+        pY->r = Y.r; pY->g = Y.g; pY->b = Y.b; pY->a = 1.0f;
+    }
+
+
+    //-------------------------------------------------------------------------------------
+    inline void DecodeBC1(
+        _Out_writes_(NUM_PIXELS_PER_BLOCK) XMVECTOR *pColor,
+        _In_ const D3DX_BC1 *pBC,
+        bool isbc1) noexcept
+    {
+        assert(pColor && pBC);
+        static_assert(sizeof(D3DX_BC1) == 8, "D3DX_BC1 should be 8 bytes");
+
+        static XMVECTORF32 s_Scale = { { { 1.f / 31.f, 1.f / 63.f, 1.f / 31.f, 1.f } } };
+
+        XMVECTOR clr0 = XMLoadU565(reinterpret_cast<const XMU565*>(&pBC->rgb[0]));
+        XMVECTOR clr1 = XMLoadU565(reinterpret_cast<const XMU565*>(&pBC->rgb[1]));
+
+        clr0 = XMVectorMultiply(clr0, s_Scale);
+        clr1 = XMVectorMultiply(clr1, s_Scale);
+
+        clr0 = XMVectorSwizzle<2, 1, 0, 3>(clr0);
+        clr1 = XMVectorSwizzle<2, 1, 0, 3>(clr1);
+
+        clr0 = XMVectorSelect(g_XMIdentityR3, clr0, g_XMSelect1110);
+        clr1 = XMVectorSelect(g_XMIdentityR3, clr1, g_XMSelect1110);
+
+        XMVECTOR clr2, clr3;
+        if (isbc1 && (pBC->rgb[0] <= pBC->rgb[1]))
+        {
+            clr2 = XMVectorLerp(clr0, clr1, 0.5f);
+            clr3 = XMVectorZero();  // Alpha of 0
+        }
+        else
+        {
+            clr2 = XMVectorLerp(clr0, clr1, 1.f / 3.f);
+            clr3 = XMVectorLerp(clr0, clr1, 2.f / 3.f);
+        }
+
+        uint32_t dw = pBC->bitmap;
+
+        for (size_t i = 0; i < NUM_PIXELS_PER_BLOCK; ++i, dw >>= 2)
+        {
+            switch (dw & 3)
+            {
+            case 0: pColor[i] = clr0; break;
+            case 1: pColor[i] = clr1; break;
+            case 2: pColor[i] = clr2; break;
+
+            case 3:
+            default: pColor[i] = clr3; break;
+            }
+        }
+    }
+
+
+    //-------------------------------------------------------------------------------------
+    void EncodeBC1(
+        _Out_ D3DX_BC1 *pBC,
+        _In_reads_(NUM_PIXELS_PER_BLOCK) const HDRColorA *pColor,
+        bool bColorKey,
+        float threshold,
+        uint32_t flags) noexcept
+    {
+        assert(pBC && pColor);
+        static_assert(sizeof(D3DX_BC1) == 8, "D3DX_BC1 should be 8 bytes");
+
+        // Determine if we need to colorkey this block
+        uint32_t uSteps;
+
+        if (bColorKey)
+        {
+            size_t uColorKey = 0;
+
+            for (size_t i = 0; i < NUM_PIXELS_PER_BLOCK; ++i)
+            {
+                if (pColor[i].a < threshold)
+                    uColorKey++;
+            }
+
+            if (NUM_PIXELS_PER_BLOCK == uColorKey)
+            {
+                pBC->rgb[0] = 0x0000;
+                pBC->rgb[1] = 0xffff;
+                pBC->bitmap = 0xffffffff;
+                return;
+            }
+
+            uSteps = (uColorKey > 0) ? 3u : 4u;
+        }
+        else
+        {
+            uSteps = 4u;
+        }
+
+        // Quantize block to R56B5, using Floyd Stienberg error diffusion.  This
+        // increases the chance that colors will map directly to the quantized
+        // axis endpoints.
+        HDRColorA Color[NUM_PIXELS_PER_BLOCK];
+        HDRColorA Error[NUM_PIXELS_PER_BLOCK];
+
+        if (flags & BC_FLAGS_DITHER_RGB)
+            memset(Error, 0x00, NUM_PIXELS_PER_BLOCK * sizeof(HDRColorA));
+
+        size_t i;
+        for (i = 0; i < NUM_PIXELS_PER_BLOCK; ++i)
+        {
+            HDRColorA Clr;
+            Clr.r = pColor[i].r;
+            Clr.g = pColor[i].g;
+            Clr.b = pColor[i].b;
+            Clr.a = 1.0f;
+
+            if (flags & BC_FLAGS_DITHER_RGB)
+            {
+                Clr.r += Error[i].r;
+                Clr.g += Error[i].g;
+                Clr.b += Error[i].b;
+            }
+
+            Color[i].r = static_cast<float>(static_cast<int32_t>(Clr.r * 31.0f + 0.5f)) * (1.0f / 31.0f);
+            Color[i].g = static_cast<float>(static_cast<int32_t>(Clr.g * 63.0f + 0.5f)) * (1.0f / 63.0f);
+            Color[i].b = static_cast<float>(static_cast<int32_t>(Clr.b * 31.0f + 0.5f)) * (1.0f / 31.0f);
+
+        #ifdef COLOR_WEIGHTS
+            Color[i].a = pColor[i].a;
+        #else
+            Color[i].a = 1.0f;
+        #endif // COLOR_WEIGHTS
+
+            if (flags & BC_FLAGS_DITHER_RGB)
+            {
+                HDRColorA Diff;
+                Diff.r = Color[i].a * (Clr.r - Color[i].r);
+                Diff.g = Color[i].a * (Clr.g - Color[i].g);
+                Diff.b = Color[i].a * (Clr.b - Color[i].b);
+                Diff.a = 0.0f;
+
+                if (3 != (i & 3))
+                {
+                    assert(i < 15);
+                    _Analysis_assume_(i < 15);
+                    Error[i + 1].r += Diff.r * (7.0f / 16.0f);
+                    Error[i + 1].g += Diff.g * (7.0f / 16.0f);
+                    Error[i + 1].b += Diff.b * (7.0f / 16.0f);
+                }
+
+                if (i < 12)
+                {
+                    if (i & 3)
+                    {
+                        Error[i + 3].r += Diff.r * (3.0f / 16.0f);
+                        Error[i + 3].g += Diff.g * (3.0f / 16.0f);
+                        Error[i + 3].b += Diff.b * (3.0f / 16.0f);
+                    }
+
+                    Error[i + 4].r += Diff.r * (5.0f / 16.0f);
+                    Error[i + 4].g += Diff.g * (5.0f / 16.0f);
+                    Error[i + 4].b += Diff.b * (5.0f / 16.0f);
+
+                    if (3 != (i & 3))
+                    {
+                        assert(i < 11);
+                        _Analysis_assume_(i < 11);
+                        Error[i + 5].r += Diff.r * (1.0f / 16.0f);
+                        Error[i + 5].g += Diff.g * (1.0f / 16.0f);
+                        Error[i + 5].b += Diff.b * (1.0f / 16.0f);
+                    }
+                }
+            }
+
+            if (!(flags & BC_FLAGS_UNIFORM))
+            {
+                Color[i].r *= g_Luminance.r;
+                Color[i].g *= g_Luminance.g;
+                Color[i].b *= g_Luminance.b;
+            }
+        }
+
+        // Perform 6D root finding function to find two endpoints of color axis.
+        // Then quantize and sort the endpoints depending on mode.
+        HDRColorA ColorA, ColorB, ColorC, ColorD;
+
+        OptimizeRGB(&ColorA, &ColorB, Color, uSteps, flags);
+
+        if (flags & BC_FLAGS_UNIFORM)
+        {
+            ColorC = ColorA;
+            ColorD = ColorB;
+        }
+        else
+        {
+            ColorC.r = ColorA.r * g_LuminanceInv.r;
+            ColorC.g = ColorA.g * g_LuminanceInv.g;
+            ColorC.b = ColorA.b * g_LuminanceInv.b;
+            ColorC.a = ColorA.a;
+
+            ColorD.r = ColorB.r * g_LuminanceInv.r;
+            ColorD.g = ColorB.g * g_LuminanceInv.g;
+            ColorD.b = ColorB.b * g_LuminanceInv.b;
+            ColorD.a = ColorB.a;
+        }
+
+        const uint16_t wColorA = Encode565(&ColorC);
+        const uint16_t wColorB = Encode565(&ColorD);
+
+        if ((uSteps == 4) && (wColorA == wColorB))
+        {
+            pBC->rgb[0] = wColorA;
+            pBC->rgb[1] = wColorB;
+            pBC->bitmap = 0x00000000;
+            return;
+        }
+
+        Decode565(&ColorC, wColorA);
+        Decode565(&ColorD, wColorB);
+
+        if (flags & BC_FLAGS_UNIFORM)
+        {
+            ColorA = ColorC;
+            ColorB = ColorD;
+        }
+        else
+        {
+            ColorA.r = ColorC.r * g_Luminance.r;
+            ColorA.g = ColorC.g * g_Luminance.g;
+            ColorA.b = ColorC.b * g_Luminance.b;
+
+            ColorB.r = ColorD.r * g_Luminance.r;
+            ColorB.g = ColorD.g * g_Luminance.g;
+            ColorB.b = ColorD.b * g_Luminance.b;
+        }
+
+        // Calculate color steps
+        HDRColorA Step[4];
+
+        if ((3 == uSteps) == (wColorA <= wColorB))
+        {
+            pBC->rgb[0] = wColorA;
+            pBC->rgb[1] = wColorB;
+
+            Step[0] = ColorA;
+            Step[1] = ColorB;
+        }
+        else
+        {
+            pBC->rgb[0] = wColorB;
+            pBC->rgb[1] = wColorA;
+
+            Step[0] = ColorB;
+            Step[1] = ColorA;
+        }
+
+        static const size_t pSteps3[] = { 0, 2, 1 };
+        static const size_t pSteps4[] = { 0, 2, 3, 1 };
+        const size_t *pSteps;
+
+        if (3 == uSteps)
+        {
+            pSteps = pSteps3;
+
+            HDRColorALerp(&Step[2], &Step[0], &Step[1], 0.5f);
+        }
+        else
+        {
+            pSteps = pSteps4;
+
+            HDRColorALerp(&Step[2], &Step[0], &Step[1], 1.0f / 3.0f);
+            HDRColorALerp(&Step[3], &Step[0], &Step[1], 2.0f / 3.0f);
+        }
+
+        // Calculate color direction
+        HDRColorA Dir;
+        Dir.r = Step[1].r - Step[0].r;
+        Dir.g = Step[1].g - Step[0].g;
+        Dir.b = Step[1].b - Step[0].b;
+        Dir.a = 0.0f;
+
+        const auto fSteps = static_cast<float>(uSteps - 1);
+        const float fScale = (wColorA != wColorB) ? (fSteps / (Dir.r * Dir.r + Dir.g * Dir.g + Dir.b * Dir.b)) : 0.0f;
+
+        Dir.r *= fScale;
+        Dir.g *= fScale;
+        Dir.b *= fScale;
+
+        // Encode colors
+        uint32_t dw = 0;
+        if (flags & BC_FLAGS_DITHER_RGB)
+            memset(Error, 0x00, NUM_PIXELS_PER_BLOCK * sizeof(HDRColorA));
+
+        for (i = 0; i < NUM_PIXELS_PER_BLOCK; ++i)
+        {
+            if ((3 == uSteps) && (pColor[i].a < threshold))
+            {
+                dw = (3u << 30) | (dw >> 2);
+            }
+            else
+            {
+                HDRColorA Clr;
+                if (flags & BC_FLAGS_UNIFORM)
+                {
+                    Clr.r = pColor[i].r;
+                    Clr.g = pColor[i].g;
+                    Clr.b = pColor[i].b;
+                }
+                else
+                {
+                    Clr.r = pColor[i].r * g_Luminance.r;
+                    Clr.g = pColor[i].g * g_Luminance.g;
+                    Clr.b = pColor[i].b * g_Luminance.b;
+                }
+                Clr.a = 1.0f;
+
+                if (flags & BC_FLAGS_DITHER_RGB)
+                {
+                    Clr.r += Error[i].r;
+                    Clr.g += Error[i].g;
+                    Clr.b += Error[i].b;
+                }
+
+                const float fDot = (Clr.r - Step[0].r) * Dir.r + (Clr.g - Step[0].g) * Dir.g + (Clr.b - Step[0].b) * Dir.b;
+
+                uint32_t iStep;
+                if (fDot <= 0.0f)
+                    iStep = 0;
+                else if (fDot >= fSteps)
+                    iStep = 1;
+                else
+                    iStep = uint32_t(pSteps[uint32_t(fDot + 0.5f)]);
+
+                dw = (iStep << 30) | (dw >> 2);
+
+                if (flags & BC_FLAGS_DITHER_RGB)
+                {
+                    HDRColorA Diff;
+                    Diff.r = Color[i].a * (Clr.r - Step[iStep].r);
+                    Diff.g = Color[i].a * (Clr.g - Step[iStep].g);
+                    Diff.b = Color[i].a * (Clr.b - Step[iStep].b);
+                    Diff.a = 0.0f;
+
+                    if (3 != (i & 3))
+                    {
+                        Error[i + 1].r += Diff.r * (7.0f / 16.0f);
+                        Error[i + 1].g += Diff.g * (7.0f / 16.0f);
+                        Error[i + 1].b += Diff.b * (7.0f / 16.0f);
+                    }
+
+                    if (i < 12)
+                    {
+                        if (i & 3)
+                        {
+                            Error[i + 3].r += Diff.r * (3.0f / 16.0f);
+                            Error[i + 3].g += Diff.g * (3.0f / 16.0f);
+                            Error[i + 3].b += Diff.b * (3.0f / 16.0f);
+                        }
+
+                        Error[i + 4].r += Diff.r * (5.0f / 16.0f);
+                        Error[i + 4].g += Diff.g * (5.0f / 16.0f);
+                        Error[i + 4].b += Diff.b * (5.0f / 16.0f);
+
+                        if (3 != (i & 3))
+                        {
+                            Error[i + 5].r += Diff.r * (1.0f / 16.0f);
+                            Error[i + 5].g += Diff.g * (1.0f / 16.0f);
+                            Error[i + 5].b += Diff.b * (1.0f / 16.0f);
+                        }
+                    }
+                }
+            }
+        }
+
+        pBC->bitmap = dw;
+    }
+
+    //-------------------------------------------------------------------------------------
+#ifdef COLOR_WEIGHTS
+    void EncodeSolidBC1(_Out_ D3DX_BC1 *pBC, _In_reads_(NUM_PIXELS_PER_BLOCK) const HDRColorA *pColor)
+    {
+    #ifdef COLOR_AVG_0WEIGHTS
+        // Compute avg color
+        HDRColorA Color;
+        Color.r = pColor[0].r;
+        Color.g = pColor[0].g;
+        Color.b = pColor[0].b;
+
+        for (size_t i = 1; i < NUM_PIXELS_PER_BLOCK; ++i)
+        {
+            Color.r += pColor[i].r;
+            Color.g += pColor[i].g;
+            Color.b += pColor[i].b;
+        }
+
+        Color.r *= 1.0f / 16.0f;
+        Color.g *= 1.0f / 16.0f;
+        Color.b *= 1.0f / 16.0f;
+
+        const uint16_t wColor = Encode565(&Color);
+    #else
+        const uint16_t wColor = 0x0000;
+    #endif // COLOR_AVG_0WEIGHTS
+
+        // Encode solid block
+        pBC->rgb[0] = wColor;
+        pBC->rgb[1] = wColor;
+        pBC->bitmap = 0x00000000;
+    }
+#endif // COLOR_WEIGHTS
+}
+
+
+//=====================================================================================
+// Entry points
+//=====================================================================================
+
+//-------------------------------------------------------------------------------------
+// BC1 Compression
+//-------------------------------------------------------------------------------------
+_Use_decl_annotations_
+void DirectX::D3DXDecodeBC1(XMVECTOR *pColor, const uint8_t *pBC) noexcept
+{
+    auto pBC1 = reinterpret_cast<const D3DX_BC1 *>(pBC);
+    DecodeBC1(pColor, pBC1, true);
+}
+
+_Use_decl_annotations_
+void DirectX::D3DXEncodeBC1(uint8_t *pBC, const XMVECTOR *pColor, float threshold, uint32_t flags) noexcept
+{
+    assert(pBC && pColor);
+
+    HDRColorA Color[NUM_PIXELS_PER_BLOCK];
+
+    if (flags & BC_FLAGS_DITHER_A)
+    {
+        float fError[NUM_PIXELS_PER_BLOCK] = {};
+
+        for (size_t i = 0; i < NUM_PIXELS_PER_BLOCK; ++i)
+        {
+            HDRColorA clr;
+            XMStoreFloat4(reinterpret_cast<XMFLOAT4*>(&clr), pColor[i]);
+
+            const float fAlph = clr.a + fError[i];
+
+            Color[i].r = clr.r;
+            Color[i].g = clr.g;
+            Color[i].b = clr.b;
+            Color[i].a = static_cast<float>(static_cast<int32_t>(clr.a + fError[i] + 0.5f));
+
+            const float fDiff = fAlph - Color[i].a;
+
+            if (3 != (i & 3))
+            {
+                assert(i < 15);
+                _Analysis_assume_(i < 15);
+                fError[i + 1] += fDiff * (7.0f / 16.0f);
+            }
+
+            if (i < 12)
+            {
+                if (i & 3)
+                    fError[i + 3] += fDiff * (3.0f / 16.0f);
+
+                fError[i + 4] += fDiff * (5.0f / 16.0f);
+
+                if (3 != (i & 3))
+                {
+                    assert(i < 11);
+                    _Analysis_assume_(i < 11);
+                    fError[i + 5] += fDiff * (1.0f / 16.0f);
+                }
+            }
+        }
+    }
+    else
+    {
+        for (size_t i = 0; i < NUM_PIXELS_PER_BLOCK; ++i)
+        {
+            XMStoreFloat4(reinterpret_cast<XMFLOAT4*>(&Color[i]), pColor[i]);
+        }
+    }
+
+    auto pBC1 = reinterpret_cast<D3DX_BC1 *>(pBC);
+    EncodeBC1(pBC1, Color, true, threshold, flags);
+}
+
+
+//-------------------------------------------------------------------------------------
+// BC2 Compression
+//-------------------------------------------------------------------------------------
+_Use_decl_annotations_
+void DirectX::D3DXDecodeBC2(XMVECTOR *pColor, const uint8_t *pBC) noexcept
+{
+    assert(pColor && pBC);
+    static_assert(sizeof(D3DX_BC2) == 16, "D3DX_BC2 should be 16 bytes");
+
+    auto pBC2 = reinterpret_cast<const D3DX_BC2 *>(pBC);
+
+    // RGB part
+    DecodeBC1(pColor, &pBC2->bc1, false);
+
+    // 4-bit alpha part
+    uint32_t dw = pBC2->bitmap[0];
+
+    for (size_t i = 0; i < 8; ++i, dw >>= 4)
+    {
+    #pragma prefast(suppress:22103, "writing blocks in two halves confuses tool")
+        pColor[i] = XMVectorSetW(pColor[i], static_cast<float>(dw & 0xf) * (1.0f / 15.0f));
+    }
+
+    dw = pBC2->bitmap[1];
+
+    for (size_t i = 8; i < NUM_PIXELS_PER_BLOCK; ++i, dw >>= 4)
+        pColor[i] = XMVectorSetW(pColor[i], static_cast<float>(dw & 0xf) * (1.0f / 15.0f));
+}
+
+_Use_decl_annotations_
+void DirectX::D3DXEncodeBC2(uint8_t *pBC, const XMVECTOR *pColor, uint32_t flags) noexcept
+{
+    assert(pBC && pColor);
+    static_assert(sizeof(D3DX_BC2) == 16, "D3DX_BC2 should be 16 bytes");
+
+    HDRColorA Color[NUM_PIXELS_PER_BLOCK];
+    for (size_t i = 0; i < NUM_PIXELS_PER_BLOCK; ++i)
+    {
+        XMStoreFloat4(reinterpret_cast<XMFLOAT4*>(&Color[i]), pColor[i]);
+    }
+
+    auto pBC2 = reinterpret_cast<D3DX_BC2 *>(pBC);
+
+    // 4-bit alpha part.  Dithered using Floyd Stienberg error diffusion.
+    pBC2->bitmap[0] = 0;
+    pBC2->bitmap[1] = 0;
+
+    float fError[NUM_PIXELS_PER_BLOCK] = {};
+    for (size_t i = 0; i < NUM_PIXELS_PER_BLOCK; ++i)
+    {
+        float fAlph = Color[i].a;
+        if (flags & BC_FLAGS_DITHER_A)
+            fAlph += fError[i];
+
+        const auto u = static_cast<uint32_t>(fAlph * 15.0f + 0.5f);
+
+        pBC2->bitmap[i >> 3] >>= 4;
+        pBC2->bitmap[i >> 3] |= (u << 28);
+
+        if (flags & BC_FLAGS_DITHER_A)
+        {
+            const float fDiff = fAlph - float(u) * (1.0f / 15.0f);
+
+            if (3 != (i & 3))
+            {
+                assert(i < 15);
+                _Analysis_assume_(i < 15);
+                fError[i + 1] += fDiff * (7.0f / 16.0f);
+            }
+
+            if (i < 12)
+            {
+                if (i & 3)
+                    fError[i + 3] += fDiff * (3.0f / 16.0f);
+
+                fError[i + 4] += fDiff * (5.0f / 16.0f);
+
+                if (3 != (i & 3))
+                {
+                    assert(i < 11);
+                    _Analysis_assume_(i < 11);
+                    fError[i + 5] += fDiff * (1.0f / 16.0f);
+                }
+            }
+        }
+    }
+
+    // RGB part
+#ifdef COLOR_WEIGHTS
+    if (!pBC2->bitmap[0] && !pBC2->bitmap[1])
+    {
+        EncodeSolidBC1(pBC2->dxt1, Color);
+        return;
+    }
+#endif // COLOR_WEIGHTS
+
+    EncodeBC1(&pBC2->bc1, Color, false, 0.f, flags);
+}
+
+
+//-------------------------------------------------------------------------------------
+// BC3 Compression
+//-------------------------------------------------------------------------------------
+_Use_decl_annotations_
+void DirectX::D3DXDecodeBC3(XMVECTOR *pColor, const uint8_t *pBC) noexcept
+{
+    assert(pColor && pBC);
+    static_assert(sizeof(D3DX_BC3) == 16, "D3DX_BC3 should be 16 bytes");
+
+    auto pBC3 = reinterpret_cast<const D3DX_BC3 *>(pBC);
+
+    // RGB part
+    DecodeBC1(pColor, &pBC3->bc1, false);
+
+    // Adaptive 3-bit alpha part
+    float fAlpha[8];
+
+    fAlpha[0] = static_cast<float>(pBC3->alpha[0]) * (1.0f / 255.0f);
+    fAlpha[1] = static_cast<float>(pBC3->alpha[1]) * (1.0f / 255.0f);
+
+    if (pBC3->alpha[0] > pBC3->alpha[1])
+    {
+        for (size_t i = 1; i < 7; ++i)
+            fAlpha[i + 1] = (fAlpha[0] * float(7u - i) + fAlpha[1] * float(i)) * (1.0f / 7.0f);
+    }
+    else
+    {
+        for (size_t i = 1; i < 5; ++i)
+            fAlpha[i + 1] = (fAlpha[0] * float(5u - i) + fAlpha[1] * float(i)) * (1.0f / 5.0f);
+
+        fAlpha[6] = 0.0f;
+        fAlpha[7] = 1.0f;
+    }
+
+    uint32_t dw = uint32_t(pBC3->bitmap[0]) | uint32_t(pBC3->bitmap[1] << 8) | uint32_t(pBC3->bitmap[2] << 16);
+
+    for (size_t i = 0; i < 8; ++i, dw >>= 3)
+        pColor[i] = XMVectorSetW(pColor[i], fAlpha[dw & 0x7]);
+
+    dw = uint32_t(pBC3->bitmap[3]) | uint32_t(pBC3->bitmap[4] << 8) | uint32_t(pBC3->bitmap[5] << 16);
+
+    for (size_t i = 8; i < NUM_PIXELS_PER_BLOCK; ++i, dw >>= 3)
+        pColor[i] = XMVectorSetW(pColor[i], fAlpha[dw & 0x7]);
+}
+
+_Use_decl_annotations_
+void DirectX::D3DXEncodeBC3(uint8_t *pBC, const XMVECTOR *pColor, uint32_t flags) noexcept
+{
+    assert(pBC && pColor);
+    static_assert(sizeof(D3DX_BC3) == 16, "D3DX_BC3 should be 16 bytes");
+
+    HDRColorA Color[NUM_PIXELS_PER_BLOCK];
+    for (size_t i = 0; i < NUM_PIXELS_PER_BLOCK; ++i)
+    {
+        XMStoreFloat4(reinterpret_cast<XMFLOAT4*>(&Color[i]), pColor[i]);
+    }
+
+    auto pBC3 = reinterpret_cast<D3DX_BC3 *>(pBC);
+
+    // Quantize block to A8, using Floyd Stienberg error diffusion.  This
+    // increases the chance that colors will map directly to the quantized
+    // axis endpoints.
+    float fAlpha[NUM_PIXELS_PER_BLOCK] = {};
+    float fError[NUM_PIXELS_PER_BLOCK] = {};
+
+    float fMinAlpha = Color[0].a;
+    float fMaxAlpha = Color[0].a;
+
+    for (size_t i = 0; i < NUM_PIXELS_PER_BLOCK; ++i)
+    {
+        float fAlph = Color[i].a;
+        if (flags & BC_FLAGS_DITHER_A)
+            fAlph += fError[i];
+
+        fAlpha[i] = static_cast<float>(static_cast<int32_t>(fAlph * 255.0f + 0.5f)) * (1.0f / 255.0f);
+
+        if (fAlpha[i] < fMinAlpha)
+            fMinAlpha = fAlpha[i];
+        else if (fAlpha[i] > fMaxAlpha)
+            fMaxAlpha = fAlpha[i];
+
+        if (flags & BC_FLAGS_DITHER_A)
+        {
+            const float fDiff = fAlph - fAlpha[i];
+
+            if (3 != (i & 3))
+            {
+                assert(i < 15);
+                _Analysis_assume_(i < 15);
+                fError[i + 1] += fDiff * (7.0f / 16.0f);
+            }
+
+            if (i < 12)
+            {
+                if (i & 3)
+                    fError[i + 3] += fDiff * (3.0f / 16.0f);
+
+                fError[i + 4] += fDiff * (5.0f / 16.0f);
+
+                if (3 != (i & 3))
+                {
+                    assert(i < 11);
+                    _Analysis_assume_(i < 11);
+                    fError[i + 5] += fDiff * (1.0f / 16.0f);
+                }
+            }
+        }
+    }
+
+#ifdef COLOR_WEIGHTS
+    if (0.0f == fMaxAlpha)
+    {
+        EncodeSolidBC1(&pBC3->dxt1, Color);
+        pBC3->alpha[0] = 0x00;
+        pBC3->alpha[1] = 0x00;
+        memset(pBC3->bitmap, 0x00, 6);
+    }
+#endif
+
+    // RGB part
+    EncodeBC1(&pBC3->bc1, Color, false, 0.f, flags);
+
+    // Alpha part
+    if (1.0f == fMinAlpha)
+    {
+        pBC3->alpha[0] = 0xff;
+        pBC3->alpha[1] = 0xff;
+        memset(pBC3->bitmap, 0x00, 6);
+        return;
+    }
+
+    // Optimize and Quantize Min and Max values
+    const uint32_t uSteps = ((0.0f == fMinAlpha) || (1.0f == fMaxAlpha)) ? 6u : 8u;
+
+    float fAlphaA, fAlphaB;
+    OptimizeAlpha<false>(&fAlphaA, &fAlphaB, fAlpha, uSteps);
+
+    auto const bAlphaA = static_cast<uint8_t>(static_cast<int32_t>(fAlphaA * 255.0f + 0.5f));
+    auto const bAlphaB = static_cast<uint8_t>(static_cast<int32_t>(fAlphaB * 255.0f + 0.5f));
+
+    fAlphaA = static_cast<float>(bAlphaA) * (1.0f / 255.0f);
+    fAlphaB = static_cast<float>(bAlphaB) * (1.0f / 255.0f);
+
+    // Setup block
+    if ((8 == uSteps) && (bAlphaA == bAlphaB))
+    {
+        pBC3->alpha[0] = bAlphaA;
+        pBC3->alpha[1] = bAlphaB;
+        memset(pBC3->bitmap, 0x00, 6);
+        return;
+    }
+
+    static const size_t pSteps6[] = { 0, 2, 3, 4, 5, 1 };
+    static const size_t pSteps8[] = { 0, 2, 3, 4, 5, 6, 7, 1 };
+
+    const size_t *pSteps;
+    float fStep[8] = {};
+
+    if (6 == uSteps)
+    {
+        pBC3->alpha[0] = bAlphaA;
+        pBC3->alpha[1] = bAlphaB;
+
+        fStep[0] = fAlphaA;
+        fStep[1] = fAlphaB;
+
+        for (size_t i = 1; i < 5; ++i)
+            fStep[i + 1] = (fStep[0] * float(5u - i) + fStep[1] * float(i)) * (1.0f / 5.0f);
+
+        fStep[6] = 0.0f;
+        fStep[7] = 1.0f;
+
+        pSteps = pSteps6;
+    }
+    else
+    {
+        pBC3->alpha[0] = bAlphaB;
+        pBC3->alpha[1] = bAlphaA;
+
+        fStep[0] = fAlphaB;
+        fStep[1] = fAlphaA;
+
+        for (size_t i = 1; i < 7; ++i)
+            fStep[i + 1] = (fStep[0] * float(7u - i) + fStep[1] * float(i)) * (1.0f / 7.0f);
+
+        pSteps = pSteps8;
+    }
+
+    // Encode alpha bitmap
+    auto const fSteps = static_cast<float>(uSteps - 1);
+    const float fScale = (fStep[0] != fStep[1]) ? (fSteps / (fStep[1] - fStep[0])) : 0.0f;
+
+    if (flags & BC_FLAGS_DITHER_A)
+        memset(fError, 0x00, NUM_PIXELS_PER_BLOCK * sizeof(float));
+
+    for (size_t iSet = 0; iSet < 2; iSet++)
+    {
+        uint32_t dw = 0;
+
+        const size_t iMin = iSet * 8;
+        const size_t iLim = iMin + 8;
+
+        for (size_t i = iMin; i < iLim; ++i)
+        {
+            float fAlph = Color[i].a;
+            if (flags & BC_FLAGS_DITHER_A)
+                fAlph += fError[i];
+            const float fDot = (fAlph - fStep[0]) * fScale;
+
+            uint32_t iStep;
+            if (fDot <= 0.0f)
+                iStep = ((6 == uSteps) && (fAlph <= fStep[0] * 0.5f)) ? 6u : 0u;
+            else if (fDot >= fSteps)
+                iStep = ((6 == uSteps) && (fAlph >= (fStep[1] + 1.0f) * 0.5f)) ? 7u : 1u;
+            else
+                iStep = uint32_t(pSteps[uint32_t(fDot + 0.5f)]);
+
+            dw = (iStep << 21) | (dw >> 3);
+
+            if (flags & BC_FLAGS_DITHER_A)
+            {
+                const float fDiff = (fAlph - fStep[iStep]);
+
+                if (3 != (i & 3))
+                    fError[i + 1] += fDiff * (7.0f / 16.0f);
+
+                if (i < 12)
+                {
+                    if (i & 3)
+                        fError[i + 3] += fDiff * (3.0f / 16.0f);
+
+                    fError[i + 4] += fDiff * (5.0f / 16.0f);
+
+                    if (3 != (i & 3))
+                        fError[i + 5] += fDiff * (1.0f / 16.0f);
+                }
+            }
+        }
+
+        pBC3->bitmap[0 + iSet * 3] = reinterpret_cast<uint8_t *>(&dw)[0];
+        pBC3->bitmap[1 + iSet * 3] = reinterpret_cast<uint8_t *>(&dw)[1];
+        pBC3->bitmap[2 + iSet * 3] = reinterpret_cast<uint8_t *>(&dw)[2];
+    }
+}

--- a/DirectXTex/DirectXTex/BC.h
+++ b/DirectXTex/DirectXTex/BC.h
@@ -1,0 +1,345 @@
+//-------------------------------------------------------------------------------------
+// BC.h
+//
+// Block-compression (BC) functionality
+//
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+//
+// http://go.microsoft.com/fwlink/?LinkId=248926
+//-------------------------------------------------------------------------------------
+
+#pragma once
+
+#include <DirectXMath.h>
+#include <DirectXPackedVector.h>
+
+namespace DirectX
+{
+//-------------------------------------------------------------------------------------
+// Macros
+//-------------------------------------------------------------------------------------
+
+// Because these are used in SAL annotations, they need to remain macros rather than const values
+#define NUM_PIXELS_PER_BLOCK 16
+
+//-------------------------------------------------------------------------------------
+// Constants
+//-------------------------------------------------------------------------------------
+
+    enum BC_FLAGS : uint32_t
+    {
+        BC_FLAGS_NONE = 0x0,
+
+        BC_FLAGS_DITHER_RGB = 0x10000,
+        // Enables dithering for RGB colors for BC1-3
+
+        BC_FLAGS_DITHER_A = 0x20000,
+        // Enables dithering for Alpha channel for BC1-3
+
+        BC_FLAGS_UNIFORM = 0x40000,
+        // By default, uses perceptual weighting for BC1-3; this flag makes it a uniform weighting
+
+        BC_FLAGS_USE_3SUBSETS = 0x80000,
+        // By default, BC7 skips mode 0 & 2; this flag adds those modes back
+
+        BC_FLAGS_FORCE_BC7_MODE6 = 0x100000,
+        // BC7 should only use mode 6; skip other modes
+    };
+
+    //-------------------------------------------------------------------------------------
+    // Structures
+    //-------------------------------------------------------------------------------------
+    class LDRColorA;
+
+    class HDRColorA
+    {
+    public:
+        float r, g, b, a;
+
+    public:
+        HDRColorA() = default;
+        HDRColorA(float _r, float _g, float _b, float _a) noexcept : r(_r), g(_g), b(_b), a(_a) {}
+
+        HDRColorA(HDRColorA const&) = default;
+        HDRColorA& operator= (const HDRColorA&) = default;
+
+        HDRColorA(HDRColorA&&) = default;
+        HDRColorA& operator= (HDRColorA&&) = default;
+
+        // binary operators
+        HDRColorA operator + (const HDRColorA& c) const noexcept
+        {
+            return HDRColorA(r + c.r, g + c.g, b + c.b, a + c.a);
+        }
+
+        HDRColorA operator - (const HDRColorA& c) const noexcept
+        {
+            return HDRColorA(r - c.r, g - c.g, b - c.b, a - c.a);
+        }
+
+        HDRColorA operator * (float f) const noexcept
+        {
+            return HDRColorA(r * f, g * f, b * f, a * f);
+        }
+
+        HDRColorA operator / (float f) const noexcept
+        {
+            const float fInv = 1.0f / f;
+            return HDRColorA(r * fInv, g * fInv, b * fInv, a * fInv);
+        }
+
+        float operator * (const HDRColorA& c) const noexcept
+        {
+            return r * c.r + g * c.g + b * c.b + a * c.a;
+        }
+
+        // assignment operators
+        HDRColorA& operator += (const HDRColorA& c) noexcept
+        {
+            r += c.r;
+            g += c.g;
+            b += c.b;
+            a += c.a;
+            return *this;
+        }
+
+        HDRColorA& operator -= (const HDRColorA& c) noexcept
+        {
+            r -= c.r;
+            g -= c.g;
+            b -= c.b;
+            a -= c.a;
+            return *this;
+        }
+
+        HDRColorA& operator *= (float f) noexcept
+        {
+            r *= f;
+            g *= f;
+            b *= f;
+            a *= f;
+            return *this;
+        }
+
+        HDRColorA& operator /= (float f) noexcept
+        {
+            const float fInv = 1.0f / f;
+            r *= fInv;
+            g *= fInv;
+            b *= fInv;
+            a *= fInv;
+            return *this;
+        }
+
+        HDRColorA& Clamp(_In_ float fMin, _In_ float fMax) noexcept
+        {
+            r = std::min<float>(fMax, std::max<float>(fMin, r));
+            g = std::min<float>(fMax, std::max<float>(fMin, g));
+            b = std::min<float>(fMax, std::max<float>(fMin, b));
+            a = std::min<float>(fMax, std::max<float>(fMin, a));
+            return *this;
+        }
+
+        HDRColorA(const LDRColorA& c) noexcept;
+        HDRColorA& operator = (const LDRColorA& c) noexcept;
+        LDRColorA ToLDRColorA() const noexcept;
+    };
+
+    inline HDRColorA* HDRColorALerp(_Out_ HDRColorA *pOut, _In_ const HDRColorA *pC1, _In_ const HDRColorA *pC2, _In_ float s) noexcept
+    {
+        pOut->r = pC1->r + s * (pC2->r - pC1->r);
+        pOut->g = pC1->g + s * (pC2->g - pC1->g);
+        pOut->b = pC1->b + s * (pC2->b - pC1->b);
+        pOut->a = pC1->a + s * (pC2->a - pC1->a);
+        return pOut;
+    }
+
+#pragma pack(push,1)
+// BC1/DXT1 compression (4 bits per texel)
+    struct D3DX_BC1
+    {
+        uint16_t    rgb[2]; // 565 colors
+        uint32_t    bitmap; // 2bpp rgb bitmap
+    };
+
+    // BC2/DXT2/3 compression (8 bits per texel)
+    struct D3DX_BC2
+    {
+        uint32_t    bitmap[2];  // 4bpp alpha bitmap
+        D3DX_BC1    bc1;        // BC1 rgb data
+    };
+
+    // BC3/DXT4/5 compression (8 bits per texel)
+    struct D3DX_BC3
+    {
+        uint8_t     alpha[2];   // alpha values
+        uint8_t     bitmap[6];  // 3bpp alpha bitmap
+        D3DX_BC1    bc1;        // BC1 rgb data
+    };
+#pragma pack(pop)
+
+//-------------------------------------------------------------------------------------
+// Templates
+//-------------------------------------------------------------------------------------
+#pragma warning(push)
+#pragma warning(disable : 4127)
+    template <bool bRange> void OptimizeAlpha(float *pX, float *pY, const float *pPoints, uint32_t cSteps) noexcept
+    {
+        static const float pC6[] = { 5.0f / 5.0f, 4.0f / 5.0f, 3.0f / 5.0f, 2.0f / 5.0f, 1.0f / 5.0f, 0.0f / 5.0f };
+        static const float pD6[] = { 0.0f / 5.0f, 1.0f / 5.0f, 2.0f / 5.0f, 3.0f / 5.0f, 4.0f / 5.0f, 5.0f / 5.0f };
+        static const float pC8[] = { 7.0f / 7.0f, 6.0f / 7.0f, 5.0f / 7.0f, 4.0f / 7.0f, 3.0f / 7.0f, 2.0f / 7.0f, 1.0f / 7.0f, 0.0f / 7.0f };
+        static const float pD8[] = { 0.0f / 7.0f, 1.0f / 7.0f, 2.0f / 7.0f, 3.0f / 7.0f, 4.0f / 7.0f, 5.0f / 7.0f, 6.0f / 7.0f, 7.0f / 7.0f };
+
+        const float *pC = (6 == cSteps) ? pC6 : pC8;
+        const float *pD = (6 == cSteps) ? pD6 : pD8;
+
+        constexpr float MAX_VALUE = 1.0f;
+        constexpr float MIN_VALUE = (bRange) ? -1.0f : 0.0f;
+
+        // Find Min and Max points, as starting point
+        float fX = MAX_VALUE;
+        float fY = MIN_VALUE;
+
+        if (8 == cSteps)
+        {
+            for (size_t iPoint = 0; iPoint < NUM_PIXELS_PER_BLOCK; iPoint++)
+            {
+                if (pPoints[iPoint] < fX)
+                    fX = pPoints[iPoint];
+
+                if (pPoints[iPoint] > fY)
+                    fY = pPoints[iPoint];
+            }
+        }
+        else
+        {
+            for (size_t iPoint = 0; iPoint < NUM_PIXELS_PER_BLOCK; iPoint++)
+            {
+                if (pPoints[iPoint] < fX && pPoints[iPoint] > MIN_VALUE)
+                    fX = pPoints[iPoint];
+
+                if (pPoints[iPoint] > fY && pPoints[iPoint] < MAX_VALUE)
+                    fY = pPoints[iPoint];
+            }
+
+            if (fX == fY)
+            {
+                fY = MAX_VALUE;
+            }
+        }
+
+        // Use Newton's Method to find local minima of sum-of-squares error.
+        auto const fSteps = static_cast<float>(cSteps - 1);
+
+        for (size_t iIteration = 0; iIteration < 8; iIteration++)
+        {
+            if ((fY - fX) < (1.0f / 256.0f))
+                break;
+
+            float const fScale = fSteps / (fY - fX);
+
+            // Calculate new steps
+            float pSteps[8];
+
+            for (size_t iStep = 0; iStep < cSteps; iStep++)
+                pSteps[iStep] = pC[iStep] * fX + pD[iStep] * fY;
+
+            if (6 == cSteps)
+            {
+                pSteps[6] = MIN_VALUE;
+                pSteps[7] = MAX_VALUE;
+            }
+
+            // Evaluate function, and derivatives
+            float dX = 0.0f;
+            float dY = 0.0f;
+            float d2X = 0.0f;
+            float d2Y = 0.0f;
+
+            for (size_t iPoint = 0; iPoint < NUM_PIXELS_PER_BLOCK; iPoint++)
+            {
+                const float fDot = (pPoints[iPoint] - fX) * fScale;
+
+                uint32_t iStep;
+                if (fDot <= 0.0f)
+                {
+                    // D3DX10 / D3DX11 didn't take into account the proper minimum value for the bRange (BC4S/BC5S) case
+                    iStep = ((6 == cSteps) && (pPoints[iPoint] <= (fX + MIN_VALUE) * 0.5f)) ? 6u : 0u;
+                }
+                else if (fDot >= fSteps)
+                {
+                    iStep = ((6 == cSteps) && (pPoints[iPoint] >= (fY + MAX_VALUE) * 0.5f)) ? 7u : (cSteps - 1);
+                }
+                else
+                {
+                    iStep = uint32_t(fDot + 0.5f);
+                }
+
+                if (iStep < cSteps)
+                {
+                    // D3DX had this computation backwards (pPoints[iPoint] - pSteps[iStep])
+                    // this fix improves RMS of the alpha component
+                    const float fDiff = pSteps[iStep] - pPoints[iPoint];
+
+                    dX += pC[iStep] * fDiff;
+                    d2X += pC[iStep] * pC[iStep];
+
+                    dY += pD[iStep] * fDiff;
+                    d2Y += pD[iStep] * pD[iStep];
+                }
+            }
+
+            // Move endpoints
+            if (d2X > 0.0f)
+                fX -= dX / d2X;
+
+            if (d2Y > 0.0f)
+                fY -= dY / d2Y;
+
+            if (fX > fY)
+            {
+                const float f = fX; fX = fY; fY = f;
+            }
+
+            if ((dX * dX < (1.0f / 64.0f)) && (dY * dY < (1.0f / 64.0f)))
+                break;
+        }
+
+        *pX = (fX < MIN_VALUE) ? MIN_VALUE : (fX > MAX_VALUE) ? MAX_VALUE : fX;
+        *pY = (fY < MIN_VALUE) ? MIN_VALUE : (fY > MAX_VALUE) ? MAX_VALUE : fY;
+    }
+#pragma warning(pop)
+
+//-------------------------------------------------------------------------------------
+// Functions
+//-------------------------------------------------------------------------------------
+
+    typedef void (*BC_DECODE)(XMVECTOR *pColor, const uint8_t *pBC);
+    typedef void (*BC_ENCODE)(uint8_t *pDXT, const XMVECTOR *pColor, uint32_t flags);
+
+    void D3DXDecodeBC1(_Out_writes_(NUM_PIXELS_PER_BLOCK) XMVECTOR *pColor, _In_reads_(8) const uint8_t *pBC) noexcept;
+    void D3DXDecodeBC2(_Out_writes_(NUM_PIXELS_PER_BLOCK) XMVECTOR *pColor, _In_reads_(16) const uint8_t *pBC) noexcept;
+    void D3DXDecodeBC3(_Out_writes_(NUM_PIXELS_PER_BLOCK) XMVECTOR *pColor, _In_reads_(16) const uint8_t *pBC) noexcept;
+    void D3DXDecodeBC4U(_Out_writes_(NUM_PIXELS_PER_BLOCK) XMVECTOR *pColor, _In_reads_(8) const uint8_t *pBC) noexcept;
+    void D3DXDecodeBC4S(_Out_writes_(NUM_PIXELS_PER_BLOCK) XMVECTOR *pColor, _In_reads_(8) const uint8_t *pBC) noexcept;
+    void D3DXDecodeBC5U(_Out_writes_(NUM_PIXELS_PER_BLOCK) XMVECTOR *pColor, _In_reads_(16) const uint8_t *pBC) noexcept;
+    void D3DXDecodeBC5S(_Out_writes_(NUM_PIXELS_PER_BLOCK) XMVECTOR *pColor, _In_reads_(16) const uint8_t *pBC) noexcept;
+    void D3DXDecodeBC6HU(_Out_writes_(NUM_PIXELS_PER_BLOCK) XMVECTOR *pColor, _In_reads_(16) const uint8_t *pBC) noexcept;
+    void D3DXDecodeBC6HS(_Out_writes_(NUM_PIXELS_PER_BLOCK) XMVECTOR *pColor, _In_reads_(16) const uint8_t *pBC) noexcept;
+    void D3DXDecodeBC7(_Out_writes_(NUM_PIXELS_PER_BLOCK) XMVECTOR *pColor, _In_reads_(16) const uint8_t *pBC) noexcept;
+
+    void D3DXEncodeBC1(_Out_writes_(8) uint8_t *pBC, _In_reads_(NUM_PIXELS_PER_BLOCK) const XMVECTOR *pColor, _In_ float threshold, _In_ uint32_t flags) noexcept;
+        // BC1 requires one additional parameter, so it doesn't match signature of BC_ENCODE above
+
+    void D3DXEncodeBC2(_Out_writes_(16) uint8_t *pBC, _In_reads_(NUM_PIXELS_PER_BLOCK) const XMVECTOR *pColor, _In_ uint32_t flags) noexcept;
+    void D3DXEncodeBC3(_Out_writes_(16) uint8_t *pBC, _In_reads_(NUM_PIXELS_PER_BLOCK) const XMVECTOR *pColor, _In_ uint32_t flags) noexcept;
+    void D3DXEncodeBC4U(_Out_writes_(8) uint8_t *pBC, _In_reads_(NUM_PIXELS_PER_BLOCK) const XMVECTOR *pColor, _In_ uint32_t flags) noexcept;
+    void D3DXEncodeBC4S(_Out_writes_(8) uint8_t *pBC, _In_reads_(NUM_PIXELS_PER_BLOCK) const XMVECTOR *pColor, _In_ uint32_t flags) noexcept;
+    void D3DXEncodeBC5U(_Out_writes_(16) uint8_t *pBC, _In_reads_(NUM_PIXELS_PER_BLOCK) const XMVECTOR *pColor, _In_ uint32_t flags) noexcept;
+    void D3DXEncodeBC5S(_Out_writes_(16) uint8_t *pBC, _In_reads_(NUM_PIXELS_PER_BLOCK) const XMVECTOR *pColor, _In_ uint32_t flags) noexcept;
+    void D3DXEncodeBC6HU(_Out_writes_(16) uint8_t *pBC, _In_reads_(NUM_PIXELS_PER_BLOCK) const XMVECTOR *pColor, _In_ uint32_t flags) noexcept;
+    void D3DXEncodeBC6HS(_Out_writes_(16) uint8_t *pBC, _In_reads_(NUM_PIXELS_PER_BLOCK) const XMVECTOR *pColor, _In_ uint32_t flags) noexcept;
+    void D3DXEncodeBC7(_Out_writes_(16) uint8_t *pBC, _In_reads_(NUM_PIXELS_PER_BLOCK) const XMVECTOR *pColor, _In_ uint32_t flags) noexcept;
+
+} // namespace

--- a/DirectXTex/DirectXTex/BC4BC5.cpp
+++ b/DirectXTex/DirectXTex/BC4BC5.cpp
@@ -1,0 +1,562 @@
+//-------------------------------------------------------------------------------------
+// BC4BC5.cpp
+//
+// Block-compression (BC) functionality for BC4 and BC5 (DirectX 10 texture compression)
+//
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+//
+// http://go.microsoft.com/fwlink/?LinkId=248926
+//-------------------------------------------------------------------------------------
+
+#include "DirectXTexP.h"
+
+#include "BC.h"
+
+using namespace DirectX;
+
+//------------------------------------------------------------------------------------
+// Constants
+//------------------------------------------------------------------------------------
+
+// Because these are used in SAL annotations, they need to remain macros rather than const values
+#define BLOCK_LEN 4
+// length of each block in texel
+
+#define BLOCK_SIZE (BLOCK_LEN * BLOCK_LEN)
+// total texels in a 4x4 block.
+
+namespace
+{
+    //------------------------------------------------------------------------------------
+    // Structures
+    //-------------------------------------------------------------------------------------
+
+#pragma warning(push)
+#pragma warning(disable : 4201)
+
+    // BC4U/BC5U
+    struct BC4_UNORM
+    {
+        float R(size_t uOffset) const noexcept
+        {
+            const size_t uIndex = GetIndex(uOffset);
+            return DecodeFromIndex(uIndex);
+        }
+
+        float DecodeFromIndex(size_t uIndex) const noexcept
+        {
+            if (uIndex == 0)
+                return float(red_0) / 255.0f;
+            if (uIndex == 1)
+                return float(red_1) / 255.0f;
+            const float fred_0 = float(red_0) / 255.0f;
+            const float fred_1 = float(red_1) / 255.0f;
+            if (red_0 > red_1)
+            {
+                uIndex -= 1;
+                return (fred_0 * float(7u - uIndex) + fred_1 * float(uIndex)) / 7.0f;
+            }
+            else
+            {
+                if (uIndex == 6)
+                    return 0.0f;
+                if (uIndex == 7)
+                    return 1.0f;
+                uIndex -= 1;
+                return (fred_0 * float(5u - uIndex) + fred_1 * float(uIndex)) / 5.0f;
+            }
+        }
+
+        size_t GetIndex(size_t uOffset) const noexcept
+        {
+            return static_cast<size_t>((data >> (3 * uOffset + 16)) & 0x07);
+        }
+
+        void SetIndex(size_t uOffset, size_t uIndex) noexcept
+        {
+            data &= ~(uint64_t(0x07) << (3 * uOffset + 16));
+            data |= (uint64_t(uIndex) << (3 * uOffset + 16));
+        }
+
+        union
+        {
+            struct
+            {
+                uint8_t red_0;
+                uint8_t red_1;
+                uint8_t indices[6];
+            };
+            uint64_t data;
+        };
+    };
+
+    // BC4S/BC5S
+    struct BC4_SNORM
+    {
+        float R(size_t uOffset) const noexcept
+        {
+            const size_t uIndex = GetIndex(uOffset);
+            return DecodeFromIndex(uIndex);
+        }
+
+        float DecodeFromIndex(size_t uIndex) const noexcept
+        {
+            const int8_t sred_0 = (red_0 == -128) ? -127 : red_0;
+            const int8_t sred_1 = (red_1 == -128) ? -127 : red_1;
+
+            if (uIndex == 0)
+                return float(sred_0) / 127.0f;
+            if (uIndex == 1)
+                return float(sred_1) / 127.0f;
+            const float fred_0 = float(sred_0) / 127.0f;
+            const float fred_1 = float(sred_1) / 127.0f;
+            if (red_0 > red_1)
+            {
+                uIndex -= 1;
+                return (fred_0 * float(7u - uIndex) + fred_1 * float(uIndex)) / 7.0f;
+            }
+            else
+            {
+                if (uIndex == 6)
+                    return -1.0f;
+                if (uIndex == 7)
+                    return 1.0f;
+                uIndex -= 1;
+                return (fred_0 * float(5u - uIndex) + fred_1 * float(uIndex)) / 5.0f;
+            }
+        }
+
+        size_t GetIndex(size_t uOffset) const noexcept
+        {
+            return static_cast<size_t>((data >> (3 * uOffset + 16)) & 0x07);
+        }
+
+        void SetIndex(size_t uOffset, size_t uIndex) noexcept
+        {
+            data &= ~(uint64_t(0x07) << (3 * uOffset + 16));
+            data |= (uint64_t(uIndex) << (3 * uOffset + 16));
+        }
+
+        union
+        {
+            struct
+            {
+                int8_t red_0;
+                int8_t red_1;
+                uint8_t indices[6];
+            };
+            uint64_t data;
+        };
+    };
+
+#pragma warning(pop)
+
+    //-------------------------------------------------------------------------------------
+    // Convert a floating point value to an 8-bit SNORM
+    //-------------------------------------------------------------------------------------
+    void inline FloatToSNorm(_In_ float fVal, _Out_ int8_t *piSNorm) noexcept
+    {
+        constexpr uint32_t dwMostNeg = (1 << (8 * sizeof(int8_t) - 1));
+
+        if (isnan(fVal))
+            fVal = 0;
+        else
+            if (fVal > 1)
+                fVal = 1;    // Clamp to 1
+            else
+                if (fVal < -1)
+                    fVal = -1;    // Clamp to -1
+
+        fVal = fVal * static_cast<int8_t>(dwMostNeg - 1);
+
+        if (fVal >= 0)
+            fVal += .5f;
+        else
+            fVal -= .5f;
+
+        *piSNorm = static_cast<int8_t>(fVal);
+    }
+
+
+    //------------------------------------------------------------------------------
+    void FindEndPointsBC4U(
+        _In_reads_(BLOCK_SIZE) const float theTexelsU[],
+        _Out_ uint8_t &endpointU_0,
+        _Out_ uint8_t &endpointU_1) noexcept
+    {
+        // The boundary of codec for signed/unsigned format
+        constexpr float MIN_NORM = 0.f;
+        constexpr float MAX_NORM = 1.f;
+
+        // Find max/min of input texels
+        float fBlockMax = theTexelsU[0];
+        float fBlockMin = theTexelsU[0];
+        for (size_t i = 0; i < BLOCK_SIZE; ++i)
+        {
+            if (theTexelsU[i] < fBlockMin)
+            {
+                fBlockMin = theTexelsU[i];
+            }
+            else if (theTexelsU[i] > fBlockMax)
+            {
+                fBlockMax = theTexelsU[i];
+            }
+        }
+
+        //  If there are boundary values in input texels, should use 4 interpolated color values to guarantee
+        //  the exact code of the boundary values.
+        const bool bUsing4BlockCodec = (MIN_NORM == fBlockMin || MAX_NORM == fBlockMax);
+
+        // Using Optimize
+        float fStart, fEnd;
+
+        if (!bUsing4BlockCodec)
+        {
+            // 6 interpolated color values
+            OptimizeAlpha<false>(&fStart, &fEnd, theTexelsU, 8);
+
+            auto iStart = static_cast<uint8_t>(fStart * 255.0f);
+            auto iEnd = static_cast<uint8_t>(fEnd * 255.0f);
+
+            endpointU_0 = iEnd;
+            endpointU_1 = iStart;
+        }
+        else
+        {
+            // 4 interpolated color values
+            OptimizeAlpha<false>(&fStart, &fEnd, theTexelsU, 6);
+
+            auto iStart = static_cast<uint8_t>(fStart * 255.0f);
+            auto iEnd = static_cast<uint8_t>(fEnd * 255.0f);
+
+            endpointU_1 = iEnd;
+            endpointU_0 = iStart;
+        }
+    }
+
+    void FindEndPointsBC4S(
+        _In_reads_(BLOCK_SIZE) const float theTexelsU[],
+        _Out_ int8_t &endpointU_0,
+        _Out_ int8_t &endpointU_1) noexcept
+    {
+        //  The boundary of codec for signed/unsigned format
+        constexpr float MIN_NORM = -1.f;
+        constexpr float MAX_NORM = 1.f;
+
+        // Find max/min of input texels
+        float fBlockMax = theTexelsU[0];
+        float fBlockMin = theTexelsU[0];
+        for (size_t i = 0; i < BLOCK_SIZE; ++i)
+        {
+            if (theTexelsU[i] < fBlockMin)
+            {
+                fBlockMin = theTexelsU[i];
+            }
+            else if (theTexelsU[i] > fBlockMax)
+            {
+                fBlockMax = theTexelsU[i];
+            }
+        }
+
+        //  If there are boundary values in input texels, should use 4 interpolated color values to guarantee
+        //  the exact code of the boundary values.
+        const bool bUsing4BlockCodec = (MIN_NORM == fBlockMin || MAX_NORM == fBlockMax);
+
+        // Using Optimize
+        float fStart, fEnd;
+
+        if (!bUsing4BlockCodec)
+        {
+            // 6 interpolated color values
+            OptimizeAlpha<true>(&fStart, &fEnd, theTexelsU, 8);
+
+            int8_t iStart, iEnd;
+            FloatToSNorm(fStart, &iStart);
+            FloatToSNorm(fEnd, &iEnd);
+
+            endpointU_0 = iEnd;
+            endpointU_1 = iStart;
+        }
+        else
+        {
+            // 4 interpolated color values
+            OptimizeAlpha<true>(&fStart, &fEnd, theTexelsU, 6);
+
+            int8_t iStart, iEnd;
+            FloatToSNorm(fStart, &iStart);
+            FloatToSNorm(fEnd, &iEnd);
+
+            endpointU_1 = iEnd;
+            endpointU_0 = iStart;
+        }
+    }
+
+
+    //------------------------------------------------------------------------------
+    inline void FindEndPointsBC5U(
+        _In_reads_(BLOCK_SIZE) const float theTexelsU[],
+        _In_reads_(BLOCK_SIZE) const float theTexelsV[],
+        _Out_ uint8_t &endpointU_0,
+        _Out_ uint8_t &endpointU_1,
+        _Out_ uint8_t &endpointV_0,
+        _Out_ uint8_t &endpointV_1) noexcept
+    {
+        //Encoding the U and V channel by BC4 codec separately.
+        FindEndPointsBC4U(theTexelsU, endpointU_0, endpointU_1);
+        FindEndPointsBC4U(theTexelsV, endpointV_0, endpointV_1);
+    }
+
+    inline void FindEndPointsBC5S(
+        _In_reads_(BLOCK_SIZE) const float theTexelsU[],
+        _In_reads_(BLOCK_SIZE) const float theTexelsV[],
+        _Out_ int8_t &endpointU_0,
+        _Out_ int8_t &endpointU_1,
+        _Out_ int8_t &endpointV_0,
+        _Out_ int8_t &endpointV_1) noexcept
+    {
+        //Encoding the U and V channel by BC4 codec separately.
+        FindEndPointsBC4S(theTexelsU, endpointU_0, endpointU_1);
+        FindEndPointsBC4S(theTexelsV, endpointV_0, endpointV_1);
+    }
+
+
+    //------------------------------------------------------------------------------
+    void FindClosestUNORM(
+        _Inout_ BC4_UNORM* pBC,
+        _In_reads_(NUM_PIXELS_PER_BLOCK) const float theTexelsU[]) noexcept
+    {
+        float rGradient[8];
+        for (size_t i = 0; i < 8; ++i)
+        {
+            rGradient[i] = pBC->DecodeFromIndex(i);
+        }
+
+        for (size_t i = 0; i < NUM_PIXELS_PER_BLOCK; ++i)
+        {
+            size_t uBestIndex = 0;
+            float fBestDelta = 100000;
+            for (size_t uIndex = 0; uIndex < 8; uIndex++)
+            {
+                const float fCurrentDelta = fabsf(rGradient[uIndex] - theTexelsU[i]);
+                if (fCurrentDelta < fBestDelta)
+                {
+                    uBestIndex = uIndex;
+                    fBestDelta = fCurrentDelta;
+                }
+            }
+            pBC->SetIndex(i, uBestIndex);
+        }
+    }
+
+    void FindClosestSNORM(
+        _Inout_ BC4_SNORM* pBC,
+        _In_reads_(NUM_PIXELS_PER_BLOCK) const float theTexelsU[]) noexcept
+    {
+        float rGradient[8];
+        for (size_t i = 0; i < 8; ++i)
+        {
+            rGradient[i] = pBC->DecodeFromIndex(i);
+        }
+
+        for (size_t i = 0; i < NUM_PIXELS_PER_BLOCK; ++i)
+        {
+            size_t uBestIndex = 0;
+            float fBestDelta = 100000;
+            for (size_t uIndex = 0; uIndex < 8; uIndex++)
+            {
+                const float fCurrentDelta = fabsf(rGradient[uIndex] - theTexelsU[i]);
+                if (fCurrentDelta < fBestDelta)
+                {
+                    uBestIndex = uIndex;
+                    fBestDelta = fCurrentDelta;
+                }
+            }
+            pBC->SetIndex(i, uBestIndex);
+        }
+    }
+}
+
+
+//=====================================================================================
+// Entry points
+//=====================================================================================
+
+//-------------------------------------------------------------------------------------
+// BC4 Compression
+//-------------------------------------------------------------------------------------
+_Use_decl_annotations_
+void DirectX::D3DXDecodeBC4U(XMVECTOR *pColor, const uint8_t *pBC) noexcept
+{
+    assert(pColor && pBC);
+    static_assert(sizeof(BC4_UNORM) == 8, "BC4_UNORM should be 8 bytes");
+
+    auto pBC4 = reinterpret_cast<const BC4_UNORM*>(pBC);
+
+    for (size_t i = 0; i < NUM_PIXELS_PER_BLOCK; ++i)
+    {
+    #pragma prefast(suppress:22103, "writing blocks in two halves confuses tool")
+        pColor[i] = XMVectorSet(pBC4->R(i), 0, 0, 1.0f);
+    }
+}
+
+_Use_decl_annotations_
+void DirectX::D3DXDecodeBC4S(XMVECTOR *pColor, const uint8_t *pBC) noexcept
+{
+    assert(pColor && pBC);
+    static_assert(sizeof(BC4_SNORM) == 8, "BC4_SNORM should be 8 bytes");
+
+    auto pBC4 = reinterpret_cast<const BC4_SNORM*>(pBC);
+
+    for (size_t i = 0; i < NUM_PIXELS_PER_BLOCK; ++i)
+    {
+    #pragma prefast(suppress:22103, "writing blocks in two halves confuses tool")
+        pColor[i] = XMVectorSet(pBC4->R(i), 0, 0, 1.0f);
+    }
+}
+
+_Use_decl_annotations_
+void DirectX::D3DXEncodeBC4U(uint8_t *pBC, const XMVECTOR *pColor, uint32_t flags) noexcept
+{
+    UNREFERENCED_PARAMETER(flags);
+
+    assert(pBC && pColor);
+    static_assert(sizeof(BC4_UNORM) == 8, "BC4_UNORM should be 8 bytes");
+
+    memset(pBC, 0, sizeof(BC4_UNORM));
+    auto pBC4 = reinterpret_cast<BC4_UNORM*>(pBC);
+    float theTexelsU[NUM_PIXELS_PER_BLOCK];
+
+    for (size_t i = 0; i < NUM_PIXELS_PER_BLOCK; ++i)
+    {
+        theTexelsU[i] = XMVectorGetX(pColor[i]);
+    }
+
+    FindEndPointsBC4U(theTexelsU, pBC4->red_0, pBC4->red_1);
+    FindClosestUNORM(pBC4, theTexelsU);
+}
+
+_Use_decl_annotations_
+void DirectX::D3DXEncodeBC4S(uint8_t *pBC, const XMVECTOR *pColor, uint32_t flags) noexcept
+{
+    UNREFERENCED_PARAMETER(flags);
+
+    assert(pBC && pColor);
+    static_assert(sizeof(BC4_SNORM) == 8, "BC4_SNORM should be 8 bytes");
+
+    memset(pBC, 0, sizeof(BC4_UNORM));
+    auto pBC4 = reinterpret_cast<BC4_SNORM*>(pBC);
+    float theTexelsU[NUM_PIXELS_PER_BLOCK];
+
+    for (size_t i = 0; i < NUM_PIXELS_PER_BLOCK; ++i)
+    {
+        theTexelsU[i] = XMVectorGetX(pColor[i]);
+    }
+
+    FindEndPointsBC4S(theTexelsU, pBC4->red_0, pBC4->red_1);
+    FindClosestSNORM(pBC4, theTexelsU);
+}
+
+
+//-------------------------------------------------------------------------------------
+// BC5 Compression
+//-------------------------------------------------------------------------------------
+_Use_decl_annotations_
+void DirectX::D3DXDecodeBC5U(XMVECTOR *pColor, const uint8_t *pBC) noexcept
+{
+    assert(pColor && pBC);
+    static_assert(sizeof(BC4_UNORM) == 8, "BC4_UNORM should be 8 bytes");
+
+    auto pBCR = reinterpret_cast<const BC4_UNORM*>(pBC);
+    auto pBCG = reinterpret_cast<const BC4_UNORM*>(pBC + sizeof(BC4_UNORM));
+
+    for (size_t i = 0; i < NUM_PIXELS_PER_BLOCK; ++i)
+    {
+    #pragma prefast(suppress:22103, "writing blocks in two halves confuses tool")
+        pColor[i] = XMVectorSet(pBCR->R(i), pBCG->R(i), 0, 1.0f);
+    }
+}
+
+_Use_decl_annotations_
+void DirectX::D3DXDecodeBC5S(XMVECTOR *pColor, const uint8_t *pBC) noexcept
+{
+    assert(pColor && pBC);
+    static_assert(sizeof(BC4_SNORM) == 8, "BC4_SNORM should be 8 bytes");
+
+    auto pBCR = reinterpret_cast<const BC4_SNORM*>(pBC);
+    auto pBCG = reinterpret_cast<const BC4_SNORM*>(pBC + sizeof(BC4_SNORM));
+
+    for (size_t i = 0; i < NUM_PIXELS_PER_BLOCK; ++i)
+    {
+    #pragma prefast(suppress:22103, "writing blocks in two halves confuses tool")
+        pColor[i] = XMVectorSet(pBCR->R(i), pBCG->R(i), 0, 1.0f);
+    }
+}
+
+_Use_decl_annotations_
+void DirectX::D3DXEncodeBC5U(uint8_t *pBC, const XMVECTOR *pColor, uint32_t flags) noexcept
+{
+    UNREFERENCED_PARAMETER(flags);
+
+    assert(pBC && pColor);
+    static_assert(sizeof(BC4_UNORM) == 8, "BC4_UNORM should be 8 bytes");
+
+    memset(pBC, 0, sizeof(BC4_UNORM) * 2);
+    auto pBCR = reinterpret_cast<BC4_UNORM*>(pBC);
+    auto pBCG = reinterpret_cast<BC4_UNORM*>(pBC + sizeof(BC4_UNORM));
+    float theTexelsU[NUM_PIXELS_PER_BLOCK];
+    float theTexelsV[NUM_PIXELS_PER_BLOCK];
+
+    for (size_t i = 0; i < NUM_PIXELS_PER_BLOCK; ++i)
+    {
+        XMFLOAT4A clr;
+        XMStoreFloat4A(&clr, pColor[i]);
+        theTexelsU[i] = clr.x;
+        theTexelsV[i] = clr.y;
+    }
+
+    FindEndPointsBC5U(
+        theTexelsU,
+        theTexelsV,
+        pBCR->red_0,
+        pBCR->red_1,
+        pBCG->red_0,
+        pBCG->red_1);
+
+    FindClosestUNORM(pBCR, theTexelsU);
+    FindClosestUNORM(pBCG, theTexelsV);
+}
+
+_Use_decl_annotations_
+void DirectX::D3DXEncodeBC5S(uint8_t *pBC, const XMVECTOR *pColor, uint32_t flags) noexcept
+{
+    UNREFERENCED_PARAMETER(flags);
+
+    assert(pBC && pColor);
+    static_assert(sizeof(BC4_SNORM) == 8, "BC4_SNORM should be 8 bytes");
+
+    memset(pBC, 0, sizeof(BC4_UNORM) * 2);
+    auto pBCR = reinterpret_cast<BC4_SNORM*>(pBC);
+    auto pBCG = reinterpret_cast<BC4_SNORM*>(pBC + sizeof(BC4_SNORM));
+    float theTexelsU[NUM_PIXELS_PER_BLOCK];
+    float theTexelsV[NUM_PIXELS_PER_BLOCK];
+
+    for (size_t i = 0; i < NUM_PIXELS_PER_BLOCK; ++i)
+    {
+        XMFLOAT4A clr;
+        XMStoreFloat4A(&clr, pColor[i]);
+        theTexelsU[i] = clr.x;
+        theTexelsV[i] = clr.y;
+    }
+
+    FindEndPointsBC5S(
+        theTexelsU,
+        theTexelsV,
+        pBCR->red_0,
+        pBCR->red_1,
+        pBCG->red_0,
+        pBCG->red_1);
+
+    FindClosestSNORM(pBCR, theTexelsU);
+    FindClosestSNORM(pBCG, theTexelsV);
+}

--- a/DirectXTex/DirectXTex/BC6HBC7.cpp
+++ b/DirectXTex/DirectXTex/BC6HBC7.cpp
@@ -1,0 +1,3659 @@
+//-------------------------------------------------------------------------------------
+// BC6HBC7.cpp
+//
+// Block-compression (BC) functionality for BC6H and BC7 (DirectX 11 texture compression)
+//
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+//
+// http://go.microsoft.com/fwlink/?LinkId=248926
+//-------------------------------------------------------------------------------------
+
+#include "DirectXTexP.h"
+
+#include "BC.h"
+
+using namespace DirectX;
+using namespace DirectX::PackedVector;
+
+//-------------------------------------------------------------------------------------
+// Macros
+//-------------------------------------------------------------------------------------
+
+#define SIGN_EXTEND(x,nb) ((((x)&(1<<((nb)-1)))?((~0)^((1<<(nb))-1)):0)|(x))
+
+// Because these are used in SAL annotations, they need to remain macros rather than const values
+#define BC6H_MAX_REGIONS 2
+#define BC6H_MAX_INDICES 16
+#define BC7_MAX_REGIONS 3
+#define BC7_MAX_INDICES 16
+
+namespace
+{
+    //-------------------------------------------------------------------------------------
+    // Constants
+    //-------------------------------------------------------------------------------------
+
+    constexpr uint16_t F16S_MASK = 0x8000;   // f16 sign mask
+    constexpr uint16_t F16EM_MASK = 0x7fff;   // f16 exp & mantissa mask
+    constexpr uint16_t F16MAX = 0x7bff;   // MAXFLT bit pattern for XMHALF
+
+    constexpr size_t BC6H_NUM_CHANNELS = 3;
+    constexpr size_t BC6H_MAX_SHAPES = 32;
+
+    constexpr size_t BC7_NUM_CHANNELS = 4;
+    constexpr size_t BC7_MAX_SHAPES = 64;
+
+    constexpr int32_t BC67_WEIGHT_MAX = 64;
+    constexpr uint32_t BC67_WEIGHT_SHIFT = 6;
+    constexpr int32_t BC67_WEIGHT_ROUND = 32;
+
+    constexpr float fEpsilon = (0.25f / 64.0f) * (0.25f / 64.0f);
+    constexpr float pC3[] = { 2.0f / 2.0f, 1.0f / 2.0f, 0.0f / 2.0f };
+    constexpr float pD3[] = { 0.0f / 2.0f, 1.0f / 2.0f, 2.0f / 2.0f };
+    constexpr float pC4[] = { 3.0f / 3.0f, 2.0f / 3.0f, 1.0f / 3.0f, 0.0f / 3.0f };
+    constexpr float pD4[] = { 0.0f / 3.0f, 1.0f / 3.0f, 2.0f / 3.0f, 3.0f / 3.0f };
+
+    // Partition, Shape, Pixel (index into 4x4 block)
+    const uint8_t g_aPartitionTable[3][64][16] =
+    {
+        {   // 1 Region case has no subsets (all 0)
+            { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 },
+            { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 },
+            { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 },
+            { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 },
+            { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 },
+            { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 },
+            { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 },
+            { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 },
+            { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 },
+            { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 },
+            { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 },
+            { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 },
+            { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 },
+            { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 },
+            { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 },
+            { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 },
+            { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 },
+            { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 },
+            { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 },
+            { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 },
+            { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 },
+            { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 },
+            { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 },
+            { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 },
+            { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 },
+            { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 },
+            { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 },
+            { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 },
+            { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 },
+            { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 },
+            { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 },
+            { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 },
+            { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 },
+            { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 },
+            { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 },
+            { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 },
+            { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 },
+            { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 },
+            { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 },
+            { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 },
+            { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 },
+            { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 },
+            { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 },
+            { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 },
+            { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 },
+            { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 },
+            { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 },
+            { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 },
+            { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 },
+            { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 },
+            { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 },
+            { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 },
+            { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 },
+            { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 },
+            { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 },
+            { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 },
+            { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 },
+            { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 },
+            { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 },
+            { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 },
+            { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 },
+            { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 },
+            { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 },
+            { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 }
+        },
+
+        {   // BC6H/BC7 Partition Set for 2 Subsets
+            { 0, 0, 1, 1, 0, 0, 1, 1, 0, 0, 1, 1, 0, 0, 1, 1 }, // Shape 0
+            { 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0, 1 }, // Shape 1
+            { 0, 1, 1, 1, 0, 1, 1, 1, 0, 1, 1, 1, 0, 1, 1, 1 }, // Shape 2
+            { 0, 0, 0, 1, 0, 0, 1, 1, 0, 0, 1, 1, 0, 1, 1, 1 }, // Shape 3
+            { 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 1, 1 }, // Shape 4
+            { 0, 0, 1, 1, 0, 1, 1, 1, 0, 1, 1, 1, 1, 1, 1, 1 }, // Shape 5
+            { 0, 0, 0, 1, 0, 0, 1, 1, 0, 1, 1, 1, 1, 1, 1, 1 }, // Shape 6
+            { 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 1, 1, 0, 1, 1, 1 }, // Shape 7
+            { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 1, 1 }, // Shape 8
+            { 0, 0, 1, 1, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1 }, // Shape 9
+            { 0, 0, 0, 0, 0, 0, 0, 1, 0, 1, 1, 1, 1, 1, 1, 1 }, // Shape 10
+            { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 1, 1, 1 }, // Shape 11
+            { 0, 0, 0, 1, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1 }, // Shape 12
+            { 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 1, 1, 1, 1 }, // Shape 13
+            { 0, 0, 0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1 }, // Shape 14
+            { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 1 }, // Shape 15
+            { 0, 0, 0, 0, 1, 0, 0, 0, 1, 1, 1, 0, 1, 1, 1, 1 }, // Shape 16
+            { 0, 1, 1, 1, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0 }, // Shape 17
+            { 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 1, 1, 1, 0 }, // Shape 18
+            { 0, 1, 1, 1, 0, 0, 1, 1, 0, 0, 0, 1, 0, 0, 0, 0 }, // Shape 19
+            { 0, 0, 1, 1, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0 }, // Shape 20
+            { 0, 0, 0, 0, 1, 0, 0, 0, 1, 1, 0, 0, 1, 1, 1, 0 }, // Shape 21
+            { 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 1, 1, 0, 0 }, // Shape 22
+            { 0, 1, 1, 1, 0, 0, 1, 1, 0, 0, 1, 1, 0, 0, 0, 1 }, // Shape 23
+            { 0, 0, 1, 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0, 0 }, // Shape 24
+            { 0, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0, 1, 1, 0, 0 }, // Shape 25
+            { 0, 1, 1, 0, 0, 1, 1, 0, 0, 1, 1, 0, 0, 1, 1, 0 }, // Shape 26
+            { 0, 0, 1, 1, 0, 1, 1, 0, 0, 1, 1, 0, 1, 1, 0, 0 }, // Shape 27
+            { 0, 0, 0, 1, 0, 1, 1, 1, 1, 1, 1, 0, 1, 0, 0, 0 }, // Shape 28
+            { 0, 0, 0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0, 0, 0 }, // Shape 29
+            { 0, 1, 1, 1, 0, 0, 0, 1, 1, 0, 0, 0, 1, 1, 1, 0 }, // Shape 30
+            { 0, 0, 1, 1, 1, 0, 0, 1, 1, 0, 0, 1, 1, 1, 0, 0 }, // Shape 31
+
+                                                                // BC7 Partition Set for 2 Subsets (second-half)
+            { 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1 }, // Shape 32
+            { 0, 0, 0, 0, 1, 1, 1, 1, 0, 0, 0, 0, 1, 1, 1, 1 }, // Shape 33
+            { 0, 1, 0, 1, 1, 0, 1, 0, 0, 1, 0, 1, 1, 0, 1, 0 }, // Shape 34
+            { 0, 0, 1, 1, 0, 0, 1, 1, 1, 1, 0, 0, 1, 1, 0, 0 }, // Shape 35
+            { 0, 0, 1, 1, 1, 1, 0, 0, 0, 0, 1, 1, 1, 1, 0, 0 }, // Shape 36
+            { 0, 1, 0, 1, 0, 1, 0, 1, 1, 0, 1, 0, 1, 0, 1, 0 }, // Shape 37
+            { 0, 1, 1, 0, 1, 0, 0, 1, 0, 1, 1, 0, 1, 0, 0, 1 }, // Shape 38
+            { 0, 1, 0, 1, 1, 0, 1, 0, 1, 0, 1, 0, 0, 1, 0, 1 }, // Shape 39
+            { 0, 1, 1, 1, 0, 0, 1, 1, 1, 1, 0, 0, 1, 1, 1, 0 }, // Shape 40
+            { 0, 0, 0, 1, 0, 0, 1, 1, 1, 1, 0, 0, 1, 0, 0, 0 }, // Shape 41
+            { 0, 0, 1, 1, 0, 0, 1, 0, 0, 1, 0, 0, 1, 1, 0, 0 }, // Shape 42
+            { 0, 0, 1, 1, 1, 0, 1, 1, 1, 1, 0, 1, 1, 1, 0, 0 }, // Shape 43
+            { 0, 1, 1, 0, 1, 0, 0, 1, 1, 0, 0, 1, 0, 1, 1, 0 }, // Shape 44
+            { 0, 0, 1, 1, 1, 1, 0, 0, 1, 1, 0, 0, 0, 0, 1, 1 }, // Shape 45
+            { 0, 1, 1, 0, 0, 1, 1, 0, 1, 0, 0, 1, 1, 0, 0, 1 }, // Shape 46
+            { 0, 0, 0, 0, 0, 1, 1, 0, 0, 1, 1, 0, 0, 0, 0, 0 }, // Shape 47
+            { 0, 1, 0, 0, 1, 1, 1, 0, 0, 1, 0, 0, 0, 0, 0, 0 }, // Shape 48
+            { 0, 0, 1, 0, 0, 1, 1, 1, 0, 0, 1, 0, 0, 0, 0, 0 }, // Shape 49
+            { 0, 0, 0, 0, 0, 0, 1, 0, 0, 1, 1, 1, 0, 0, 1, 0 }, // Shape 50
+            { 0, 0, 0, 0, 0, 1, 0, 0, 1, 1, 1, 0, 0, 1, 0, 0 }, // Shape 51
+            { 0, 1, 1, 0, 1, 1, 0, 0, 1, 0, 0, 1, 0, 0, 1, 1 }, // Shape 52
+            { 0, 0, 1, 1, 0, 1, 1, 0, 1, 1, 0, 0, 1, 0, 0, 1 }, // Shape 53
+            { 0, 1, 1, 0, 0, 0, 1, 1, 1, 0, 0, 1, 1, 1, 0, 0 }, // Shape 54
+            { 0, 0, 1, 1, 1, 0, 0, 1, 1, 1, 0, 0, 0, 1, 1, 0 }, // Shape 55
+            { 0, 1, 1, 0, 1, 1, 0, 0, 1, 1, 0, 0, 1, 0, 0, 1 }, // Shape 56
+            { 0, 1, 1, 0, 0, 0, 1, 1, 0, 0, 1, 1, 1, 0, 0, 1 }, // Shape 57
+            { 0, 1, 1, 1, 1, 1, 1, 0, 1, 0, 0, 0, 0, 0, 0, 1 }, // Shape 58
+            { 0, 0, 0, 1, 1, 0, 0, 0, 1, 1, 1, 0, 0, 1, 1, 1 }, // Shape 59
+            { 0, 0, 0, 0, 1, 1, 1, 1, 0, 0, 1, 1, 0, 0, 1, 1 }, // Shape 60
+            { 0, 0, 1, 1, 0, 0, 1, 1, 1, 1, 1, 1, 0, 0, 0, 0 }, // Shape 61
+            { 0, 0, 1, 0, 0, 0, 1, 0, 1, 1, 1, 0, 1, 1, 1, 0 }, // Shape 62
+            { 0, 1, 0, 0, 0, 1, 0, 0, 0, 1, 1, 1, 0, 1, 1, 1 }  // Shape 63
+        },
+
+        {   // BC7 Partition Set for 3 Subsets
+            { 0, 0, 1, 1, 0, 0, 1, 1, 0, 2, 2, 1, 2, 2, 2, 2 }, // Shape 0
+            { 0, 0, 0, 1, 0, 0, 1, 1, 2, 2, 1, 1, 2, 2, 2, 1 }, // Shape 1
+            { 0, 0, 0, 0, 2, 0, 0, 1, 2, 2, 1, 1, 2, 2, 1, 1 }, // Shape 2
+            { 0, 2, 2, 2, 0, 0, 2, 2, 0, 0, 1, 1, 0, 1, 1, 1 }, // Shape 3
+            { 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 2, 2, 1, 1, 2, 2 }, // Shape 4
+            { 0, 0, 1, 1, 0, 0, 1, 1, 0, 0, 2, 2, 0, 0, 2, 2 }, // Shape 5
+            { 0, 0, 2, 2, 0, 0, 2, 2, 1, 1, 1, 1, 1, 1, 1, 1 }, // Shape 6
+            { 0, 0, 1, 1, 0, 0, 1, 1, 2, 2, 1, 1, 2, 2, 1, 1 }, // Shape 7
+            { 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 2, 2, 2, 2 }, // Shape 8
+            { 0, 0, 0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 2, 2, 2, 2 }, // Shape 9
+            { 0, 0, 0, 0, 1, 1, 1, 1, 2, 2, 2, 2, 2, 2, 2, 2 }, // Shape 10
+            { 0, 0, 1, 2, 0, 0, 1, 2, 0, 0, 1, 2, 0, 0, 1, 2 }, // Shape 11
+            { 0, 1, 1, 2, 0, 1, 1, 2, 0, 1, 1, 2, 0, 1, 1, 2 }, // Shape 12
+            { 0, 1, 2, 2, 0, 1, 2, 2, 0, 1, 2, 2, 0, 1, 2, 2 }, // Shape 13
+            { 0, 0, 1, 1, 0, 1, 1, 2, 1, 1, 2, 2, 1, 2, 2, 2 }, // Shape 14
+            { 0, 0, 1, 1, 2, 0, 0, 1, 2, 2, 0, 0, 2, 2, 2, 0 }, // Shape 15
+            { 0, 0, 0, 1, 0, 0, 1, 1, 0, 1, 1, 2, 1, 1, 2, 2 }, // Shape 16
+            { 0, 1, 1, 1, 0, 0, 1, 1, 2, 0, 0, 1, 2, 2, 0, 0 }, // Shape 17
+            { 0, 0, 0, 0, 1, 1, 2, 2, 1, 1, 2, 2, 1, 1, 2, 2 }, // Shape 18
+            { 0, 0, 2, 2, 0, 0, 2, 2, 0, 0, 2, 2, 1, 1, 1, 1 }, // Shape 19
+            { 0, 1, 1, 1, 0, 1, 1, 1, 0, 2, 2, 2, 0, 2, 2, 2 }, // Shape 20
+            { 0, 0, 0, 1, 0, 0, 0, 1, 2, 2, 2, 1, 2, 2, 2, 1 }, // Shape 21
+            { 0, 0, 0, 0, 0, 0, 1, 1, 0, 1, 2, 2, 0, 1, 2, 2 }, // Shape 22
+            { 0, 0, 0, 0, 1, 1, 0, 0, 2, 2, 1, 0, 2, 2, 1, 0 }, // Shape 23
+            { 0, 1, 2, 2, 0, 1, 2, 2, 0, 0, 1, 1, 0, 0, 0, 0 }, // Shape 24
+            { 0, 0, 1, 2, 0, 0, 1, 2, 1, 1, 2, 2, 2, 2, 2, 2 }, // Shape 25
+            { 0, 1, 1, 0, 1, 2, 2, 1, 1, 2, 2, 1, 0, 1, 1, 0 }, // Shape 26
+            { 0, 0, 0, 0, 0, 1, 1, 0, 1, 2, 2, 1, 1, 2, 2, 1 }, // Shape 27
+            { 0, 0, 2, 2, 1, 1, 0, 2, 1, 1, 0, 2, 0, 0, 2, 2 }, // Shape 28
+            { 0, 1, 1, 0, 0, 1, 1, 0, 2, 0, 0, 2, 2, 2, 2, 2 }, // Shape 29
+            { 0, 0, 1, 1, 0, 1, 2, 2, 0, 1, 2, 2, 0, 0, 1, 1 }, // Shape 30
+            { 0, 0, 0, 0, 2, 0, 0, 0, 2, 2, 1, 1, 2, 2, 2, 1 }, // Shape 31
+            { 0, 0, 0, 0, 0, 0, 0, 2, 1, 1, 2, 2, 1, 2, 2, 2 }, // Shape 32
+            { 0, 2, 2, 2, 0, 0, 2, 2, 0, 0, 1, 2, 0, 0, 1, 1 }, // Shape 33
+            { 0, 0, 1, 1, 0, 0, 1, 2, 0, 0, 2, 2, 0, 2, 2, 2 }, // Shape 34
+            { 0, 1, 2, 0, 0, 1, 2, 0, 0, 1, 2, 0, 0, 1, 2, 0 }, // Shape 35
+            { 0, 0, 0, 0, 1, 1, 1, 1, 2, 2, 2, 2, 0, 0, 0, 0 }, // Shape 36
+            { 0, 1, 2, 0, 1, 2, 0, 1, 2, 0, 1, 2, 0, 1, 2, 0 }, // Shape 37
+            { 0, 1, 2, 0, 2, 0, 1, 2, 1, 2, 0, 1, 0, 1, 2, 0 }, // Shape 38
+            { 0, 0, 1, 1, 2, 2, 0, 0, 1, 1, 2, 2, 0, 0, 1, 1 }, // Shape 39
+            { 0, 0, 1, 1, 1, 1, 2, 2, 2, 2, 0, 0, 0, 0, 1, 1 }, // Shape 40
+            { 0, 1, 0, 1, 0, 1, 0, 1, 2, 2, 2, 2, 2, 2, 2, 2 }, // Shape 41
+            { 0, 0, 0, 0, 0, 0, 0, 0, 2, 1, 2, 1, 2, 1, 2, 1 }, // Shape 42
+            { 0, 0, 2, 2, 1, 1, 2, 2, 0, 0, 2, 2, 1, 1, 2, 2 }, // Shape 43
+            { 0, 0, 2, 2, 0, 0, 1, 1, 0, 0, 2, 2, 0, 0, 1, 1 }, // Shape 44
+            { 0, 2, 2, 0, 1, 2, 2, 1, 0, 2, 2, 0, 1, 2, 2, 1 }, // Shape 45
+            { 0, 1, 0, 1, 2, 2, 2, 2, 2, 2, 2, 2, 0, 1, 0, 1 }, // Shape 46
+            { 0, 0, 0, 0, 2, 1, 2, 1, 2, 1, 2, 1, 2, 1, 2, 1 }, // Shape 47
+            { 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 2, 2, 2, 2 }, // Shape 48
+            { 0, 2, 2, 2, 0, 1, 1, 1, 0, 2, 2, 2, 0, 1, 1, 1 }, // Shape 49
+            { 0, 0, 0, 2, 1, 1, 1, 2, 0, 0, 0, 2, 1, 1, 1, 2 }, // Shape 50
+            { 0, 0, 0, 0, 2, 1, 1, 2, 2, 1, 1, 2, 2, 1, 1, 2 }, // Shape 51
+            { 0, 2, 2, 2, 0, 1, 1, 1, 0, 1, 1, 1, 0, 2, 2, 2 }, // Shape 52
+            { 0, 0, 0, 2, 1, 1, 1, 2, 1, 1, 1, 2, 0, 0, 0, 2 }, // Shape 53
+            { 0, 1, 1, 0, 0, 1, 1, 0, 0, 1, 1, 0, 2, 2, 2, 2 }, // Shape 54
+            { 0, 0, 0, 0, 0, 0, 0, 0, 2, 1, 1, 2, 2, 1, 1, 2 }, // Shape 55
+            { 0, 1, 1, 0, 0, 1, 1, 0, 2, 2, 2, 2, 2, 2, 2, 2 }, // Shape 56
+            { 0, 0, 2, 2, 0, 0, 1, 1, 0, 0, 1, 1, 0, 0, 2, 2 }, // Shape 57
+            { 0, 0, 2, 2, 1, 1, 2, 2, 1, 1, 2, 2, 0, 0, 2, 2 }, // Shape 58
+            { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 2, 1, 1, 2 }, // Shape 59
+            { 0, 0, 0, 2, 0, 0, 0, 1, 0, 0, 0, 2, 0, 0, 0, 1 }, // Shape 60
+            { 0, 2, 2, 2, 1, 2, 2, 2, 0, 2, 2, 2, 1, 2, 2, 2 }, // Shape 61
+            { 0, 1, 0, 1, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2 }, // Shape 62
+            { 0, 1, 1, 1, 2, 0, 1, 1, 2, 2, 0, 1, 2, 2, 2, 0 }  // Shape 63
+        }
+    };
+
+    // Partition, Shape, Fixup
+    const uint8_t g_aFixUp[3][64][3] =
+    {
+        {   // No fix-ups for 1st subset for BC6H or BC7
+            { 0, 0, 0 },{ 0, 0, 0 },{ 0, 0, 0 },{ 0, 0, 0 },
+            { 0, 0, 0 },{ 0, 0, 0 },{ 0, 0, 0 },{ 0, 0, 0 },
+            { 0, 0, 0 },{ 0, 0, 0 },{ 0, 0, 0 },{ 0, 0, 0 },
+            { 0, 0, 0 },{ 0, 0, 0 },{ 0, 0, 0 },{ 0, 0, 0 },
+            { 0, 0, 0 },{ 0, 0, 0 },{ 0, 0, 0 },{ 0, 0, 0 },
+            { 0, 0, 0 },{ 0, 0, 0 },{ 0, 0, 0 },{ 0, 0, 0 },
+            { 0, 0, 0 },{ 0, 0, 0 },{ 0, 0, 0 },{ 0, 0, 0 },
+            { 0, 0, 0 },{ 0, 0, 0 },{ 0, 0, 0 },{ 0, 0, 0 },
+            { 0, 0, 0 },{ 0, 0, 0 },{ 0, 0, 0 },{ 0, 0, 0 },
+            { 0, 0, 0 },{ 0, 0, 0 },{ 0, 0, 0 },{ 0, 0, 0 },
+            { 0, 0, 0 },{ 0, 0, 0 },{ 0, 0, 0 },{ 0, 0, 0 },
+            { 0, 0, 0 },{ 0, 0, 0 },{ 0, 0, 0 },{ 0, 0, 0 },
+            { 0, 0, 0 },{ 0, 0, 0 },{ 0, 0, 0 },{ 0, 0, 0 },
+            { 0, 0, 0 },{ 0, 0, 0 },{ 0, 0, 0 },{ 0, 0, 0 },
+            { 0, 0, 0 },{ 0, 0, 0 },{ 0, 0, 0 },{ 0, 0, 0 },
+            { 0, 0, 0 },{ 0, 0, 0 },{ 0, 0, 0 },{ 0, 0, 0 }
+        },
+
+        {   // BC6H/BC7 Partition Set Fixups for 2 Subsets
+            { 0,15, 0 },{ 0,15, 0 },{ 0,15, 0 },{ 0,15, 0 },
+            { 0,15, 0 },{ 0,15, 0 },{ 0,15, 0 },{ 0,15, 0 },
+            { 0,15, 0 },{ 0,15, 0 },{ 0,15, 0 },{ 0,15, 0 },
+            { 0,15, 0 },{ 0,15, 0 },{ 0,15, 0 },{ 0,15, 0 },
+            { 0,15, 0 },{ 0, 2, 0 },{ 0, 8, 0 },{ 0, 2, 0 },
+            { 0, 2, 0 },{ 0, 8, 0 },{ 0, 8, 0 },{ 0,15, 0 },
+            { 0, 2, 0 },{ 0, 8, 0 },{ 0, 2, 0 },{ 0, 2, 0 },
+            { 0, 8, 0 },{ 0, 8, 0 },{ 0, 2, 0 },{ 0, 2, 0 },
+
+            // BC7 Partition Set Fixups for 2 Subsets (second-half)
+            { 0,15, 0 },{ 0,15, 0 },{ 0, 6, 0 },{ 0, 8, 0 },
+            { 0, 2, 0 },{ 0, 8, 0 },{ 0,15, 0 },{ 0,15, 0 },
+            { 0, 2, 0 },{ 0, 8, 0 },{ 0, 2, 0 },{ 0, 2, 0 },
+            { 0, 2, 0 },{ 0,15, 0 },{ 0,15, 0 },{ 0, 6, 0 },
+            { 0, 6, 0 },{ 0, 2, 0 },{ 0, 6, 0 },{ 0, 8, 0 },
+            { 0,15, 0 },{ 0,15, 0 },{ 0, 2, 0 },{ 0, 2, 0 },
+            { 0,15, 0 },{ 0,15, 0 },{ 0,15, 0 },{ 0,15, 0 },
+            { 0,15, 0 },{ 0, 2, 0 },{ 0, 2, 0 },{ 0,15, 0 }
+        },
+
+        {   // BC7 Partition Set Fixups for 3 Subsets
+            { 0, 3,15 },{ 0, 3, 8 },{ 0,15, 8 },{ 0,15, 3 },
+            { 0, 8,15 },{ 0, 3,15 },{ 0,15, 3 },{ 0,15, 8 },
+            { 0, 8,15 },{ 0, 8,15 },{ 0, 6,15 },{ 0, 6,15 },
+            { 0, 6,15 },{ 0, 5,15 },{ 0, 3,15 },{ 0, 3, 8 },
+            { 0, 3,15 },{ 0, 3, 8 },{ 0, 8,15 },{ 0,15, 3 },
+            { 0, 3,15 },{ 0, 3, 8 },{ 0, 6,15 },{ 0,10, 8 },
+            { 0, 5, 3 },{ 0, 8,15 },{ 0, 8, 6 },{ 0, 6,10 },
+            { 0, 8,15 },{ 0, 5,15 },{ 0,15,10 },{ 0,15, 8 },
+            { 0, 8,15 },{ 0,15, 3 },{ 0, 3,15 },{ 0, 5,10 },
+            { 0, 6,10 },{ 0,10, 8 },{ 0, 8, 9 },{ 0,15,10 },
+            { 0,15, 6 },{ 0, 3,15 },{ 0,15, 8 },{ 0, 5,15 },
+            { 0,15, 3 },{ 0,15, 6 },{ 0,15, 6 },{ 0,15, 8 },
+            { 0, 3,15 },{ 0,15, 3 },{ 0, 5,15 },{ 0, 5,15 },
+            { 0, 5,15 },{ 0, 8,15 },{ 0, 5,15 },{ 0,10,15 },
+            { 0, 5,15 },{ 0,10,15 },{ 0, 8,15 },{ 0,13,15 },
+            { 0,15, 3 },{ 0,12,15 },{ 0, 3,15 },{ 0, 3, 8 }
+        }
+    };
+
+    const int g_aWeights2[] = { 0, 21, 43, 64 };
+    const int g_aWeights3[] = { 0, 9, 18, 27, 37, 46, 55, 64 };
+    const int g_aWeights4[] = { 0, 4, 9, 13, 17, 21, 26, 30, 34, 38, 43, 47, 51, 55, 60, 64 };
+}
+
+namespace DirectX
+{
+    class LDRColorA
+    {
+    public:
+        uint8_t r, g, b, a;
+
+        LDRColorA() = default;
+        LDRColorA(uint8_t _r, uint8_t _g, uint8_t _b, uint8_t _a) noexcept : r(_r), g(_g), b(_b), a(_a) {}
+
+        LDRColorA(LDRColorA const&) = default;
+        LDRColorA& operator= (const LDRColorA&) = default;
+
+        LDRColorA(LDRColorA&&) = default;
+        LDRColorA& operator= (LDRColorA&&) = default;
+
+        const uint8_t& operator [] (_In_range_(0, 3) size_t uElement) const noexcept
+        {
+            switch (uElement)
+            {
+            case 0: return r;
+            case 1: return g;
+            case 2: return b;
+            case 3: return a;
+            default: assert(false); return r;
+            }
+        }
+
+        uint8_t& operator [] (_In_range_(0, 3) size_t uElement) noexcept
+        {
+            switch (uElement)
+            {
+            case 0: return r;
+            case 1: return g;
+            case 2: return b;
+            case 3: return a;
+            default: assert(false); return r;
+            }
+        }
+
+        LDRColorA operator = (_In_ const HDRColorA& c) noexcept
+        {
+            LDRColorA ret;
+            HDRColorA tmp(c);
+            tmp = tmp.Clamp(0.0f, 1.0f) * 255.0f;
+            ret.r = uint8_t(tmp.r + 0.001f);
+            ret.g = uint8_t(tmp.g + 0.001f);
+            ret.b = uint8_t(tmp.b + 0.001f);
+            ret.a = uint8_t(tmp.a + 0.001f);
+            return ret;
+        }
+
+        static void InterpolateRGB(_In_ const LDRColorA& c0, _In_ const LDRColorA& c1, _In_ size_t wc, _In_ _In_range_(2, 4) size_t wcprec, _Out_ LDRColorA& out) noexcept
+        {
+            const int* aWeights = nullptr;
+            switch (wcprec)
+            {
+            case 2: aWeights = g_aWeights2; assert(wc < 4); _Analysis_assume_(wc < 4); break;
+            case 3: aWeights = g_aWeights3; assert(wc < 8); _Analysis_assume_(wc < 8); break;
+            case 4: aWeights = g_aWeights4; assert(wc < 16); _Analysis_assume_(wc < 16); break;
+            default: assert(false); out.r = out.g = out.b = 0; return;
+            }
+            out.r = uint8_t((uint32_t(c0.r) * uint32_t(BC67_WEIGHT_MAX - aWeights[wc]) + uint32_t(c1.r) * uint32_t(aWeights[wc]) + BC67_WEIGHT_ROUND) >> BC67_WEIGHT_SHIFT);
+            out.g = uint8_t((uint32_t(c0.g) * uint32_t(BC67_WEIGHT_MAX - aWeights[wc]) + uint32_t(c1.g) * uint32_t(aWeights[wc]) + BC67_WEIGHT_ROUND) >> BC67_WEIGHT_SHIFT);
+            out.b = uint8_t((uint32_t(c0.b) * uint32_t(BC67_WEIGHT_MAX - aWeights[wc]) + uint32_t(c1.b) * uint32_t(aWeights[wc]) + BC67_WEIGHT_ROUND) >> BC67_WEIGHT_SHIFT);
+        }
+
+        static void InterpolateA(_In_ const LDRColorA& c0, _In_ const LDRColorA& c1, _In_ size_t wa, _In_range_(2, 4) _In_ size_t waprec, _Out_ LDRColorA& out) noexcept
+        {
+            const int* aWeights = nullptr;
+            switch (waprec)
+            {
+            case 2: aWeights = g_aWeights2; assert(wa < 4); _Analysis_assume_(wa < 4); break;
+            case 3: aWeights = g_aWeights3; assert(wa < 8); _Analysis_assume_(wa < 8); break;
+            case 4: aWeights = g_aWeights4; assert(wa < 16); _Analysis_assume_(wa < 16); break;
+            default: assert(false); out.a = 0; return;
+            }
+            out.a = uint8_t((uint32_t(c0.a) * uint32_t(BC67_WEIGHT_MAX - aWeights[wa]) + uint32_t(c1.a) * uint32_t(aWeights[wa]) + BC67_WEIGHT_ROUND) >> BC67_WEIGHT_SHIFT);
+        }
+
+        static void Interpolate(_In_ const LDRColorA& c0, _In_ const LDRColorA& c1, _In_ size_t wc, _In_ size_t wa, _In_ _In_range_(2, 4) size_t wcprec, _In_ _In_range_(2, 4) size_t waprec, _Out_ LDRColorA& out) noexcept
+        {
+            InterpolateRGB(c0, c1, wc, wcprec, out);
+            InterpolateA(c0, c1, wa, waprec, out);
+        }
+    };
+
+    static_assert(sizeof(LDRColorA) == 4, "Unexpected packing");
+
+    struct LDREndPntPair
+    {
+        LDRColorA A;
+        LDRColorA B;
+    };
+
+    inline HDRColorA::HDRColorA(const LDRColorA& c) noexcept
+    {
+        r = float(c.r) * (1.0f / 255.0f);
+        g = float(c.g) * (1.0f / 255.0f);
+        b = float(c.b) * (1.0f / 255.0f);
+        a = float(c.a) * (1.0f / 255.0f);
+    }
+
+    inline HDRColorA& HDRColorA::operator = (const LDRColorA& c) noexcept
+    {
+        r = static_cast<float>(c.r);
+        g = static_cast<float>(c.g);
+        b = static_cast<float>(c.b);
+        a = static_cast<float>(c.a);
+        return *this;
+    }
+
+    inline LDRColorA HDRColorA::ToLDRColorA() const noexcept
+    {
+        return LDRColorA(static_cast<uint8_t>(r + 0.01f), static_cast<uint8_t>(g + 0.01f), static_cast<uint8_t>(b + 0.01f), static_cast<uint8_t>(a + 0.01f));
+    }
+}
+
+namespace
+{
+    class INTColor
+    {
+    public:
+        int r, g, b;
+        int pad;
+
+        INTColor() = default;
+        INTColor(int nr, int ng, int nb) noexcept : r(nr), g(ng), b(nb), pad(0) {}
+
+        INTColor(INTColor const&) = default;
+        INTColor& operator= (const INTColor&) = default;
+
+        INTColor(INTColor&&) = default;
+        INTColor& operator= (INTColor&&) = default;
+
+        INTColor& operator += (_In_ const INTColor& c) noexcept
+        {
+            r += c.r;
+            g += c.g;
+            b += c.b;
+            return *this;
+        }
+
+        INTColor& operator -= (_In_ const INTColor& c) noexcept
+        {
+            r -= c.r;
+            g -= c.g;
+            b -= c.b;
+            return *this;
+        }
+
+        INTColor& operator &= (_In_ const INTColor& c) noexcept
+        {
+            r &= c.r;
+            g &= c.g;
+            b &= c.b;
+            return *this;
+        }
+
+        int& operator [] (_In_ uint8_t i) noexcept
+        {
+            assert(i < sizeof(INTColor) / sizeof(int));
+            _Analysis_assume_(i < sizeof(INTColor) / sizeof(int));
+            return reinterpret_cast<int*>(this)[i];
+        }
+
+        void Set(_In_ const HDRColorA& c, _In_ bool bSigned) noexcept
+        {
+            PackedVector::XMHALF4 aF16;
+
+            const XMVECTOR v = XMLoadFloat4(reinterpret_cast<const XMFLOAT4*>(&c));
+            XMStoreHalf4(&aF16, v);
+
+            r = F16ToINT(aF16.x, bSigned);
+            g = F16ToINT(aF16.y, bSigned);
+            b = F16ToINT(aF16.z, bSigned);
+        }
+
+        INTColor& Clamp(_In_ int iMin, _In_ int iMax) noexcept
+        {
+            r = std::min<int>(iMax, std::max<int>(iMin, r));
+            g = std::min<int>(iMax, std::max<int>(iMin, g));
+            b = std::min<int>(iMax, std::max<int>(iMin, b));
+            return *this;
+        }
+
+        INTColor& SignExtend(_In_ const LDRColorA& Prec) noexcept
+        {
+            r = SIGN_EXTEND(r, int(Prec.r));
+            g = SIGN_EXTEND(g, int(Prec.g));
+            b = SIGN_EXTEND(b, int(Prec.b));
+            return *this;
+        }
+
+        void ToF16(_Out_writes_(3) PackedVector::HALF aF16[3], _In_ bool bSigned) const noexcept
+        {
+            aF16[0] = INT2F16(r, bSigned);
+            aF16[1] = INT2F16(g, bSigned);
+            aF16[2] = INT2F16(b, bSigned);
+        }
+
+    private:
+        static int F16ToINT(_In_ const PackedVector::HALF& f, _In_ bool bSigned) noexcept
+        {
+            uint16_t input = *reinterpret_cast<const uint16_t*>(&f);
+            int out, s;
+            if (bSigned)
+            {
+                s = input & F16S_MASK;
+                input &= F16EM_MASK;
+                if (input > F16MAX) out = F16MAX;
+                else out = input;
+                out = s ? -out : out;
+            }
+            else
+            {
+                if (input & F16S_MASK) out = 0;
+                else out = input;
+            }
+            return out;
+        }
+
+        static PackedVector::HALF INT2F16(_In_ int input, _In_ bool bSigned) noexcept
+        {
+            PackedVector::HALF h;
+            uint16_t out;
+            if (bSigned)
+            {
+                int s = 0;
+                if (input < 0)
+                {
+                    s = F16S_MASK;
+                    input = -input;
+                }
+                out = uint16_t(s | input);
+            }
+            else
+            {
+                assert(input >= 0 && input <= F16MAX);
+                out = static_cast<uint16_t>(input);
+            }
+
+            *reinterpret_cast<uint16_t*>(&h) = out;
+            return h;
+        }
+    };
+
+    static_assert(sizeof(INTColor) == 16, "Unexpected packing");
+
+    struct INTEndPntPair
+    {
+        INTColor A;
+        INTColor B;
+    };
+
+    template< size_t SizeInBytes >
+    class CBits
+    {
+    public:
+        uint8_t GetBit(_Inout_ size_t& uStartBit) const noexcept
+        {
+            assert(uStartBit < 128);
+            _Analysis_assume_(uStartBit < 128);
+            const size_t uIndex = uStartBit >> 3;
+            auto const ret = static_cast<uint8_t>((m_uBits[uIndex] >> (uStartBit - (uIndex << 3))) & 0x01);
+            uStartBit++;
+            return ret;
+        }
+
+        uint8_t GetBits(_Inout_ size_t& uStartBit, _In_ size_t uNumBits) const noexcept
+        {
+            if (uNumBits == 0) return 0;
+            assert(uStartBit + uNumBits <= 128 && uNumBits <= 8);
+            _Analysis_assume_(uStartBit + uNumBits <= 128 && uNumBits <= 8);
+            uint8_t ret;
+            const size_t uIndex = uStartBit >> 3;
+            const size_t uBase = uStartBit - (uIndex << 3);
+            if (uBase + uNumBits > 8)
+            {
+                const size_t uFirstIndexBits = 8 - uBase;
+                const size_t uNextIndexBits = uNumBits - uFirstIndexBits;
+                ret = static_cast<uint8_t>((unsigned(m_uBits[uIndex]) >> uBase) | ((unsigned(m_uBits[uIndex + 1]) & ((1u << uNextIndexBits) - 1)) << uFirstIndexBits));
+            }
+            else
+            {
+                ret = static_cast<uint8_t>((m_uBits[uIndex] >> uBase) & ((1 << uNumBits) - 1));
+            }
+            assert(ret < (1 << uNumBits));
+            uStartBit += uNumBits;
+            return ret;
+        }
+
+        void SetBit(_Inout_ size_t& uStartBit, _In_ uint8_t uValue) noexcept
+        {
+            assert(uStartBit < 128 && uValue < 2);
+            _Analysis_assume_(uStartBit < 128 && uValue < 2);
+            size_t uIndex = uStartBit >> 3;
+            const size_t uBase = uStartBit - (uIndex << 3);
+            m_uBits[uIndex] &= ~(1 << uBase);
+            m_uBits[uIndex] |= uValue << uBase;
+            uStartBit++;
+        }
+
+        void SetBits(_Inout_ size_t& uStartBit, _In_ size_t uNumBits, _In_ uint8_t uValue) noexcept
+        {
+            if (uNumBits == 0)
+                return;
+            assert(uStartBit + uNumBits <= 128 && uNumBits <= 8);
+            _Analysis_assume_(uStartBit + uNumBits <= 128 && uNumBits <= 8);
+            assert(uValue < (1 << uNumBits));
+            size_t uIndex = uStartBit >> 3;
+            const size_t uBase = uStartBit - (uIndex << 3);
+            if (uBase + uNumBits > 8)
+            {
+                const size_t uFirstIndexBits = 8 - uBase;
+                const size_t uNextIndexBits = uNumBits - uFirstIndexBits;
+                m_uBits[uIndex] &= ~(((1 << uFirstIndexBits) - 1) << uBase);
+                m_uBits[uIndex] |= uValue << uBase;
+                m_uBits[uIndex + 1] &= ~((1 << uNextIndexBits) - 1);
+                m_uBits[uIndex + 1] |= uValue >> uFirstIndexBits;
+            }
+            else
+            {
+                m_uBits[uIndex] &= ~(((1 << uNumBits) - 1) << uBase);
+                m_uBits[uIndex] |= uValue << uBase;
+            }
+            uStartBit += uNumBits;
+        }
+
+    private:
+        uint8_t m_uBits[SizeInBytes];
+    };
+
+    // BC6H compression (16 bits per texel)
+    class D3DX_BC6H : private CBits< 16 >
+    {
+    public:
+        void Decode(_In_ bool bSigned, _Out_writes_(NUM_PIXELS_PER_BLOCK) HDRColorA* pOut) const noexcept;
+        void Encode(_In_ bool bSigned, _In_reads_(NUM_PIXELS_PER_BLOCK) const HDRColorA* const pIn) noexcept;
+
+    private:
+    #pragma warning(push)
+    #pragma warning(disable : 4480)
+        enum EField : uint8_t
+        {
+            NA, // N/A
+            M,  // Mode
+            D,  // Shape
+            RW,
+            RX,
+            RY,
+            RZ,
+            GW,
+            GX,
+            GY,
+            GZ,
+            BW,
+            BX,
+            BY,
+            BZ,
+        };
+    #pragma warning(pop)
+
+        struct ModeDescriptor
+        {
+            EField m_eField;
+            uint8_t   m_uBit;
+        };
+
+        struct ModeInfo
+        {
+            uint8_t uMode;
+            uint8_t uPartitions;
+            bool bTransformed;
+            uint8_t uIndexPrec;
+            LDRColorA RGBAPrec[BC6H_MAX_REGIONS][2];
+        };
+
+    #pragma warning(push)
+    #pragma warning(disable : 4512)
+        struct EncodeParams
+        {
+            float fBestErr;
+            const bool bSigned;
+            uint8_t uMode;
+            uint8_t uShape;
+            const HDRColorA* const aHDRPixels;
+            INTEndPntPair aUnqEndPts[BC6H_MAX_SHAPES][BC6H_MAX_REGIONS];
+            INTColor aIPixels[NUM_PIXELS_PER_BLOCK];
+
+            EncodeParams(const HDRColorA* const aOriginal, bool bSignedFormat) noexcept :
+                fBestErr(FLT_MAX), bSigned(bSignedFormat), uMode(0), uShape(0), aHDRPixels(aOriginal), aUnqEndPts{}, aIPixels{}
+            {
+                for (size_t i = 0; i < NUM_PIXELS_PER_BLOCK; ++i)
+                {
+                    aIPixels[i].Set(aOriginal[i], bSigned);
+                }
+            }
+        };
+    #pragma warning(pop)
+
+        static int Quantize(_In_ int iValue, _In_ int prec, _In_ bool bSigned) noexcept;
+        static int Unquantize(_In_ int comp, _In_ uint8_t uBitsPerComp, _In_ bool bSigned) noexcept;
+        static int FinishUnquantize(_In_ int comp, _In_ bool bSigned) noexcept;
+
+        static bool EndPointsFit(_In_ const EncodeParams* pEP, _In_reads_(BC6H_MAX_REGIONS) const INTEndPntPair aEndPts[]) noexcept;
+
+        void GeneratePaletteQuantized(_In_ const EncodeParams* pEP, _In_ const INTEndPntPair& endPts,
+            _Out_writes_(BC6H_MAX_INDICES) INTColor aPalette[]) const noexcept;
+        float MapColorsQuantized(_In_ const EncodeParams* pEP, _In_reads_(np) const INTColor aColors[], _In_ size_t np, _In_ const INTEndPntPair &endPts) const noexcept;
+        float PerturbOne(_In_ const EncodeParams* pEP, _In_reads_(np) const INTColor aColors[], _In_ size_t np, _In_ uint8_t ch,
+            _In_ const INTEndPntPair& oldEndPts, _Out_ INTEndPntPair& newEndPts, _In_ float fOldErr, _In_ int do_b) const noexcept;
+        void OptimizeOne(_In_ const EncodeParams* pEP, _In_reads_(np) const INTColor aColors[], _In_ size_t np, _In_ float aOrgErr,
+            _In_ const INTEndPntPair &aOrgEndPts, _Out_ INTEndPntPair &aOptEndPts) const noexcept;
+        void OptimizeEndPoints(_In_ const EncodeParams* pEP, _In_reads_(BC6H_MAX_REGIONS) const float aOrgErr[],
+            _In_reads_(BC6H_MAX_REGIONS) const INTEndPntPair aOrgEndPts[],
+            _Out_writes_all_(BC6H_MAX_REGIONS) INTEndPntPair aOptEndPts[]) const noexcept;
+        static void SwapIndices(_In_ const EncodeParams* pEP, _Inout_updates_all_(BC6H_MAX_REGIONS) INTEndPntPair aEndPts[],
+            _In_reads_(NUM_PIXELS_PER_BLOCK) size_t aIndices[]) noexcept;
+        void AssignIndices(_In_ const EncodeParams* pEP, _In_reads_(BC6H_MAX_REGIONS) const INTEndPntPair aEndPts[],
+            _Out_writes_(NUM_PIXELS_PER_BLOCK) size_t aIndices[],
+            _Out_writes_(BC6H_MAX_REGIONS) float aTotErr[]) const noexcept;
+        void QuantizeEndPts(_In_ const EncodeParams* pEP, _Out_writes_(BC6H_MAX_REGIONS) INTEndPntPair* qQntEndPts) const noexcept;
+        void EmitBlock(_In_ const EncodeParams* pEP, _In_reads_(BC6H_MAX_REGIONS) const INTEndPntPair aEndPts[],
+            _In_reads_(NUM_PIXELS_PER_BLOCK) const size_t aIndices[]) noexcept;
+        void Refine(_Inout_ EncodeParams* pEP) noexcept;
+
+        static void GeneratePaletteUnquantized(_In_ const EncodeParams* pEP, _In_ size_t uRegion, _Out_writes_(BC6H_MAX_INDICES) INTColor aPalette[]) noexcept;
+        float MapColors(_In_ const EncodeParams* pEP, _In_ size_t uRegion, _In_ size_t np, _In_reads_(np) const size_t* auIndex) const noexcept;
+        float RoughMSE(_Inout_ EncodeParams* pEP) const noexcept;
+
+    private:
+        static constexpr uint8_t c_NumModes = 14;
+        static constexpr uint8_t c_NumModeInfo = 32;
+
+        static const ModeDescriptor ms_aDesc[c_NumModes][82];
+        static const ModeInfo ms_aInfo[c_NumModes];
+        static const int ms_aModeToInfo[c_NumModeInfo];
+    };
+
+    // BC67 compression (16b bits per texel)
+    class D3DX_BC7 : private CBits< 16 >
+    {
+    public:
+        void Decode(_Out_writes_(NUM_PIXELS_PER_BLOCK) HDRColorA* pOut) const noexcept;
+        void Encode(uint32_t flags, _In_reads_(NUM_PIXELS_PER_BLOCK) const HDRColorA* const pIn) noexcept;
+
+    private:
+        struct ModeInfo
+        {
+            uint8_t uPartitions;
+            uint8_t uPartitionBits;
+            uint8_t uPBits;
+            uint8_t uRotationBits;
+            uint8_t uIndexModeBits;
+            uint8_t uIndexPrec;
+            uint8_t uIndexPrec2;
+            LDRColorA RGBAPrec;
+            LDRColorA RGBAPrecWithP;
+        };
+
+    #pragma warning(push)
+    #pragma warning(disable : 4512)
+        struct EncodeParams
+        {
+            uint8_t uMode;
+            LDREndPntPair aEndPts[BC7_MAX_SHAPES][BC7_MAX_REGIONS];
+            LDRColorA aLDRPixels[NUM_PIXELS_PER_BLOCK];
+            const HDRColorA* const aHDRPixels;
+
+            EncodeParams(const HDRColorA* const aOriginal) noexcept : uMode(0), aEndPts{}, aLDRPixels{}, aHDRPixels(aOriginal) {}
+        };
+    #pragma warning(pop)
+
+        static uint8_t Quantize(_In_ uint8_t comp, _In_ uint8_t uPrec) noexcept
+        {
+            assert(0 < uPrec && uPrec <= 8);
+            const uint8_t rnd = std::min<uint8_t>(255u, static_cast<uint8_t>(unsigned(comp) + (1u << (7 - uPrec))));
+            return uint8_t(rnd >> (8u - uPrec));
+        }
+
+        static LDRColorA Quantize(_In_ const LDRColorA& c, _In_ const LDRColorA& RGBAPrec) noexcept
+        {
+            LDRColorA q;
+            q.r = Quantize(c.r, RGBAPrec.r);
+            q.g = Quantize(c.g, RGBAPrec.g);
+            q.b = Quantize(c.b, RGBAPrec.b);
+            if (RGBAPrec.a)
+                q.a = Quantize(c.a, RGBAPrec.a);
+            else
+                q.a = 255;
+            return q;
+        }
+
+        static uint8_t Unquantize(_In_ uint8_t comp, _In_ size_t uPrec) noexcept
+        {
+            assert(0 < uPrec && uPrec <= 8);
+            comp = static_cast<uint8_t>(unsigned(comp) << (8 - uPrec));
+            return uint8_t(comp | (comp >> uPrec));
+        }
+
+        static LDRColorA Unquantize(_In_ const LDRColorA& c, _In_ const LDRColorA& RGBAPrec) noexcept
+        {
+            LDRColorA q;
+            q.r = Unquantize(c.r, RGBAPrec.r);
+            q.g = Unquantize(c.g, RGBAPrec.g);
+            q.b = Unquantize(c.b, RGBAPrec.b);
+            q.a = RGBAPrec.a > 0 ? Unquantize(c.a, RGBAPrec.a) : 255u;
+            return q;
+        }
+
+        void GeneratePaletteQuantized(_In_ const EncodeParams* pEP, _In_ size_t uIndexMode, _In_ const LDREndPntPair& endpts,
+            _Out_writes_(BC7_MAX_INDICES) LDRColorA aPalette[]) const noexcept;
+        float PerturbOne(_In_ const EncodeParams* pEP, _In_reads_(np) const LDRColorA colors[], _In_ size_t np, _In_ size_t uIndexMode,
+            _In_ size_t ch, _In_ const LDREndPntPair &old_endpts,
+            _Out_ LDREndPntPair &new_endpts, _In_ float old_err, _In_ uint8_t do_b) const noexcept;
+        void Exhaustive(_In_ const EncodeParams* pEP, _In_reads_(np) const LDRColorA aColors[], _In_ size_t np, _In_ size_t uIndexMode,
+            _In_ size_t ch, _Inout_ float& fOrgErr, _Inout_ LDREndPntPair& optEndPt) const noexcept;
+        void OptimizeOne(_In_ const EncodeParams* pEP, _In_reads_(np) const LDRColorA colors[], _In_ size_t np, _In_ size_t uIndexMode,
+            _In_ float orig_err, _In_ const LDREndPntPair &orig_endpts, _Out_ LDREndPntPair &opt_endpts) const noexcept;
+        void OptimizeEndPoints(_In_ const EncodeParams* pEP, _In_ size_t uShape, _In_ size_t uIndexMode,
+            _In_reads_(BC7_MAX_REGIONS) const float orig_err[],
+            _In_reads_(BC7_MAX_REGIONS) const LDREndPntPair orig_endpts[],
+            _Out_writes_(BC7_MAX_REGIONS) LDREndPntPair opt_endpts[]) const noexcept;
+        void AssignIndices(_In_ const EncodeParams* pEP, _In_ size_t uShape, _In_ size_t uIndexMode,
+            _In_reads_(BC7_MAX_REGIONS) LDREndPntPair endpts[],
+            _Out_writes_(NUM_PIXELS_PER_BLOCK) size_t aIndices[], _Out_writes_(NUM_PIXELS_PER_BLOCK) size_t aIndices2[],
+            _Out_writes_(BC7_MAX_REGIONS) float afTotErr[]) const noexcept;
+        void EmitBlock(_In_ const EncodeParams* pEP, _In_ size_t uShape, _In_ size_t uRotation, _In_ size_t uIndexMode,
+            _In_reads_(BC7_MAX_REGIONS) const LDREndPntPair aEndPts[],
+            _In_reads_(NUM_PIXELS_PER_BLOCK) const size_t aIndex[],
+            _In_reads_(NUM_PIXELS_PER_BLOCK) const size_t aIndex2[]) noexcept;
+        void FixEndpointPBits(_In_ const EncodeParams* pEP, _In_reads_(BC7_MAX_REGIONS) const LDREndPntPair *pOrigEndpoints, _Out_writes_(BC7_MAX_REGIONS) LDREndPntPair *pFixedEndpoints) noexcept;
+        float Refine(_In_ const EncodeParams* pEP, _In_ size_t uShape, _In_ size_t uRotation, _In_ size_t uIndexMode) noexcept;
+
+        float MapColors(_In_ const EncodeParams* pEP, _In_reads_(np) const LDRColorA aColors[], _In_ size_t np, _In_ size_t uIndexMode,
+            _In_ const LDREndPntPair& endPts, _In_ float fMinErr) const noexcept;
+        static float RoughMSE(_Inout_ EncodeParams* pEP, _In_ size_t uShape, _In_ size_t uIndexMode) noexcept;
+
+    private:
+        static constexpr uint8_t c_NumModes = 8;
+
+        static const ModeInfo ms_aInfo[c_NumModes];
+    };
+}
+
+// BC6H Compression
+const D3DX_BC6H::ModeDescriptor D3DX_BC6H::ms_aDesc[D3DX_BC6H::c_NumModes][82] =
+{
+    {   // Mode 1 (0x00) - 10 5 5 5
+        { M, 0}, { M, 1}, {GY, 4}, {BY, 4}, {BZ, 4}, {RW, 0}, {RW, 1}, {RW, 2}, {RW, 3}, {RW, 4},
+        {RW, 5}, {RW, 6}, {RW, 7}, {RW, 8}, {RW, 9}, {GW, 0}, {GW, 1}, {GW, 2}, {GW, 3}, {GW, 4},
+        {GW, 5}, {GW, 6}, {GW, 7}, {GW, 8}, {GW, 9}, {BW, 0}, {BW, 1}, {BW, 2}, {BW, 3}, {BW, 4},
+        {BW, 5}, {BW, 6}, {BW, 7}, {BW, 8}, {BW, 9}, {RX, 0}, {RX, 1}, {RX, 2}, {RX, 3}, {RX, 4},
+        {GZ, 4}, {GY, 0}, {GY, 1}, {GY, 2}, {GY, 3}, {GX, 0}, {GX, 1}, {GX, 2}, {GX, 3}, {GX, 4},
+        {BZ, 0}, {GZ, 0}, {GZ, 1}, {GZ, 2}, {GZ, 3}, {BX, 0}, {BX, 1}, {BX, 2}, {BX, 3}, {BX, 4},
+        {BZ, 1}, {BY, 0}, {BY, 1}, {BY, 2}, {BY, 3}, {RY, 0}, {RY, 1}, {RY, 2}, {RY, 3}, {RY, 4},
+        {BZ, 2}, {RZ, 0}, {RZ, 1}, {RZ, 2}, {RZ, 3}, {RZ, 4}, {BZ, 3}, { D, 0}, { D, 1}, { D, 2},
+        { D, 3}, { D, 4},
+    },
+
+    {   // Mode 2 (0x01) - 7 6 6 6
+        { M, 0}, { M, 1}, {GY, 5}, {GZ, 4}, {GZ, 5}, {RW, 0}, {RW, 1}, {RW, 2}, {RW, 3}, {RW, 4},
+        {RW, 5}, {RW, 6}, {BZ, 0}, {BZ, 1}, {BY, 4}, {GW, 0}, {GW, 1}, {GW, 2}, {GW, 3}, {GW, 4},
+        {GW, 5}, {GW, 6}, {BY, 5}, {BZ, 2}, {GY, 4}, {BW, 0}, {BW, 1}, {BW, 2}, {BW, 3}, {BW, 4},
+        {BW, 5}, {BW, 6}, {BZ, 3}, {BZ, 5}, {BZ, 4}, {RX, 0}, {RX, 1}, {RX, 2}, {RX, 3}, {RX, 4},
+        {RX, 5}, {GY, 0}, {GY, 1}, {GY, 2}, {GY, 3}, {GX, 0}, {GX, 1}, {GX, 2}, {GX, 3}, {GX, 4},
+        {GX, 5}, {GZ, 0}, {GZ, 1}, {GZ, 2}, {GZ, 3}, {BX, 0}, {BX, 1}, {BX, 2}, {BX, 3}, {BX, 4},
+        {BX, 5}, {BY, 0}, {BY, 1}, {BY, 2}, {BY, 3}, {RY, 0}, {RY, 1}, {RY, 2}, {RY, 3}, {RY, 4},
+        {RY, 5}, {RZ, 0}, {RZ, 1}, {RZ, 2}, {RZ, 3}, {RZ, 4}, {RZ, 5}, { D, 0}, { D, 1}, { D, 2},
+        { D, 3}, { D, 4},
+    },
+
+    {   // Mode 3 (0x02) - 11 5 4 4
+        { M, 0}, { M, 1}, { M, 2}, { M, 3}, { M, 4}, {RW, 0}, {RW, 1}, {RW, 2}, {RW, 3}, {RW, 4},
+        {RW, 5}, {RW, 6}, {RW, 7}, {RW, 8}, {RW, 9}, {GW, 0}, {GW, 1}, {GW, 2}, {GW, 3}, {GW, 4},
+        {GW, 5}, {GW, 6}, {GW, 7}, {GW, 8}, {GW, 9}, {BW, 0}, {BW, 1}, {BW, 2}, {BW, 3}, {BW, 4},
+        {BW, 5}, {BW, 6}, {BW, 7}, {BW, 8}, {BW, 9}, {RX, 0}, {RX, 1}, {RX, 2}, {RX, 3}, {RX, 4},
+        {RW,10}, {GY, 0}, {GY, 1}, {GY, 2}, {GY, 3}, {GX, 0}, {GX, 1}, {GX, 2}, {GX, 3}, {GW,10},
+        {BZ, 0}, {GZ, 0}, {GZ, 1}, {GZ, 2}, {GZ, 3}, {BX, 0}, {BX, 1}, {BX, 2}, {BX, 3}, {BW,10},
+        {BZ, 1}, {BY, 0}, {BY, 1}, {BY, 2}, {BY, 3}, {RY, 0}, {RY, 1}, {RY, 2}, {RY, 3}, {RY, 4},
+        {BZ, 2}, {RZ, 0}, {RZ, 1}, {RZ, 2}, {RZ, 3}, {RZ, 4}, {BZ, 3}, { D, 0}, { D, 1}, { D, 2},
+        { D, 3}, { D, 4},
+    },
+
+    {   // Mode 4 (0x06) - 11 4 5 4
+        { M, 0}, { M, 1}, { M, 2}, { M, 3}, { M, 4}, {RW, 0}, {RW, 1}, {RW, 2}, {RW, 3}, {RW, 4},
+        {RW, 5}, {RW, 6}, {RW, 7}, {RW, 8}, {RW, 9}, {GW, 0}, {GW, 1}, {GW, 2}, {GW, 3}, {GW, 4},
+        {GW, 5}, {GW, 6}, {GW, 7}, {GW, 8}, {GW, 9}, {BW, 0}, {BW, 1}, {BW, 2}, {BW, 3}, {BW, 4},
+        {BW, 5}, {BW, 6}, {BW, 7}, {BW, 8}, {BW, 9}, {RX, 0}, {RX, 1}, {RX, 2}, {RX, 3}, {RW,10},
+        {GZ, 4}, {GY, 0}, {GY, 1}, {GY, 2}, {GY, 3}, {GX, 0}, {GX, 1}, {GX, 2}, {GX, 3}, {GX, 4},
+        {GW,10}, {GZ, 0}, {GZ, 1}, {GZ, 2}, {GZ, 3}, {BX, 0}, {BX, 1}, {BX, 2}, {BX, 3}, {BW,10},
+        {BZ, 1}, {BY, 0}, {BY, 1}, {BY, 2}, {BY, 3}, {RY, 0}, {RY, 1}, {RY, 2}, {RY, 3}, {BZ, 0},
+        {BZ, 2}, {RZ, 0}, {RZ, 1}, {RZ, 2}, {RZ, 3}, {GY, 4}, {BZ, 3}, { D, 0}, { D, 1}, { D, 2},
+        { D, 3}, { D, 4},
+    },
+
+    {   // Mode 5 (0x0a) - 11 4 4 5
+        { M, 0}, { M, 1}, { M, 2}, { M, 3}, { M, 4}, {RW, 0}, {RW, 1}, {RW, 2}, {RW, 3}, {RW, 4},
+        {RW, 5}, {RW, 6}, {RW, 7}, {RW, 8}, {RW, 9}, {GW, 0}, {GW, 1}, {GW, 2}, {GW, 3}, {GW, 4},
+        {GW, 5}, {GW, 6}, {GW, 7}, {GW, 8}, {GW, 9}, {BW, 0}, {BW, 1}, {BW, 2}, {BW, 3}, {BW, 4},
+        {BW, 5}, {BW, 6}, {BW, 7}, {BW, 8}, {BW, 9}, {RX, 0}, {RX, 1}, {RX, 2}, {RX, 3}, {RW,10},
+        {BY, 4}, {GY, 0}, {GY, 1}, {GY, 2}, {GY, 3}, {GX, 0}, {GX, 1}, {GX, 2}, {GX, 3}, {GW,10},
+        {BZ, 0}, {GZ, 0}, {GZ, 1}, {GZ, 2}, {GZ, 3}, {BX, 0}, {BX, 1}, {BX, 2}, {BX, 3}, {BX, 4},
+        {BW,10}, {BY, 0}, {BY, 1}, {BY, 2}, {BY, 3}, {RY, 0}, {RY, 1}, {RY, 2}, {RY, 3}, {BZ, 1},
+        {BZ, 2}, {RZ, 0}, {RZ, 1}, {RZ, 2}, {RZ, 3}, {BZ, 4}, {BZ, 3}, { D, 0}, { D, 1}, { D, 2},
+        { D, 3}, { D, 4},
+    },
+
+    {   // Mode 6 (0x0e) - 9 5 5 5
+        { M, 0}, { M, 1}, { M, 2}, { M, 3}, { M, 4}, {RW, 0}, {RW, 1}, {RW, 2}, {RW, 3}, {RW, 4},
+        {RW, 5}, {RW, 6}, {RW, 7}, {RW, 8}, {BY, 4}, {GW, 0}, {GW, 1}, {GW, 2}, {GW, 3}, {GW, 4},
+        {GW, 5}, {GW, 6}, {GW, 7}, {GW, 8}, {GY, 4}, {BW, 0}, {BW, 1}, {BW, 2}, {BW, 3}, {BW, 4},
+        {BW, 5}, {BW, 6}, {BW, 7}, {BW, 8}, {BZ, 4}, {RX, 0}, {RX, 1}, {RX, 2}, {RX, 3}, {RX, 4},
+        {GZ, 4}, {GY, 0}, {GY, 1}, {GY, 2}, {GY, 3}, {GX, 0}, {GX, 1}, {GX, 2}, {GX, 3}, {GX, 4},
+        {BZ, 0}, {GZ, 0}, {GZ, 1}, {GZ, 2}, {GZ, 3}, {BX, 0}, {BX, 1}, {BX, 2}, {BX, 3}, {BX, 4},
+        {BZ, 1}, {BY, 0}, {BY, 1}, {BY, 2}, {BY, 3}, {RY, 0}, {RY, 1}, {RY, 2}, {RY, 3}, {RY, 4},
+        {BZ, 2}, {RZ, 0}, {RZ, 1}, {RZ, 2}, {RZ, 3}, {RZ, 4}, {BZ, 3}, { D, 0}, { D, 1}, { D, 2},
+        { D, 3}, { D, 4},
+    },
+
+    {   // Mode 7 (0x12) - 8 6 5 5
+        { M, 0}, { M, 1}, { M, 2}, { M, 3}, { M, 4}, {RW, 0}, {RW, 1}, {RW, 2}, {RW, 3}, {RW, 4},
+        {RW, 5}, {RW, 6}, {RW, 7}, {GZ, 4}, {BY, 4}, {GW, 0}, {GW, 1}, {GW, 2}, {GW, 3}, {GW, 4},
+        {GW, 5}, {GW, 6}, {GW, 7}, {BZ, 2}, {GY, 4}, {BW, 0}, {BW, 1}, {BW, 2}, {BW, 3}, {BW, 4},
+        {BW, 5}, {BW, 6}, {BW, 7}, {BZ, 3}, {BZ, 4}, {RX, 0}, {RX, 1}, {RX, 2}, {RX, 3}, {RX, 4},
+        {RX, 5}, {GY, 0}, {GY, 1}, {GY, 2}, {GY, 3}, {GX, 0}, {GX, 1}, {GX, 2}, {GX, 3}, {GX, 4},
+        {BZ, 0}, {GZ, 0}, {GZ, 1}, {GZ, 2}, {GZ, 3}, {BX, 0}, {BX, 1}, {BX, 2}, {BX, 3}, {BX, 4},
+        {BZ, 1}, {BY, 0}, {BY, 1}, {BY, 2}, {BY, 3}, {RY, 0}, {RY, 1}, {RY, 2}, {RY, 3}, {RY, 4},
+        {RY, 5}, {RZ, 0}, {RZ, 1}, {RZ, 2}, {RZ, 3}, {RZ, 4}, {RZ, 5}, { D, 0}, { D, 1}, { D, 2},
+        { D, 3}, { D, 4},
+    },
+
+    {   // Mode 8 (0x16) - 8 5 6 5
+        { M, 0}, { M, 1}, { M, 2}, { M, 3}, { M, 4}, {RW, 0}, {RW, 1}, {RW, 2}, {RW, 3}, {RW, 4},
+        {RW, 5}, {RW, 6}, {RW, 7}, {BZ, 0}, {BY, 4}, {GW, 0}, {GW, 1}, {GW, 2}, {GW, 3}, {GW, 4},
+        {GW, 5}, {GW, 6}, {GW, 7}, {GY, 5}, {GY, 4}, {BW, 0}, {BW, 1}, {BW, 2}, {BW, 3}, {BW, 4},
+        {BW, 5}, {BW, 6}, {BW, 7}, {GZ, 5}, {BZ, 4}, {RX, 0}, {RX, 1}, {RX, 2}, {RX, 3}, {RX, 4},
+        {GZ, 4}, {GY, 0}, {GY, 1}, {GY, 2}, {GY, 3}, {GX, 0}, {GX, 1}, {GX, 2}, {GX, 3}, {GX, 4},
+        {GX, 5}, {GZ, 0}, {GZ, 1}, {GZ, 2}, {GZ, 3}, {BX, 0}, {BX, 1}, {BX, 2}, {BX, 3}, {BX, 4},
+        {BZ, 1}, {BY, 0}, {BY, 1}, {BY, 2}, {BY, 3}, {RY, 0}, {RY, 1}, {RY, 2}, {RY, 3}, {RY, 4},
+        {BZ, 2}, {RZ, 0}, {RZ, 1}, {RZ, 2}, {RZ, 3}, {RZ, 4}, {BZ, 3}, { D, 0}, { D, 1}, { D, 2},
+        { D, 3}, { D, 4},
+    },
+
+    {   // Mode 9 (0x1a) - 8 5 5 6
+        { M, 0}, { M, 1}, { M, 2}, { M, 3}, { M, 4}, {RW, 0}, {RW, 1}, {RW, 2}, {RW, 3}, {RW, 4},
+        {RW, 5}, {RW, 6}, {RW, 7}, {BZ, 1}, {BY, 4}, {GW, 0}, {GW, 1}, {GW, 2}, {GW, 3}, {GW, 4},
+        {GW, 5}, {GW, 6}, {GW, 7}, {BY, 5}, {GY, 4}, {BW, 0}, {BW, 1}, {BW, 2}, {BW, 3}, {BW, 4},
+        {BW, 5}, {BW, 6}, {BW, 7}, {BZ, 5}, {BZ, 4}, {RX, 0}, {RX, 1}, {RX, 2}, {RX, 3}, {RX, 4},
+        {GZ, 4}, {GY, 0}, {GY, 1}, {GY, 2}, {GY, 3}, {GX, 0}, {GX, 1}, {GX, 2}, {GX, 3}, {GX, 4},
+        {BZ, 0}, {GZ, 0}, {GZ, 1}, {GZ, 2}, {GZ, 3}, {BX, 0}, {BX, 1}, {BX, 2}, {BX, 3}, {BX, 4},
+        {BX, 5}, {BY, 0}, {BY, 1}, {BY, 2}, {BY, 3}, {RY, 0}, {RY, 1}, {RY, 2}, {RY, 3}, {RY, 4},
+        {BZ, 2}, {RZ, 0}, {RZ, 1}, {RZ, 2}, {RZ, 3}, {RZ, 4}, {BZ, 3}, { D, 0}, { D, 1}, { D, 2},
+        { D, 3}, { D, 4},
+    },
+
+    {   // Mode 10 (0x1e) - 6 6 6 6
+        { M, 0}, { M, 1}, { M, 2}, { M, 3}, { M, 4}, {RW, 0}, {RW, 1}, {RW, 2}, {RW, 3}, {RW, 4},
+        {RW, 5}, {GZ, 4}, {BZ, 0}, {BZ, 1}, {BY, 4}, {GW, 0}, {GW, 1}, {GW, 2}, {GW, 3}, {GW, 4},
+        {GW, 5}, {GY, 5}, {BY, 5}, {BZ, 2}, {GY, 4}, {BW, 0}, {BW, 1}, {BW, 2}, {BW, 3}, {BW, 4},
+        {BW, 5}, {GZ, 5}, {BZ, 3}, {BZ, 5}, {BZ, 4}, {RX, 0}, {RX, 1}, {RX, 2}, {RX, 3}, {RX, 4},
+        {RX, 5}, {GY, 0}, {GY, 1}, {GY, 2}, {GY, 3}, {GX, 0}, {GX, 1}, {GX, 2}, {GX, 3}, {GX, 4},
+        {GX, 5}, {GZ, 0}, {GZ, 1}, {GZ, 2}, {GZ, 3}, {BX, 0}, {BX, 1}, {BX, 2}, {BX, 3}, {BX, 4},
+        {BX, 5}, {BY, 0}, {BY, 1}, {BY, 2}, {BY, 3}, {RY, 0}, {RY, 1}, {RY, 2}, {RY, 3}, {RY, 4},
+        {RY, 5}, {RZ, 0}, {RZ, 1}, {RZ, 2}, {RZ, 3}, {RZ, 4}, {RZ, 5}, { D, 0}, { D, 1}, { D, 2},
+        { D, 3}, { D, 4},
+    },
+
+    {   // Mode 11 (0x03) - 10 10
+        { M, 0}, { M, 1}, { M, 2}, { M, 3}, { M, 4}, {RW, 0}, {RW, 1}, {RW, 2}, {RW, 3}, {RW, 4},
+        {RW, 5}, {RW, 6}, {RW, 7}, {RW, 8}, {RW, 9}, {GW, 0}, {GW, 1}, {GW, 2}, {GW, 3}, {GW, 4},
+        {GW, 5}, {GW, 6}, {GW, 7}, {GW, 8}, {GW, 9}, {BW, 0}, {BW, 1}, {BW, 2}, {BW, 3}, {BW, 4},
+        {BW, 5}, {BW, 6}, {BW, 7}, {BW, 8}, {BW, 9}, {RX, 0}, {RX, 1}, {RX, 2}, {RX, 3}, {RX, 4},
+        {RX, 5}, {RX, 6}, {RX, 7}, {RX, 8}, {RX, 9}, {GX, 0}, {GX, 1}, {GX, 2}, {GX, 3}, {GX, 4},
+        {GX, 5}, {GX, 6}, {GX, 7}, {GX, 8}, {GX, 9}, {BX, 0}, {BX, 1}, {BX, 2}, {BX, 3}, {BX, 4},
+        {BX, 5}, {BX, 6}, {BX, 7}, {BX, 8}, {BX, 9}, {NA, 0}, {NA, 0}, {NA, 0}, {NA, 0}, {NA, 0},
+        {NA, 0}, {NA, 0}, {NA, 0}, {NA, 0}, {NA, 0}, {NA, 0}, {NA, 0}, {NA, 0}, {NA, 0}, {NA, 0},
+        {NA, 0}, {NA, 0},
+    },
+
+    {   // Mode 12 (0x07) - 11 9
+        { M, 0}, { M, 1}, { M, 2}, { M, 3}, { M, 4}, {RW, 0}, {RW, 1}, {RW, 2}, {RW, 3}, {RW, 4},
+        {RW, 5}, {RW, 6}, {RW, 7}, {RW, 8}, {RW, 9}, {GW, 0}, {GW, 1}, {GW, 2}, {GW, 3}, {GW, 4},
+        {GW, 5}, {GW, 6}, {GW, 7}, {GW, 8}, {GW, 9}, {BW, 0}, {BW, 1}, {BW, 2}, {BW, 3}, {BW, 4},
+        {BW, 5}, {BW, 6}, {BW, 7}, {BW, 8}, {BW, 9}, {RX, 0}, {RX, 1}, {RX, 2}, {RX, 3}, {RX, 4},
+        {RX, 5}, {RX, 6}, {RX, 7}, {RX, 8}, {RW,10}, {GX, 0}, {GX, 1}, {GX, 2}, {GX, 3}, {GX, 4},
+        {GX, 5}, {GX, 6}, {GX, 7}, {GX, 8}, {GW,10}, {BX, 0}, {BX, 1}, {BX, 2}, {BX, 3}, {BX, 4},
+        {BX, 5}, {BX, 6}, {BX, 7}, {BX, 8}, {BW,10}, {NA, 0}, {NA, 0}, {NA, 0}, {NA, 0}, {NA, 0},
+        {NA, 0}, {NA, 0}, {NA, 0}, {NA, 0}, {NA, 0}, {NA, 0}, {NA, 0}, {NA, 0}, {NA, 0}, {NA, 0},
+        {NA, 0}, {NA, 0},
+    },
+
+    {   // Mode 13 (0x0b) - 12 8
+        { M, 0}, { M, 1}, { M, 2}, { M, 3}, { M, 4}, {RW, 0}, {RW, 1}, {RW, 2}, {RW, 3}, {RW, 4},
+        {RW, 5}, {RW, 6}, {RW, 7}, {RW, 8}, {RW, 9}, {GW, 0}, {GW, 1}, {GW, 2}, {GW, 3}, {GW, 4},
+        {GW, 5}, {GW, 6}, {GW, 7}, {GW, 8}, {GW, 9}, {BW, 0}, {BW, 1}, {BW, 2}, {BW, 3}, {BW, 4},
+        {BW, 5}, {BW, 6}, {BW, 7}, {BW, 8}, {BW, 9}, {RX, 0}, {RX, 1}, {RX, 2}, {RX, 3}, {RX, 4},
+        {RX, 5}, {RX, 6}, {RX, 7}, {RW,11}, {RW,10}, {GX, 0}, {GX, 1}, {GX, 2}, {GX, 3}, {GX, 4},
+        {GX, 5}, {GX, 6}, {GX, 7}, {GW,11}, {GW,10}, {BX, 0}, {BX, 1}, {BX, 2}, {BX, 3}, {BX, 4},
+        {BX, 5}, {BX, 6}, {BX, 7}, {BW,11}, {BW,10}, {NA, 0}, {NA, 0}, {NA, 0}, {NA, 0}, {NA, 0},
+        {NA, 0}, {NA, 0}, {NA, 0}, {NA, 0}, {NA, 0}, {NA, 0}, {NA, 0}, {NA, 0}, {NA, 0}, {NA, 0},
+        {NA, 0}, {NA, 0},
+    },
+
+    {   // Mode 14 (0x0f) - 16 4
+        { M, 0}, { M, 1}, { M, 2}, { M, 3}, { M, 4}, {RW, 0}, {RW, 1}, {RW, 2}, {RW, 3}, {RW, 4},
+        {RW, 5}, {RW, 6}, {RW, 7}, {RW, 8}, {RW, 9}, {GW, 0}, {GW, 1}, {GW, 2}, {GW, 3}, {GW, 4},
+        {GW, 5}, {GW, 6}, {GW, 7}, {GW, 8}, {GW, 9}, {BW, 0}, {BW, 1}, {BW, 2}, {BW, 3}, {BW, 4},
+        {BW, 5}, {BW, 6}, {BW, 7}, {BW, 8}, {BW, 9}, {RX, 0}, {RX, 1}, {RX, 2}, {RX, 3}, {RW,15},
+        {RW,14}, {RW,13}, {RW,12}, {RW,11}, {RW,10}, {GX, 0}, {GX, 1}, {GX, 2}, {GX, 3}, {GW,15},
+        {GW,14}, {GW,13}, {GW,12}, {GW,11}, {GW,10}, {BX, 0}, {BX, 1}, {BX, 2}, {BX, 3}, {BW,15},
+        {BW,14}, {BW,13}, {BW,12}, {BW,11}, {BW,10}, {NA, 0}, {NA, 0}, {NA, 0}, {NA, 0}, {NA, 0},
+        {NA, 0}, {NA, 0}, {NA, 0}, {NA, 0}, {NA, 0}, {NA, 0}, {NA, 0}, {NA, 0}, {NA, 0}, {NA, 0},
+        {NA, 0}, {NA, 0},
+    },
+};
+
+// Mode, Partitions, Transformed, IndexPrec, RGBAPrec
+const D3DX_BC6H::ModeInfo D3DX_BC6H::ms_aInfo[D3DX_BC6H::c_NumModes] =
+{
+    {0x00, 1, true,  3, { { LDRColorA(10,10,10,0), LDRColorA(5, 5, 5,0) }, { LDRColorA(5,5,5,0), LDRColorA(5,5,5,0) } } }, // Mode 1
+    {0x01, 1, true,  3, { { LDRColorA(7, 7, 7,0), LDRColorA(6, 6, 6,0) }, { LDRColorA(6,6,6,0), LDRColorA(6,6,6,0) } } }, // Mode 2
+    {0x02, 1, true,  3, { { LDRColorA(11,11,11,0), LDRColorA(5, 4, 4,0) }, { LDRColorA(5,4,4,0), LDRColorA(5,4,4,0) } } }, // Mode 3
+    {0x06, 1, true,  3, { { LDRColorA(11,11,11,0), LDRColorA(4, 5, 4,0) }, { LDRColorA(4,5,4,0), LDRColorA(4,5,4,0) } } }, // Mode 4
+    {0x0a, 1, true,  3, { { LDRColorA(11,11,11,0), LDRColorA(4, 4, 5,0) }, { LDRColorA(4,4,5,0), LDRColorA(4,4,5,0) } } }, // Mode 5
+    {0x0e, 1, true,  3, { { LDRColorA(9, 9, 9,0), LDRColorA(5, 5, 5,0) }, { LDRColorA(5,5,5,0), LDRColorA(5,5,5,0) } } }, // Mode 6
+    {0x12, 1, true,  3, { { LDRColorA(8, 8, 8,0), LDRColorA(6, 5, 5,0) }, { LDRColorA(6,5,5,0), LDRColorA(6,5,5,0) } } }, // Mode 7
+    {0x16, 1, true,  3, { { LDRColorA(8, 8, 8,0), LDRColorA(5, 6, 5,0) }, { LDRColorA(5,6,5,0), LDRColorA(5,6,5,0) } } }, // Mode 8
+    {0x1a, 1, true,  3, { { LDRColorA(8, 8, 8,0), LDRColorA(5, 5, 6,0) }, { LDRColorA(5,5,6,0), LDRColorA(5,5,6,0) } } }, // Mode 9
+    {0x1e, 1, false, 3, { { LDRColorA(6, 6, 6,0), LDRColorA(6, 6, 6,0) }, { LDRColorA(6,6,6,0), LDRColorA(6,6,6,0) } } }, // Mode 10
+    {0x03, 0, false, 4, { { LDRColorA(10,10,10,0), LDRColorA(10,10,10,0) }, { LDRColorA(0,0,0,0), LDRColorA(0,0,0,0) } } }, // Mode 11
+    {0x07, 0, true,  4, { { LDRColorA(11,11,11,0), LDRColorA(9, 9, 9,0) }, { LDRColorA(0,0,0,0), LDRColorA(0,0,0,0) } } }, // Mode 12
+    {0x0b, 0, true,  4, { { LDRColorA(12,12,12,0), LDRColorA(8, 8, 8,0) }, { LDRColorA(0,0,0,0), LDRColorA(0,0,0,0) } } }, // Mode 13
+    {0x0f, 0, true,  4, { { LDRColorA(16,16,16,0), LDRColorA(4, 4, 4,0) }, { LDRColorA(0,0,0,0), LDRColorA(0,0,0,0) } } }, // Mode 14
+};
+
+const int D3DX_BC6H::ms_aModeToInfo[D3DX_BC6H::c_NumModeInfo] =
+{
+     0, // Mode 1   - 0x00
+     1, // Mode 2   - 0x01
+     2, // Mode 3   - 0x02
+    10, // Mode 11  - 0x03
+    -1, // Invalid  - 0x04
+    -1, // Invalid  - 0x05
+     3, // Mode 4   - 0x06
+    11, // Mode 12  - 0x07
+    -1, // Invalid  - 0x08
+    -1, // Invalid  - 0x09
+     4, // Mode 5   - 0x0a
+    12, // Mode 13  - 0x0b
+    -1, // Invalid  - 0x0c
+    -1, // Invalid  - 0x0d
+     5, // Mode 6   - 0x0e
+    13, // Mode 14  - 0x0f
+    -1, // Invalid  - 0x10
+    -1, // Invalid  - 0x11
+     6, // Mode 7   - 0x12
+    -1, // Reserved - 0x13
+    -1, // Invalid  - 0x14
+    -1, // Invalid  - 0x15
+     7, // Mode 8   - 0x16
+    -1, // Reserved - 0x17
+    -1, // Invalid  - 0x18
+    -1, // Invalid  - 0x19
+     8, // Mode 9   - 0x1a
+    -1, // Reserved - 0x1b
+    -1, // Invalid  - 0x1c
+    -1, // Invalid  - 0x1d
+     9, // Mode 10  - 0x1e
+    -1, // Resreved - 0x1f
+};
+
+// BC7 compression: uPartitions, uPartitionBits, uPBits, uRotationBits, uIndexModeBits, uIndexPrec, uIndexPrec2, RGBAPrec, RGBAPrecWithP
+const D3DX_BC7::ModeInfo D3DX_BC7::ms_aInfo[D3DX_BC7::c_NumModes] =
+{
+    {2, 4, 6, 0, 0, 3, 0, LDRColorA(4,4,4,0), LDRColorA(5,5,5,0)},
+        // Mode 0: Color only, 3 Subsets, RGBP 4441 (unique P-bit), 3-bit indecies, 16 partitions
+    {1, 6, 2, 0, 0, 3, 0, LDRColorA(6,6,6,0), LDRColorA(7,7,7,0)},
+        // Mode 1: Color only, 2 Subsets, RGBP 6661 (shared P-bit), 3-bit indecies, 64 partitions
+    {2, 6, 0, 0, 0, 2, 0, LDRColorA(5,5,5,0), LDRColorA(5,5,5,0)},
+        // Mode 2: Color only, 3 Subsets, RGB 555, 2-bit indecies, 64 partitions
+    {1, 6, 4, 0, 0, 2, 0, LDRColorA(7,7,7,0), LDRColorA(8,8,8,0)},
+        // Mode 3: Color only, 2 Subsets, RGBP 7771 (unique P-bit), 2-bits indecies, 64 partitions
+    {0, 0, 0, 2, 1, 2, 3, LDRColorA(5,5,5,6), LDRColorA(5,5,5,6)},
+        // Mode 4: Color w/ Separate Alpha, 1 Subset, RGB 555, A6, 16x2/16x3-bit indices, 2-bit rotation, 1-bit index selector
+    {0, 0, 0, 2, 0, 2, 2, LDRColorA(7,7,7,8), LDRColorA(7,7,7,8)},
+        // Mode 5: Color w/ Separate Alpha, 1 Subset, RGB 777, A8, 16x2/16x2-bit indices, 2-bit rotation
+    {0, 0, 2, 0, 0, 4, 0, LDRColorA(7,7,7,7), LDRColorA(8,8,8,8)},
+        // Mode 6: Color+Alpha, 1 Subset, RGBAP 77771 (unique P-bit), 16x4-bit indecies
+    {1, 6, 4, 0, 0, 2, 0, LDRColorA(5,5,5,5), LDRColorA(6,6,6,6)}
+        // Mode 7: Color+Alpha, 2 Subsets, RGBAP 55551 (unique P-bit), 2-bit indices, 64 partitions
+};
+
+
+namespace
+{
+    //-------------------------------------------------------------------------------------
+    // Helper functions
+    //-------------------------------------------------------------------------------------
+    inline bool IsFixUpOffset(_In_range_(0, 2) size_t uPartitions, _In_range_(0, 63) size_t uShape, _In_range_(0, 15) size_t uOffset) noexcept
+    {
+        assert(uPartitions < 3 && uShape < 64 && uOffset < 16);
+        _Analysis_assume_(uPartitions < 3 && uShape < 64 && uOffset < 16);
+        for (size_t p = 0; p <= uPartitions; p++)
+        {
+            if (uOffset == g_aFixUp[uPartitions][uShape][p])
+            {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    inline void TransformForward(_Inout_updates_all_(BC6H_MAX_REGIONS) INTEndPntPair aEndPts[]) noexcept
+    {
+        aEndPts[0].B -= aEndPts[0].A;
+        aEndPts[1].A -= aEndPts[0].A;
+        aEndPts[1].B -= aEndPts[0].A;
+    }
+
+    inline void TransformInverse(_Inout_updates_all_(BC6H_MAX_REGIONS) INTEndPntPair aEndPts[], _In_ const LDRColorA& Prec, _In_ bool bSigned) noexcept
+    {
+        const INTColor WrapMask((1 << Prec.r) - 1, (1 << Prec.g) - 1, (1 << Prec.b) - 1);
+        aEndPts[0].B += aEndPts[0].A; aEndPts[0].B &= WrapMask;
+        aEndPts[1].A += aEndPts[0].A; aEndPts[1].A &= WrapMask;
+        aEndPts[1].B += aEndPts[0].A; aEndPts[1].B &= WrapMask;
+        if (bSigned)
+        {
+            aEndPts[0].B.SignExtend(Prec);
+            aEndPts[1].A.SignExtend(Prec);
+            aEndPts[1].B.SignExtend(Prec);
+        }
+    }
+
+    inline float Norm(_In_ const INTColor& a, _In_ const INTColor& b) noexcept
+    {
+        const float dr = float(a.r) - float(b.r);
+        const float dg = float(a.g) - float(b.g);
+        const float db = float(a.b) - float(b.b);
+        return dr * dr + dg * dg + db * db;
+    }
+
+    // return # of bits needed to store n. handle signed or unsigned cases properly
+    inline int NBits(_In_ int n, _In_ bool bIsSigned) noexcept
+    {
+        int nb;
+        if (n == 0)
+        {
+            return 0;	// no bits needed for 0, signed or not
+        }
+        else if (n > 0)
+        {
+            for (nb = 0; n; ++nb, n >>= 1);
+            return nb + (bIsSigned ? 1 : 0);
+        }
+        else
+        {
+            assert(bIsSigned);
+            for (nb = 0; n < -1; ++nb, n >>= 1);
+            return nb + 1;
+        }
+    }
+
+
+    //-------------------------------------------------------------------------------------
+    void OptimizeRGB(
+        _In_reads_(NUM_PIXELS_PER_BLOCK) const HDRColorA* const pPoints,
+        _Out_ HDRColorA* pX,
+        _Out_ HDRColorA* pY,
+        _In_range_(3, 4) uint32_t cSteps,
+        size_t cPixels,
+        _In_reads_(cPixels) const size_t* pIndex) noexcept
+    {
+        const float *pC = (3 == cSteps) ? pC3 : pC4;
+        const float *pD = (3 == cSteps) ? pD3 : pD4;
+
+        // Find Min and Max points, as starting point
+        HDRColorA X(FLT_MAX, FLT_MAX, FLT_MAX, 0.0f);
+        HDRColorA Y(-FLT_MAX, -FLT_MAX, -FLT_MAX, 0.0f);
+
+        for (size_t iPoint = 0; iPoint < cPixels; iPoint++)
+        {
+            if (pPoints[pIndex[iPoint]].r < X.r) X.r = pPoints[pIndex[iPoint]].r;
+            if (pPoints[pIndex[iPoint]].g < X.g) X.g = pPoints[pIndex[iPoint]].g;
+            if (pPoints[pIndex[iPoint]].b < X.b) X.b = pPoints[pIndex[iPoint]].b;
+            if (pPoints[pIndex[iPoint]].r > Y.r) Y.r = pPoints[pIndex[iPoint]].r;
+            if (pPoints[pIndex[iPoint]].g > Y.g) Y.g = pPoints[pIndex[iPoint]].g;
+            if (pPoints[pIndex[iPoint]].b > Y.b) Y.b = pPoints[pIndex[iPoint]].b;
+        }
+
+        // Diagonal axis
+        HDRColorA AB;
+        AB.r = Y.r - X.r;
+        AB.g = Y.g - X.g;
+        AB.b = Y.b - X.b;
+
+        const float fAB = AB.r * AB.r + AB.g * AB.g + AB.b * AB.b;
+
+        // Single color block.. no need to root-find
+        if (fAB < FLT_MIN)
+        {
+            pX->r = X.r; pX->g = X.g; pX->b = X.b;
+            pY->r = Y.r; pY->g = Y.g; pY->b = Y.b;
+            return;
+        }
+
+        // Try all four axis directions, to determine which diagonal best fits data
+        const float fABInv = 1.0f / fAB;
+
+        HDRColorA Dir;
+        Dir.r = AB.r * fABInv;
+        Dir.g = AB.g * fABInv;
+        Dir.b = AB.b * fABInv;
+
+        HDRColorA Mid;
+        Mid.r = (X.r + Y.r) * 0.5f;
+        Mid.g = (X.g + Y.g) * 0.5f;
+        Mid.b = (X.b + Y.b) * 0.5f;
+
+        float fDir[4];
+        fDir[0] = fDir[1] = fDir[2] = fDir[3] = 0.0f;
+
+        for (size_t iPoint = 0; iPoint < cPixels; iPoint++)
+        {
+            HDRColorA Pt;
+            Pt.r = (pPoints[pIndex[iPoint]].r - Mid.r) * Dir.r;
+            Pt.g = (pPoints[pIndex[iPoint]].g - Mid.g) * Dir.g;
+            Pt.b = (pPoints[pIndex[iPoint]].b - Mid.b) * Dir.b;
+
+            float f;
+            f = Pt.r + Pt.g + Pt.b; fDir[0] += f * f;
+            f = Pt.r + Pt.g - Pt.b; fDir[1] += f * f;
+            f = Pt.r - Pt.g + Pt.b; fDir[2] += f * f;
+            f = Pt.r - Pt.g - Pt.b; fDir[3] += f * f;
+        }
+
+        float fDirMax = fDir[0];
+        size_t  iDirMax = 0;
+
+        for (size_t iDir = 1; iDir < 4; iDir++)
+        {
+            if (fDir[iDir] > fDirMax)
+            {
+                fDirMax = fDir[iDir];
+                iDirMax = iDir;
+            }
+        }
+
+        if (iDirMax & 2) std::swap(X.g, Y.g);
+        if (iDirMax & 1) std::swap(X.b, Y.b);
+
+        // Two color block.. no need to root-find
+        if (fAB < 1.0f / 4096.0f)
+        {
+            pX->r = X.r; pX->g = X.g; pX->b = X.b;
+            pY->r = Y.r; pY->g = Y.g; pY->b = Y.b;
+            return;
+        }
+
+        // Use Newton's Method to find local minima of sum-of-squares error.
+        auto const fSteps = static_cast<float>(cSteps - 1);
+
+        for (size_t iIteration = 0; iIteration < 8; iIteration++)
+        {
+            // Calculate new steps
+            HDRColorA pSteps[4] = {};
+
+            for (size_t iStep = 0; iStep < cSteps; iStep++)
+            {
+                pSteps[iStep].r = X.r * pC[iStep] + Y.r * pD[iStep];
+                pSteps[iStep].g = X.g * pC[iStep] + Y.g * pD[iStep];
+                pSteps[iStep].b = X.b * pC[iStep] + Y.b * pD[iStep];
+            }
+
+            // Calculate color direction
+            Dir.r = Y.r - X.r;
+            Dir.g = Y.g - X.g;
+            Dir.b = Y.b - X.b;
+
+            const float fLen = (Dir.r * Dir.r + Dir.g * Dir.g + Dir.b * Dir.b);
+
+            if (fLen < (1.0f / 4096.0f))
+                break;
+
+            const float fScale = fSteps / fLen;
+
+            Dir.r *= fScale;
+            Dir.g *= fScale;
+            Dir.b *= fScale;
+
+            // Evaluate function, and derivatives
+            float d2X = 0.0f, d2Y = 0.0f;
+            HDRColorA dX(0.0f, 0.0f, 0.0f, 0.0f), dY(0.0f, 0.0f, 0.0f, 0.0f);
+
+            for (size_t iPoint = 0; iPoint < cPixels; iPoint++)
+            {
+                const float fDot = (pPoints[pIndex[iPoint]].r - X.r) * Dir.r +
+                    (pPoints[pIndex[iPoint]].g - X.g) * Dir.g +
+                    (pPoints[pIndex[iPoint]].b - X.b) * Dir.b;
+
+                uint32_t iStep;
+                if (fDot <= 0.0f)
+                    iStep = 0;
+                else if (fDot >= fSteps)
+                    iStep = cSteps - 1;
+                else
+                    iStep = uint32_t(fDot + 0.5f);
+
+                HDRColorA Diff;
+                Diff.r = pSteps[iStep].r - pPoints[pIndex[iPoint]].r;
+                Diff.g = pSteps[iStep].g - pPoints[pIndex[iPoint]].g;
+                Diff.b = pSteps[iStep].b - pPoints[pIndex[iPoint]].b;
+
+                const float fC = pC[iStep] * (1.0f / 8.0f);
+                const float fD = pD[iStep] * (1.0f / 8.0f);
+
+                d2X += fC * pC[iStep];
+                dX.r += fC * Diff.r;
+                dX.g += fC * Diff.g;
+                dX.b += fC * Diff.b;
+
+                d2Y += fD * pD[iStep];
+                dY.r += fD * Diff.r;
+                dY.g += fD * Diff.g;
+                dY.b += fD * Diff.b;
+            }
+
+            // Move endpoints
+            if (d2X > 0.0f)
+            {
+                const float f = -1.0f / d2X;
+
+                X.r += dX.r * f;
+                X.g += dX.g * f;
+                X.b += dX.b * f;
+            }
+
+            if (d2Y > 0.0f)
+            {
+                const float f = -1.0f / d2Y;
+
+                Y.r += dY.r * f;
+                Y.g += dY.g * f;
+                Y.b += dY.b * f;
+            }
+
+            if ((dX.r * dX.r < fEpsilon) && (dX.g * dX.g < fEpsilon) && (dX.b * dX.b < fEpsilon) &&
+                (dY.r * dY.r < fEpsilon) && (dY.g * dY.g < fEpsilon) && (dY.b * dY.b < fEpsilon))
+            {
+                break;
+            }
+        }
+
+        pX->r = X.r; pX->g = X.g; pX->b = X.b;
+        pY->r = Y.r; pY->g = Y.g; pY->b = Y.b;
+    }
+
+
+    //-------------------------------------------------------------------------------------
+    void OptimizeRGBA(
+        _In_reads_(NUM_PIXELS_PER_BLOCK) const HDRColorA* const pPoints,
+        _Out_ HDRColorA* pX,
+        _Out_ HDRColorA* pY,
+        _In_range_(3, 4) uint32_t cSteps,
+        size_t cPixels,
+        _In_reads_(cPixels) const size_t* pIndex) noexcept
+    {
+        const float *pC = (3 == cSteps) ? pC3 : pC4;
+        const float *pD = (3 == cSteps) ? pD3 : pD4;
+
+        // Find Min and Max points, as starting point
+        HDRColorA X(1.0f, 1.0f, 1.0f, 1.0f);
+        HDRColorA Y(0.0f, 0.0f, 0.0f, 0.0f);
+
+        for (size_t iPoint = 0; iPoint < cPixels; iPoint++)
+        {
+            if (pPoints[pIndex[iPoint]].r < X.r) X.r = pPoints[pIndex[iPoint]].r;
+            if (pPoints[pIndex[iPoint]].g < X.g) X.g = pPoints[pIndex[iPoint]].g;
+            if (pPoints[pIndex[iPoint]].b < X.b) X.b = pPoints[pIndex[iPoint]].b;
+            if (pPoints[pIndex[iPoint]].a < X.a) X.a = pPoints[pIndex[iPoint]].a;
+            if (pPoints[pIndex[iPoint]].r > Y.r) Y.r = pPoints[pIndex[iPoint]].r;
+            if (pPoints[pIndex[iPoint]].g > Y.g) Y.g = pPoints[pIndex[iPoint]].g;
+            if (pPoints[pIndex[iPoint]].b > Y.b) Y.b = pPoints[pIndex[iPoint]].b;
+            if (pPoints[pIndex[iPoint]].a > Y.a) Y.a = pPoints[pIndex[iPoint]].a;
+        }
+
+        // Diagonal axis
+        const HDRColorA AB = Y - X;
+        const float fAB = AB * AB;
+
+        // Single color block.. no need to root-find
+        if (fAB < FLT_MIN)
+        {
+            *pX = X;
+            *pY = Y;
+            return;
+        }
+
+        // Try all four axis directions, to determine which diagonal best fits data
+        const float fABInv = 1.0f / fAB;
+        HDRColorA Dir = AB * fABInv;
+        const HDRColorA Mid = (X + Y) * 0.5f;
+
+        float fDir[8];
+        fDir[0] = fDir[1] = fDir[2] = fDir[3] = fDir[4] = fDir[5] = fDir[6] = fDir[7] = 0.0f;
+
+        for (size_t iPoint = 0; iPoint < cPixels; iPoint++)
+        {
+            HDRColorA Pt;
+            Pt.r = (pPoints[pIndex[iPoint]].r - Mid.r) * Dir.r;
+            Pt.g = (pPoints[pIndex[iPoint]].g - Mid.g) * Dir.g;
+            Pt.b = (pPoints[pIndex[iPoint]].b - Mid.b) * Dir.b;
+            Pt.a = (pPoints[pIndex[iPoint]].a - Mid.a) * Dir.a;
+
+            float f;
+            f = Pt.r + Pt.g + Pt.b + Pt.a; fDir[0] += f * f;
+            f = Pt.r + Pt.g + Pt.b - Pt.a; fDir[1] += f * f;
+            f = Pt.r + Pt.g - Pt.b + Pt.a; fDir[2] += f * f;
+            f = Pt.r + Pt.g - Pt.b - Pt.a; fDir[3] += f * f;
+            f = Pt.r - Pt.g + Pt.b + Pt.a; fDir[4] += f * f;
+            f = Pt.r - Pt.g + Pt.b - Pt.a; fDir[5] += f * f;
+            f = Pt.r - Pt.g - Pt.b + Pt.a; fDir[6] += f * f;
+            f = Pt.r - Pt.g - Pt.b - Pt.a; fDir[7] += f * f;
+        }
+
+        float fDirMax = fDir[0];
+        size_t  iDirMax = 0;
+
+        for (size_t iDir = 1; iDir < 8; iDir++)
+        {
+            if (fDir[iDir] > fDirMax)
+            {
+                fDirMax = fDir[iDir];
+                iDirMax = iDir;
+            }
+        }
+
+        if (iDirMax & 4) std::swap(X.g, Y.g);
+        if (iDirMax & 2) std::swap(X.b, Y.b);
+        if (iDirMax & 1) std::swap(X.a, Y.a);
+
+        // Two color block.. no need to root-find
+        if (fAB < 1.0f / 4096.0f)
+        {
+            *pX = X;
+            *pY = Y;
+            return;
+        }
+
+        // Use Newton's Method to find local minima of sum-of-squares error.
+        const auto fSteps = static_cast<float>(cSteps - 1u);
+
+        for (size_t iIteration = 0; iIteration < 8; iIteration++)
+        {
+            // Calculate new steps
+            HDRColorA pSteps[BC7_MAX_INDICES];
+
+            LDRColorA lX, lY;
+            lX = (X * 255.0f).ToLDRColorA();
+            lY = (Y * 255.0f).ToLDRColorA();
+
+            for (size_t iStep = 0; iStep < cSteps; iStep++)
+            {
+                pSteps[iStep] = X * pC[iStep] + Y * pD[iStep];
+                //LDRColorA::Interpolate(lX, lY, i, i, wcprec, waprec, aSteps[i]);
+            }
+
+            // Calculate color direction
+            Dir = Y - X;
+            const float fLen = Dir * Dir;
+            if (fLen < (1.0f / 4096.0f))
+                break;
+
+            const float fScale = fSteps / fLen;
+            Dir *= fScale;
+
+            // Evaluate function, and derivatives
+            float d2X = 0.0f, d2Y = 0.0f;
+            HDRColorA dX(0.0f, 0.0f, 0.0f, 0.0f), dY(0.0f, 0.0f, 0.0f, 0.0f);
+
+            for (size_t iPoint = 0; iPoint < cPixels; ++iPoint)
+            {
+                const float fDot = (pPoints[pIndex[iPoint]] - X) * Dir;
+
+                uint32_t iStep;
+                if (fDot <= 0.0f)
+                    iStep = 0;
+                else if (fDot >= fSteps)
+                    iStep = cSteps - 1;
+                else
+                    iStep = uint32_t(fDot + 0.5f);
+
+                const HDRColorA Diff = pSteps[iStep] - pPoints[pIndex[iPoint]];
+                const float fC = pC[iStep] * (1.0f / 8.0f);
+                const float fD = pD[iStep] * (1.0f / 8.0f);
+
+                d2X += fC * pC[iStep];
+                dX += Diff * fC;
+
+                d2Y += fD * pD[iStep];
+                dY += Diff * fD;
+            }
+
+            // Move endpoints
+            if (d2X > 0.0f)
+            {
+                const float f = -1.0f / d2X;
+                X += dX * f;
+            }
+
+            if (d2Y > 0.0f)
+            {
+                const float f = -1.0f / d2Y;
+                Y += dY * f;
+            }
+
+            if ((dX * dX < fEpsilon) && (dY * dY < fEpsilon))
+                break;
+        }
+
+        *pX = X;
+        *pY = Y;
+    }
+
+
+    //-------------------------------------------------------------------------------------
+    float ComputeError(
+        _Inout_ const LDRColorA& pixel,
+        _In_reads_(1 << uIndexPrec) const LDRColorA aPalette[],
+        uint8_t uIndexPrec,
+        uint8_t uIndexPrec2,
+        _Out_opt_ size_t* pBestIndex = nullptr,
+        _Out_opt_ size_t* pBestIndex2 = nullptr) noexcept
+    {
+        const size_t uNumIndices = size_t(1) << uIndexPrec;
+        const size_t uNumIndices2 = size_t(1) << uIndexPrec2;
+        float fTotalErr = 0;
+        float fBestErr = FLT_MAX;
+
+        if (pBestIndex)
+            *pBestIndex = 0;
+        if (pBestIndex2)
+            *pBestIndex2 = 0;
+
+        const XMVECTOR vpixel = XMLoadUByte4(reinterpret_cast<const XMUBYTE4*>(&pixel));
+
+        if (uIndexPrec2 == 0)
+        {
+            for (size_t i = 0; i < uNumIndices && fBestErr > 0; i++)
+            {
+                XMVECTOR tpixel = XMLoadUByte4(reinterpret_cast<const XMUBYTE4*>(&aPalette[i]));
+                // Compute ErrorMetric
+                tpixel = XMVectorSubtract(vpixel, tpixel);
+                const float fErr = XMVectorGetX(XMVector4Dot(tpixel, tpixel));
+                if (fErr > fBestErr)	// error increased, so we're done searching
+                    break;
+                if (fErr < fBestErr)
+                {
+                    fBestErr = fErr;
+                    if (pBestIndex)
+                        *pBestIndex = i;
+                }
+            }
+            fTotalErr += fBestErr;
+        }
+        else
+        {
+            for (size_t i = 0; i < uNumIndices && fBestErr > 0; i++)
+            {
+                XMVECTOR tpixel = XMLoadUByte4(reinterpret_cast<const XMUBYTE4*>(&aPalette[i]));
+                // Compute ErrorMetricRGB
+                tpixel = XMVectorSubtract(vpixel, tpixel);
+                const float fErr = XMVectorGetX(XMVector3Dot(tpixel, tpixel));
+                if (fErr > fBestErr)	// error increased, so we're done searching
+                    break;
+                if (fErr < fBestErr)
+                {
+                    fBestErr = fErr;
+                    if (pBestIndex)
+                        *pBestIndex = i;
+                }
+            }
+            fTotalErr += fBestErr;
+            fBestErr = FLT_MAX;
+            for (size_t i = 0; i < uNumIndices2 && fBestErr > 0; i++)
+            {
+                // Compute ErrorMetricAlpha
+                const float ea = float(pixel.a) - float(aPalette[i].a);
+                const float fErr = ea*ea;
+                if (fErr > fBestErr)	// error increased, so we're done searching
+                    break;
+                if (fErr < fBestErr)
+                {
+                    fBestErr = fErr;
+                    if (pBestIndex2)
+                        *pBestIndex2 = i;
+                }
+            }
+            fTotalErr += fBestErr;
+        }
+
+        return fTotalErr;
+    }
+
+
+    void FillWithErrorColors(_Out_writes_(NUM_PIXELS_PER_BLOCK) HDRColorA* pOut) noexcept
+    {
+        for (size_t i = 0; i < NUM_PIXELS_PER_BLOCK; ++i)
+        {
+        #ifdef _DEBUG
+            // Use Magenta in debug as a highly-visible error color
+            pOut[i] = HDRColorA(1.0f, 0.0f, 1.0f, 1.0f);
+        #else
+            // In production use, default to black
+            pOut[i] = HDRColorA(0.0f, 0.0f, 0.0f, 1.0f);
+        #endif
+        }
+    }
+}
+
+
+//-------------------------------------------------------------------------------------
+// BC6H Compression
+//-------------------------------------------------------------------------------------
+_Use_decl_annotations_
+void D3DX_BC6H::Decode(bool bSigned, HDRColorA* pOut) const noexcept
+{
+    assert(pOut);
+
+    size_t uStartBit = 0;
+    uint8_t uMode = GetBits(uStartBit, 2u);
+    if (uMode != 0x00 && uMode != 0x01)
+    {
+        uMode = static_cast<uint8_t>((unsigned(GetBits(uStartBit, 3)) << 2) | uMode);
+    }
+
+    assert(uMode < c_NumModeInfo);
+    _Analysis_assume_(uMode < c_NumModeInfo);
+
+    if (ms_aModeToInfo[uMode] >= 0)
+    {
+        assert(static_cast<unsigned int>(ms_aModeToInfo[uMode]) < c_NumModes);
+        _Analysis_assume_(ms_aModeToInfo[uMode] < c_NumModes);
+        const ModeDescriptor* desc = ms_aDesc[ms_aModeToInfo[uMode]];
+        const ModeInfo& info = ms_aInfo[ms_aModeToInfo[uMode]];
+
+        INTEndPntPair aEndPts[BC6H_MAX_REGIONS] = {};
+        uint32_t uShape = 0;
+
+        // Read header
+        const size_t uHeaderBits = info.uPartitions > 0 ? 82u : 65u;
+        while (uStartBit < uHeaderBits)
+        {
+            const size_t uCurBit = uStartBit;
+            if (GetBit(uStartBit))
+            {
+                switch (desc[uCurBit].m_eField)
+                {
+                case D:  uShape |= 1 << uint32_t(desc[uCurBit].m_uBit); break;
+                case RW: aEndPts[0].A.r |= 1 << uint32_t(desc[uCurBit].m_uBit); break;
+                case RX: aEndPts[0].B.r |= 1 << uint32_t(desc[uCurBit].m_uBit); break;
+                case RY: aEndPts[1].A.r |= 1 << uint32_t(desc[uCurBit].m_uBit); break;
+                case RZ: aEndPts[1].B.r |= 1 << uint32_t(desc[uCurBit].m_uBit); break;
+                case GW: aEndPts[0].A.g |= 1 << uint32_t(desc[uCurBit].m_uBit); break;
+                case GX: aEndPts[0].B.g |= 1 << uint32_t(desc[uCurBit].m_uBit); break;
+                case GY: aEndPts[1].A.g |= 1 << uint32_t(desc[uCurBit].m_uBit); break;
+                case GZ: aEndPts[1].B.g |= 1 << uint32_t(desc[uCurBit].m_uBit); break;
+                case BW: aEndPts[0].A.b |= 1 << uint32_t(desc[uCurBit].m_uBit); break;
+                case BX: aEndPts[0].B.b |= 1 << uint32_t(desc[uCurBit].m_uBit); break;
+                case BY: aEndPts[1].A.b |= 1 << uint32_t(desc[uCurBit].m_uBit); break;
+                case BZ: aEndPts[1].B.b |= 1 << uint32_t(desc[uCurBit].m_uBit); break;
+                default:
+                    {
+                    #if defined(_WIN32) && defined(_DEBUG)
+                        OutputDebugStringA("BC6H: Invalid header bits encountered during decoding\n");
+                    #endif
+                        FillWithErrorColors(pOut);
+                        return;
+                    }
+                }
+            }
+        }
+
+        assert(uShape < 64);
+        _Analysis_assume_(uShape < 64);
+
+        // Sign extend necessary end points
+        if (bSigned)
+        {
+            aEndPts[0].A.SignExtend(info.RGBAPrec[0][0]);
+        }
+        if (bSigned || info.bTransformed)
+        {
+            assert(info.uPartitions < BC6H_MAX_REGIONS);
+            _Analysis_assume_(info.uPartitions < BC6H_MAX_REGIONS);
+            for (size_t p = 0; p <= info.uPartitions; ++p)
+            {
+                if (p != 0)
+                {
+                    aEndPts[p].A.SignExtend(info.RGBAPrec[p][0]);
+                }
+                aEndPts[p].B.SignExtend(info.RGBAPrec[p][1]);
+            }
+        }
+
+        // Inverse transform the end points
+        if (info.bTransformed)
+        {
+            TransformInverse(aEndPts, info.RGBAPrec[0][0], bSigned);
+        }
+
+        // Read indices
+        for (size_t i = 0; i < NUM_PIXELS_PER_BLOCK; ++i)
+        {
+            const size_t uNumBits = IsFixUpOffset(info.uPartitions, uShape, i) ? info.uIndexPrec - 1u : info.uIndexPrec;
+            if (uStartBit + uNumBits > 128)
+            {
+            #if defined(_WIN32) && defined(_DEBUG)
+                OutputDebugStringA("BC6H: Invalid block encountered during decoding\n");
+            #endif
+                FillWithErrorColors(pOut);
+                return;
+            }
+            const uint8_t uIndex = GetBits(uStartBit, uNumBits);
+
+            if (uIndex >= ((info.uPartitions > 0) ? 8 : 16))
+            {
+            #if defined(_WIN32) && defined(_DEBUG)
+                OutputDebugStringA("BC6H: Invalid index encountered during decoding\n");
+            #endif
+                FillWithErrorColors(pOut);
+                return;
+            }
+
+            const size_t uRegion = g_aPartitionTable[info.uPartitions][uShape][i];
+            assert(uRegion < BC6H_MAX_REGIONS);
+            _Analysis_assume_(uRegion < BC6H_MAX_REGIONS);
+
+            // Unquantize endpoints and interpolate
+            const int r1 = Unquantize(aEndPts[uRegion].A.r, info.RGBAPrec[0][0].r, bSigned);
+            const int g1 = Unquantize(aEndPts[uRegion].A.g, info.RGBAPrec[0][0].g, bSigned);
+            const int b1 = Unquantize(aEndPts[uRegion].A.b, info.RGBAPrec[0][0].b, bSigned);
+            const int r2 = Unquantize(aEndPts[uRegion].B.r, info.RGBAPrec[0][0].r, bSigned);
+            const int g2 = Unquantize(aEndPts[uRegion].B.g, info.RGBAPrec[0][0].g, bSigned);
+            const int b2 = Unquantize(aEndPts[uRegion].B.b, info.RGBAPrec[0][0].b, bSigned);
+            const int* aWeights = info.uPartitions > 0 ? g_aWeights3 : g_aWeights4;
+            INTColor fc;
+            fc.r = FinishUnquantize((r1 * (BC67_WEIGHT_MAX - aWeights[uIndex]) + r2 * aWeights[uIndex] + BC67_WEIGHT_ROUND) >> BC67_WEIGHT_SHIFT, bSigned);
+            fc.g = FinishUnquantize((g1 * (BC67_WEIGHT_MAX - aWeights[uIndex]) + g2 * aWeights[uIndex] + BC67_WEIGHT_ROUND) >> BC67_WEIGHT_SHIFT, bSigned);
+            fc.b = FinishUnquantize((b1 * (BC67_WEIGHT_MAX - aWeights[uIndex]) + b2 * aWeights[uIndex] + BC67_WEIGHT_ROUND) >> BC67_WEIGHT_SHIFT, bSigned);
+
+            HALF rgb[3];
+            fc.ToF16(rgb, bSigned);
+
+            pOut[i].r = XMConvertHalfToFloat(rgb[0]);
+            pOut[i].g = XMConvertHalfToFloat(rgb[1]);
+            pOut[i].b = XMConvertHalfToFloat(rgb[2]);
+            pOut[i].a = 1.0f;
+        }
+    }
+    else
+    {
+    #if defined(_WIN32) && defined(_DEBUG)
+        const char* warnstr = "BC6H: Invalid mode encountered during decoding\n";
+        switch (uMode)
+        {
+        case 0x13:  warnstr = "BC6H: Reserved mode 10011 encountered during decoding\n"; break;
+        case 0x17:  warnstr = "BC6H: Reserved mode 10111 encountered during decoding\n"; break;
+        case 0x1B:  warnstr = "BC6H: Reserved mode 11011 encountered during decoding\n"; break;
+        case 0x1F:  warnstr = "BC6H: Reserved mode 11111 encountered during decoding\n"; break;
+        default: break;
+        }
+        OutputDebugStringA(warnstr);
+    #endif
+        // Per the BC6H format spec, we must return opaque black
+        for (size_t i = 0; i < NUM_PIXELS_PER_BLOCK; ++i)
+        {
+            pOut[i] = HDRColorA(0.0f, 0.0f, 0.0f, 1.0f);
+        }
+    }
+}
+
+
+_Use_decl_annotations_
+void D3DX_BC6H::Encode(bool bSigned, const HDRColorA* const pIn) noexcept
+{
+    assert(pIn);
+
+    EncodeParams EP(pIn, bSigned);
+
+    for (EP.uMode = 0; EP.uMode < c_NumModes && EP.fBestErr > 0; ++EP.uMode)
+    {
+        const uint8_t uShapes = ms_aInfo[EP.uMode].uPartitions ? 32u : 1u;
+        // Number of rough cases to look at. reasonable values of this are 1, uShapes/4, and uShapes
+        // uShapes/4 gets nearly all the cases; you can increase that a bit (say by 3 or 4) if you really want to squeeze the last bit out
+        const size_t uItems = std::max<size_t>(1u, size_t(uShapes >> 2));
+        float afRoughMSE[BC6H_MAX_SHAPES];
+        uint8_t auShape[BC6H_MAX_SHAPES];
+
+        // pick the best uItems shapes and refine these.
+        for (EP.uShape = 0; EP.uShape < uShapes; ++EP.uShape)
+        {
+            size_t uShape = EP.uShape;
+            afRoughMSE[uShape] = RoughMSE(&EP);
+            auShape[uShape] = static_cast<uint8_t>(uShape);
+        }
+
+        // Bubble up the first uItems items
+        for (size_t i = 0; i < uItems; i++)
+        {
+            for (size_t j = i + 1; j < uShapes; j++)
+            {
+                if (afRoughMSE[i] > afRoughMSE[j])
+                {
+                    std::swap(afRoughMSE[i], afRoughMSE[j]);
+                    std::swap(auShape[i], auShape[j]);
+                }
+            }
+        }
+
+        for (size_t i = 0; i < uItems && EP.fBestErr > 0; i++)
+        {
+            EP.uShape = auShape[i];
+            Refine(&EP);
+        }
+    }
+}
+
+
+//-------------------------------------------------------------------------------------
+_Use_decl_annotations_
+int D3DX_BC6H::Quantize(int iValue, int prec, bool bSigned) noexcept
+{
+    assert(prec > 1);	// didn't bother to make it work for 1
+    int q, s = 0;
+    if (bSigned)
+    {
+        assert(iValue >= -F16MAX && iValue <= F16MAX);
+        if (iValue < 0)
+        {
+            s = 1;
+            iValue = -iValue;
+        }
+        q = (prec >= 16) ? iValue : (iValue << (prec - 1)) / (F16MAX + 1);
+        if (s)
+            q = -q;
+        assert(q > -(1 << (prec - 1)) && q < (1 << (prec - 1)));
+    }
+    else
+    {
+        assert(iValue >= 0 && iValue <= F16MAX);
+        q = (prec >= 15) ? iValue : (iValue << prec) / (F16MAX + 1);
+        assert(q >= 0 && q < (1 << prec));
+    }
+
+    return q;
+}
+
+
+_Use_decl_annotations_
+int D3DX_BC6H::Unquantize(int comp, uint8_t uBitsPerComp, bool bSigned) noexcept
+{
+    int unq = 0, s = 0;
+    if (bSigned)
+    {
+        if (uBitsPerComp >= 16)
+        {
+            unq = comp;
+        }
+        else
+        {
+            if (comp < 0)
+            {
+                s = 1;
+                comp = -comp;
+            }
+
+            if (comp == 0) unq = 0;
+            else if (comp >= ((1 << (uBitsPerComp - 1)) - 1)) unq = 0x7FFF;
+            else unq = ((comp << 15) + 0x4000) >> (uBitsPerComp - 1);
+
+            if (s) unq = -unq;
+        }
+    }
+    else
+    {
+        if (uBitsPerComp >= 15) unq = comp;
+        else if (comp == 0) unq = 0;
+        else if (comp == ((1 << uBitsPerComp) - 1)) unq = 0xFFFF;
+        else unq = ((comp << 16) + 0x8000) >> uBitsPerComp;
+    }
+
+    return unq;
+}
+
+
+_Use_decl_annotations_
+int D3DX_BC6H::FinishUnquantize(int comp, bool bSigned) noexcept
+{
+    if (bSigned)
+    {
+        return (comp < 0) ? -(((-comp) * 31) >> 5) : (comp * 31) >> 5;  // scale the magnitude by 31/32
+    }
+    else
+    {
+        return (comp * 31) >> 6;                                        // scale the magnitude by 31/64
+    }
+}
+
+
+//-------------------------------------------------------------------------------------
+_Use_decl_annotations_
+bool D3DX_BC6H::EndPointsFit(const EncodeParams* pEP, const INTEndPntPair aEndPts[]) noexcept
+{
+    assert(pEP);
+    assert(pEP->uMode < c_NumModes);
+    _Analysis_assume_(pEP->uMode < c_NumModes);
+
+    const bool bTransformed = ms_aInfo[pEP->uMode].bTransformed;
+    const bool bIsSigned = pEP->bSigned;
+    const LDRColorA& Prec0 = ms_aInfo[pEP->uMode].RGBAPrec[0][0];
+    const LDRColorA& Prec1 = ms_aInfo[pEP->uMode].RGBAPrec[0][1];
+    const LDRColorA& Prec2 = ms_aInfo[pEP->uMode].RGBAPrec[1][0];
+    const LDRColorA& Prec3 = ms_aInfo[pEP->uMode].RGBAPrec[1][1];
+
+    INTColor aBits[4];
+    aBits[0].r = NBits(aEndPts[0].A.r, bIsSigned);
+    aBits[0].g = NBits(aEndPts[0].A.g, bIsSigned);
+    aBits[0].b = NBits(aEndPts[0].A.b, bIsSigned);
+    aBits[1].r = NBits(aEndPts[0].B.r, bTransformed || bIsSigned);
+    aBits[1].g = NBits(aEndPts[0].B.g, bTransformed || bIsSigned);
+    aBits[1].b = NBits(aEndPts[0].B.b, bTransformed || bIsSigned);
+    if (aBits[0].r > Prec0.r || aBits[1].r > Prec1.r ||
+        aBits[0].g > Prec0.g || aBits[1].g > Prec1.g ||
+        aBits[0].b > Prec0.b || aBits[1].b > Prec1.b)
+        return false;
+
+    if (ms_aInfo[pEP->uMode].uPartitions)
+    {
+        aBits[2].r = NBits(aEndPts[1].A.r, bTransformed || bIsSigned);
+        aBits[2].g = NBits(aEndPts[1].A.g, bTransformed || bIsSigned);
+        aBits[2].b = NBits(aEndPts[1].A.b, bTransformed || bIsSigned);
+        aBits[3].r = NBits(aEndPts[1].B.r, bTransformed || bIsSigned);
+        aBits[3].g = NBits(aEndPts[1].B.g, bTransformed || bIsSigned);
+        aBits[3].b = NBits(aEndPts[1].B.b, bTransformed || bIsSigned);
+
+        if (aBits[2].r > Prec2.r || aBits[3].r > Prec3.r ||
+            aBits[2].g > Prec2.g || aBits[3].g > Prec3.g ||
+            aBits[2].b > Prec2.b || aBits[3].b > Prec3.b)
+            return false;
+    }
+
+    return true;
+}
+
+
+_Use_decl_annotations_
+void D3DX_BC6H::GeneratePaletteQuantized(const EncodeParams* pEP, const INTEndPntPair& endPts, INTColor aPalette[]) const noexcept
+{
+    assert(pEP);
+    assert(pEP->uMode < c_NumModes);
+    _Analysis_assume_(pEP->uMode < c_NumModes);
+
+    const size_t uIndexPrec = ms_aInfo[pEP->uMode].uIndexPrec;
+    const size_t uNumIndices = size_t(1) << uIndexPrec;
+    assert(uNumIndices > 0);
+    _Analysis_assume_(uNumIndices > 0);
+    const LDRColorA& Prec = ms_aInfo[pEP->uMode].RGBAPrec[0][0];
+
+    // scale endpoints
+    INTEndPntPair unqEndPts;
+    unqEndPts.A.r = Unquantize(endPts.A.r, Prec.r, pEP->bSigned);
+    unqEndPts.A.g = Unquantize(endPts.A.g, Prec.g, pEP->bSigned);
+    unqEndPts.A.b = Unquantize(endPts.A.b, Prec.b, pEP->bSigned);
+    unqEndPts.B.r = Unquantize(endPts.B.r, Prec.r, pEP->bSigned);
+    unqEndPts.B.g = Unquantize(endPts.B.g, Prec.g, pEP->bSigned);
+    unqEndPts.B.b = Unquantize(endPts.B.b, Prec.b, pEP->bSigned);
+
+    // interpolate
+    const int* aWeights = nullptr;
+    switch (uIndexPrec)
+    {
+    case 3: aWeights = g_aWeights3; assert(uNumIndices <= 8); _Analysis_assume_(uNumIndices <= 8); break;
+    case 4: aWeights = g_aWeights4; assert(uNumIndices <= 16); _Analysis_assume_(uNumIndices <= 16); break;
+    default:
+        assert(false);
+        for (size_t i = 0; i < uNumIndices; ++i)
+        {
+        #pragma prefast(suppress:22102 22103, "writing blocks in two halves confuses tool")
+            aPalette[i] = INTColor(0, 0, 0);
+        }
+        return;
+    }
+
+    for (size_t i = 0; i < uNumIndices; ++i)
+    {
+        aPalette[i].r = FinishUnquantize(
+            (unqEndPts.A.r * (BC67_WEIGHT_MAX - aWeights[i]) + unqEndPts.B.r * aWeights[i] + BC67_WEIGHT_ROUND) >> BC67_WEIGHT_SHIFT,
+            pEP->bSigned);
+        aPalette[i].g = FinishUnquantize(
+            (unqEndPts.A.g * (BC67_WEIGHT_MAX - aWeights[i]) + unqEndPts.B.g * aWeights[i] + BC67_WEIGHT_ROUND) >> BC67_WEIGHT_SHIFT,
+            pEP->bSigned);
+        aPalette[i].b = FinishUnquantize(
+            (unqEndPts.A.b * (BC67_WEIGHT_MAX - aWeights[i]) + unqEndPts.B.b * aWeights[i] + BC67_WEIGHT_ROUND) >> BC67_WEIGHT_SHIFT,
+            pEP->bSigned);
+    }
+}
+
+
+// given a collection of colors and quantized endpoints, generate a palette, choose best entries, and return a single toterr
+_Use_decl_annotations_
+float D3DX_BC6H::MapColorsQuantized(const EncodeParams* pEP, const INTColor aColors[], size_t np, const INTEndPntPair &endPts) const noexcept
+{
+    assert(pEP);
+    assert(pEP->uMode < c_NumModes);
+    _Analysis_assume_(pEP->uMode < c_NumModes);
+
+    const uint8_t uIndexPrec = ms_aInfo[pEP->uMode].uIndexPrec;
+    auto const uNumIndices = static_cast<const uint8_t>(1u << uIndexPrec);
+    INTColor aPalette[BC6H_MAX_INDICES];
+    GeneratePaletteQuantized(pEP, endPts, aPalette);
+
+    float fTotErr = 0;
+    for (size_t i = 0; i < np; ++i)
+    {
+        const XMVECTOR vcolors = XMLoadSInt4(reinterpret_cast<const XMINT4*>(&aColors[i]));
+
+        // Compute ErrorMetricRGB
+        XMVECTOR tpal = XMLoadSInt4(reinterpret_cast<const XMINT4*>(&aPalette[0]));
+        tpal = XMVectorSubtract(vcolors, tpal);
+        float fBestErr = XMVectorGetX(XMVector3Dot(tpal, tpal));
+
+        for (int j = 1; j < uNumIndices && fBestErr > 0; ++j)
+        {
+            // Compute ErrorMetricRGB
+            tpal = XMLoadSInt4(reinterpret_cast<const XMINT4*>(&aPalette[j]));
+            tpal = XMVectorSubtract(vcolors, tpal);
+            const float fErr = XMVectorGetX(XMVector3Dot(tpal, tpal));
+            if (fErr > fBestErr) break;     // error increased, so we're done searching
+            if (fErr < fBestErr) fBestErr = fErr;
+        }
+        fTotErr += fBestErr;
+    }
+    return fTotErr;
+}
+
+
+_Use_decl_annotations_
+float D3DX_BC6H::PerturbOne(const EncodeParams* pEP, const INTColor aColors[], size_t np, uint8_t ch,
+    const INTEndPntPair& oldEndPts, INTEndPntPair& newEndPts, float fOldErr, int do_b) const noexcept
+{
+    assert(pEP);
+    assert(pEP->uMode < c_NumModes);
+    _Analysis_assume_(pEP->uMode < c_NumModes);
+
+    uint8_t uPrec;
+    switch (ch)
+    {
+    case 0: uPrec = ms_aInfo[pEP->uMode].RGBAPrec[0][0].r; break;
+    case 1: uPrec = ms_aInfo[pEP->uMode].RGBAPrec[0][0].g; break;
+    case 2: uPrec = ms_aInfo[pEP->uMode].RGBAPrec[0][0].b; break;
+    default: assert(false); newEndPts = oldEndPts; return FLT_MAX;
+    }
+    INTEndPntPair tmpEndPts;
+    float fMinErr = fOldErr;
+    int beststep = 0;
+
+    // copy real endpoints so we can perturb them
+    tmpEndPts = newEndPts = oldEndPts;
+
+    // do a logarithmic search for the best error for this endpoint (which)
+    for (int step = 1 << (uPrec - 1); step; step >>= 1)
+    {
+        bool bImproved = false;
+        for (int sign = -1; sign <= 1; sign += 2)
+        {
+            if (do_b == 0)
+            {
+                tmpEndPts.A[ch] = newEndPts.A[ch] + sign * step;
+                if (tmpEndPts.A[ch] < 0 || tmpEndPts.A[ch] >= (1 << uPrec))
+                    continue;
+            }
+            else
+            {
+                tmpEndPts.B[ch] = newEndPts.B[ch] + sign * step;
+                if (tmpEndPts.B[ch] < 0 || tmpEndPts.B[ch] >= (1 << uPrec))
+                    continue;
+            }
+
+            const float fErr = MapColorsQuantized(pEP, aColors, np, tmpEndPts);
+
+            if (fErr < fMinErr)
+            {
+                bImproved = true;
+                fMinErr = fErr;
+                beststep = sign * step;
+            }
+        }
+        // if this was an improvement, move the endpoint and continue search from there
+        if (bImproved)
+        {
+            if (do_b == 0)
+                newEndPts.A[ch] += beststep;
+            else
+                newEndPts.B[ch] += beststep;
+        }
+    }
+    return fMinErr;
+}
+
+
+_Use_decl_annotations_
+void D3DX_BC6H::OptimizeOne(const EncodeParams* pEP, const INTColor aColors[], size_t np, float aOrgErr,
+    const INTEndPntPair &aOrgEndPts, INTEndPntPair &aOptEndPts) const noexcept
+{
+    assert(pEP);
+    float aOptErr = aOrgErr;
+    aOptEndPts.A = aOrgEndPts.A;
+    aOptEndPts.B = aOrgEndPts.B;
+
+    INTEndPntPair new_a, new_b;
+    INTEndPntPair newEndPts;
+    int do_b;
+
+    // now optimize each channel separately
+    for (uint8_t ch = 0; ch < BC6H_NUM_CHANNELS; ++ch)
+    {
+        // figure out which endpoint when perturbed gives the most improvement and start there
+        // if we just alternate, we can easily end up in a local minima
+        const float fErr0 = PerturbOne(pEP, aColors, np, ch, aOptEndPts, new_a, aOptErr, 0);	// perturb endpt A
+        const float fErr1 = PerturbOne(pEP, aColors, np, ch, aOptEndPts, new_b, aOptErr, 1);	// perturb endpt B
+
+        if (fErr0 < fErr1)
+        {
+            if (fErr0 >= aOptErr) continue;
+            aOptEndPts.A[ch] = new_a.A[ch];
+            aOptErr = fErr0;
+            do_b = 1;		// do B next
+        }
+        else
+        {
+            if (fErr1 >= aOptErr) continue;
+            aOptEndPts.B[ch] = new_b.B[ch];
+            aOptErr = fErr1;
+            do_b = 0;		// do A next
+        }
+
+        // now alternate endpoints and keep trying until there is no improvement
+        for (;;)
+        {
+            const float fErr = PerturbOne(pEP, aColors, np, ch, aOptEndPts, newEndPts, aOptErr, do_b);
+            if (fErr >= aOptErr)
+                break;
+            if (do_b == 0)
+                aOptEndPts.A[ch] = newEndPts.A[ch];
+            else
+                aOptEndPts.B[ch] = newEndPts.B[ch];
+            aOptErr = fErr;
+            do_b = 1 - do_b;	// now move the other endpoint
+        }
+    }
+}
+
+
+_Use_decl_annotations_
+void D3DX_BC6H::OptimizeEndPoints(const EncodeParams* pEP, const float aOrgErr[], const INTEndPntPair aOrgEndPts[], INTEndPntPair aOptEndPts[]) const noexcept
+{
+    assert(pEP);
+    assert(pEP->uMode < c_NumModes);
+    _Analysis_assume_(pEP->uMode < c_NumModes);
+
+    const uint8_t uPartitions = ms_aInfo[pEP->uMode].uPartitions;
+    assert(uPartitions < BC6H_MAX_REGIONS);
+    _Analysis_assume_(uPartitions < BC6H_MAX_REGIONS);
+    INTColor aPixels[NUM_PIXELS_PER_BLOCK];
+
+    for (size_t p = 0; p <= uPartitions; ++p)
+    {
+        // collect the pixels in the region
+        size_t np = 0;
+        for (size_t i = 0; i < NUM_PIXELS_PER_BLOCK; ++i)
+        {
+            if (g_aPartitionTable[p][pEP->uShape][i] == p)
+            {
+                aPixels[np++] = pEP->aIPixels[i];
+            }
+        }
+
+        OptimizeOne(pEP, aPixels, np, aOrgErr[p], aOrgEndPts[p], aOptEndPts[p]);
+    }
+}
+
+
+// Swap endpoints as needed to ensure that the indices at fix up have a 0 high-order bit
+_Use_decl_annotations_
+void D3DX_BC6H::SwapIndices(const EncodeParams* pEP, INTEndPntPair aEndPts[], size_t aIndices[]) noexcept
+{
+    assert(pEP);
+    assert(pEP->uMode < c_NumModes);
+    _Analysis_assume_(pEP->uMode < c_NumModes);
+
+    const size_t uPartitions = ms_aInfo[pEP->uMode].uPartitions;
+    const size_t uNumIndices = size_t(1) << ms_aInfo[pEP->uMode].uIndexPrec;
+    const size_t uHighIndexBit = uNumIndices >> 1;
+
+    assert(uPartitions < BC6H_MAX_REGIONS && pEP->uShape < BC6H_MAX_SHAPES);
+    _Analysis_assume_(uPartitions < BC6H_MAX_REGIONS && pEP->uShape < BC6H_MAX_SHAPES);
+
+    for (size_t p = 0; p <= uPartitions; ++p)
+    {
+        const size_t i = g_aFixUp[uPartitions][pEP->uShape][p];
+        assert(g_aPartitionTable[uPartitions][pEP->uShape][i] == p);
+        if (aIndices[i] & uHighIndexBit)
+        {
+            // high bit is set, swap the aEndPts and indices for this region
+            std::swap(aEndPts[p].A, aEndPts[p].B);
+
+            for (size_t j = 0; j < NUM_PIXELS_PER_BLOCK; ++j)
+                if (g_aPartitionTable[uPartitions][pEP->uShape][j] == p)
+                    aIndices[j] = uNumIndices - 1 - aIndices[j];
+        }
+    }
+}
+
+
+// assign indices given a tile, shape, and quantized endpoints, return toterr for each region
+_Use_decl_annotations_
+void D3DX_BC6H::AssignIndices(const EncodeParams* pEP, const INTEndPntPair aEndPts[], size_t aIndices[], float aTotErr[]) const noexcept
+{
+    assert(pEP);
+    assert(pEP->uMode < c_NumModes);
+    _Analysis_assume_(pEP->uMode < c_NumModes);
+
+    const uint8_t uPartitions = ms_aInfo[pEP->uMode].uPartitions;
+    auto const uNumIndices = static_cast<const uint8_t>(1u << ms_aInfo[pEP->uMode].uIndexPrec);
+
+    assert(uPartitions < BC6H_MAX_REGIONS && pEP->uShape < BC6H_MAX_SHAPES);
+    _Analysis_assume_(uPartitions < BC6H_MAX_REGIONS && pEP->uShape < BC6H_MAX_SHAPES);
+
+    // build list of possibles
+    INTColor aPalette[BC6H_MAX_REGIONS][BC6H_MAX_INDICES];
+
+    for (size_t p = 0; p <= uPartitions; ++p)
+    {
+        GeneratePaletteQuantized(pEP, aEndPts[p], aPalette[p]);
+        aTotErr[p] = 0;
+    }
+
+    for (size_t i = 0; i < NUM_PIXELS_PER_BLOCK; ++i)
+    {
+        const uint8_t uRegion = g_aPartitionTable[uPartitions][pEP->uShape][i];
+        assert(uRegion < BC6H_MAX_REGIONS);
+        _Analysis_assume_(uRegion < BC6H_MAX_REGIONS);
+        float fBestErr = Norm(pEP->aIPixels[i], aPalette[uRegion][0]);
+        aIndices[i] = 0;
+
+        for (uint8_t j = 1; j < uNumIndices && fBestErr > 0; ++j)
+        {
+            const float fErr = Norm(pEP->aIPixels[i], aPalette[uRegion][j]);
+            if (fErr > fBestErr) break;	// error increased, so we're done searching
+            if (fErr < fBestErr)
+            {
+                fBestErr = fErr;
+                aIndices[i] = j;
+            }
+        }
+        aTotErr[uRegion] += fBestErr;
+    }
+}
+
+
+_Use_decl_annotations_
+void D3DX_BC6H::QuantizeEndPts(const EncodeParams* pEP, INTEndPntPair* aQntEndPts) const noexcept
+{
+    assert(pEP && aQntEndPts);
+    assert(pEP->uMode < c_NumModes);
+    _Analysis_assume_(pEP->uMode < c_NumModes);
+
+    const INTEndPntPair* aUnqEndPts = pEP->aUnqEndPts[pEP->uShape];
+    const LDRColorA& Prec = ms_aInfo[pEP->uMode].RGBAPrec[0][0];
+    const uint8_t uPartitions = ms_aInfo[pEP->uMode].uPartitions;
+    assert(uPartitions < BC6H_MAX_REGIONS);
+    _Analysis_assume_(uPartitions < BC6H_MAX_REGIONS);
+
+    for (size_t p = 0; p <= uPartitions; ++p)
+    {
+        aQntEndPts[p].A.r = Quantize(aUnqEndPts[p].A.r, Prec.r, pEP->bSigned);
+        aQntEndPts[p].A.g = Quantize(aUnqEndPts[p].A.g, Prec.g, pEP->bSigned);
+        aQntEndPts[p].A.b = Quantize(aUnqEndPts[p].A.b, Prec.b, pEP->bSigned);
+        aQntEndPts[p].B.r = Quantize(aUnqEndPts[p].B.r, Prec.r, pEP->bSigned);
+        aQntEndPts[p].B.g = Quantize(aUnqEndPts[p].B.g, Prec.g, pEP->bSigned);
+        aQntEndPts[p].B.b = Quantize(aUnqEndPts[p].B.b, Prec.b, pEP->bSigned);
+    }
+}
+
+
+_Use_decl_annotations_
+void D3DX_BC6H::EmitBlock(const EncodeParams* pEP, const INTEndPntPair aEndPts[], const size_t aIndices[]) noexcept
+{
+    assert(pEP);
+    assert(pEP->uMode < c_NumModes);
+    _Analysis_assume_(pEP->uMode < c_NumModes);
+
+    const uint8_t uRealMode = ms_aInfo[pEP->uMode].uMode;
+    const uint8_t uPartitions = ms_aInfo[pEP->uMode].uPartitions;
+    const uint8_t uIndexPrec = ms_aInfo[pEP->uMode].uIndexPrec;
+    const size_t uHeaderBits = uPartitions > 0 ? 82u : 65u;
+    const ModeDescriptor* desc = ms_aDesc[pEP->uMode];
+    size_t uStartBit = 0;
+
+    while (uStartBit < uHeaderBits)
+    {
+        switch (desc[uStartBit].m_eField)
+        {
+        case M:  SetBit(uStartBit, uint8_t(uRealMode >> desc[uStartBit].m_uBit) & 0x01u); break;
+        case D:  SetBit(uStartBit, uint8_t(pEP->uShape >> desc[uStartBit].m_uBit) & 0x01u); break;
+        case RW: SetBit(uStartBit, uint8_t(aEndPts[0].A.r >> desc[uStartBit].m_uBit) & 0x01u); break;
+        case RX: SetBit(uStartBit, uint8_t(aEndPts[0].B.r >> desc[uStartBit].m_uBit) & 0x01u); break;
+        case RY: SetBit(uStartBit, uint8_t(aEndPts[1].A.r >> desc[uStartBit].m_uBit) & 0x01u); break;
+        case RZ: SetBit(uStartBit, uint8_t(aEndPts[1].B.r >> desc[uStartBit].m_uBit) & 0x01u); break;
+        case GW: SetBit(uStartBit, uint8_t(aEndPts[0].A.g >> desc[uStartBit].m_uBit) & 0x01u); break;
+        case GX: SetBit(uStartBit, uint8_t(aEndPts[0].B.g >> desc[uStartBit].m_uBit) & 0x01u); break;
+        case GY: SetBit(uStartBit, uint8_t(aEndPts[1].A.g >> desc[uStartBit].m_uBit) & 0x01u); break;
+        case GZ: SetBit(uStartBit, uint8_t(aEndPts[1].B.g >> desc[uStartBit].m_uBit) & 0x01u); break;
+        case BW: SetBit(uStartBit, uint8_t(aEndPts[0].A.b >> desc[uStartBit].m_uBit) & 0x01u); break;
+        case BX: SetBit(uStartBit, uint8_t(aEndPts[0].B.b >> desc[uStartBit].m_uBit) & 0x01u); break;
+        case BY: SetBit(uStartBit, uint8_t(aEndPts[1].A.b >> desc[uStartBit].m_uBit) & 0x01u); break;
+        case BZ: SetBit(uStartBit, uint8_t(aEndPts[1].B.b >> desc[uStartBit].m_uBit) & 0x01u); break;
+        default: assert(false);
+        }
+    }
+
+    for (size_t i = 0; i < NUM_PIXELS_PER_BLOCK; ++i)
+    {
+        if (IsFixUpOffset(ms_aInfo[pEP->uMode].uPartitions, pEP->uShape, i))
+            SetBits(uStartBit, uIndexPrec - 1u, static_cast<uint8_t>(aIndices[i]));
+        else
+            SetBits(uStartBit, uIndexPrec, static_cast<uint8_t>(aIndices[i]));
+    }
+    assert(uStartBit == 128);
+}
+
+
+_Use_decl_annotations_
+void D3DX_BC6H::Refine(EncodeParams* pEP) noexcept
+{
+    assert(pEP);
+    assert(pEP->uMode < c_NumModes);
+    _Analysis_assume_(pEP->uMode < c_NumModes);
+
+    const uint8_t uPartitions = ms_aInfo[pEP->uMode].uPartitions;
+    assert(uPartitions < BC6H_MAX_REGIONS);
+    _Analysis_assume_(uPartitions < BC6H_MAX_REGIONS);
+
+    const bool bTransformed = ms_aInfo[pEP->uMode].bTransformed;
+    float aOrgErr[BC6H_MAX_REGIONS], aOptErr[BC6H_MAX_REGIONS];
+    INTEndPntPair aOrgEndPts[BC6H_MAX_REGIONS], aOptEndPts[BC6H_MAX_REGIONS];
+    size_t aOrgIdx[NUM_PIXELS_PER_BLOCK], aOptIdx[NUM_PIXELS_PER_BLOCK];
+
+    QuantizeEndPts(pEP, aOrgEndPts);
+    AssignIndices(pEP, aOrgEndPts, aOrgIdx, aOrgErr);
+    SwapIndices(pEP, aOrgEndPts, aOrgIdx);
+
+    if (bTransformed) TransformForward(aOrgEndPts);
+    if (EndPointsFit(pEP, aOrgEndPts))
+    {
+        if (bTransformed) TransformInverse(aOrgEndPts, ms_aInfo[pEP->uMode].RGBAPrec[0][0], pEP->bSigned);
+        OptimizeEndPoints(pEP, aOrgErr, aOrgEndPts, aOptEndPts);
+        AssignIndices(pEP, aOptEndPts, aOptIdx, aOptErr);
+        SwapIndices(pEP, aOptEndPts, aOptIdx);
+
+        float fOrgTotErr = 0.0f, fOptTotErr = 0.0f;
+        for (size_t p = 0; p <= uPartitions; ++p)
+        {
+            fOrgTotErr += aOrgErr[p];
+            fOptTotErr += aOptErr[p];
+        }
+
+        if (bTransformed) TransformForward(aOptEndPts);
+        if (EndPointsFit(pEP, aOptEndPts) && fOptTotErr < fOrgTotErr && fOptTotErr < pEP->fBestErr)
+        {
+            pEP->fBestErr = fOptTotErr;
+            EmitBlock(pEP, aOptEndPts, aOptIdx);
+        }
+        else if (fOrgTotErr < pEP->fBestErr)
+        {
+            // either it stopped fitting when we optimized it, or there was no improvement
+            // so go back to the unoptimized endpoints which we know will fit
+            if (bTransformed) TransformForward(aOrgEndPts);
+            pEP->fBestErr = fOrgTotErr;
+            EmitBlock(pEP, aOrgEndPts, aOrgIdx);
+        }
+    }
+}
+
+
+_Use_decl_annotations_
+void D3DX_BC6H::GeneratePaletteUnquantized(const EncodeParams* pEP, size_t uRegion, INTColor aPalette[]) noexcept
+{
+    assert(pEP);
+    assert(uRegion < BC6H_MAX_REGIONS && pEP->uShape < BC6H_MAX_SHAPES);
+    _Analysis_assume_(uRegion < BC6H_MAX_REGIONS && pEP->uShape < BC6H_MAX_SHAPES);
+    assert(pEP->uMode < c_NumModes);
+    _Analysis_assume_(pEP->uMode < c_NumModes);
+
+    const INTEndPntPair& endPts = pEP->aUnqEndPts[pEP->uShape][uRegion];
+    const uint8_t uIndexPrec = ms_aInfo[pEP->uMode].uIndexPrec;
+    auto const uNumIndices = static_cast<const uint8_t>(1u << uIndexPrec);
+    assert(uNumIndices > 0);
+    _Analysis_assume_(uNumIndices > 0);
+
+    const int* aWeights = nullptr;
+    switch (uIndexPrec)
+    {
+    case 3: aWeights = g_aWeights3; assert(uNumIndices <= 8); _Analysis_assume_(uNumIndices <= 8); break;
+    case 4: aWeights = g_aWeights4; assert(uNumIndices <= 16); _Analysis_assume_(uNumIndices <= 16); break;
+    default:
+        assert(false);
+        for (size_t i = 0; i < uNumIndices; ++i)
+        {
+        #pragma prefast(suppress:22102 22103, "writing blocks in two halves confuses tool")
+            aPalette[i] = INTColor(0, 0, 0);
+        }
+        return;
+    }
+
+    for (size_t i = 0; i < uNumIndices; ++i)
+    {
+        aPalette[i].r = (endPts.A.r * (BC67_WEIGHT_MAX - aWeights[i]) + endPts.B.r * aWeights[i] + BC67_WEIGHT_ROUND) >> BC67_WEIGHT_SHIFT;
+        aPalette[i].g = (endPts.A.g * (BC67_WEIGHT_MAX - aWeights[i]) + endPts.B.g * aWeights[i] + BC67_WEIGHT_ROUND) >> BC67_WEIGHT_SHIFT;
+        aPalette[i].b = (endPts.A.b * (BC67_WEIGHT_MAX - aWeights[i]) + endPts.B.b * aWeights[i] + BC67_WEIGHT_ROUND) >> BC67_WEIGHT_SHIFT;
+    }
+}
+
+
+_Use_decl_annotations_
+float D3DX_BC6H::MapColors(const EncodeParams* pEP, size_t uRegion, size_t np, const size_t* auIndex) const noexcept
+{
+    assert(pEP);
+    assert(pEP->uMode < c_NumModes);
+    _Analysis_assume_(pEP->uMode < c_NumModes);
+
+    const uint8_t uIndexPrec = ms_aInfo[pEP->uMode].uIndexPrec;
+    auto const uNumIndices = static_cast<const uint8_t>(1u << uIndexPrec);
+    INTColor aPalette[BC6H_MAX_INDICES];
+    GeneratePaletteUnquantized(pEP, uRegion, aPalette);
+
+    float fTotalErr = 0.0f;
+    for (size_t i = 0; i < np; ++i)
+    {
+        float fBestErr = Norm(pEP->aIPixels[auIndex[i]], aPalette[0]);
+        for (uint8_t j = 1; j < uNumIndices && fBestErr > 0.0f; ++j)
+        {
+            const float fErr = Norm(pEP->aIPixels[auIndex[i]], aPalette[j]);
+            if (fErr > fBestErr) break;      // error increased, so we're done searching
+            if (fErr < fBestErr) fBestErr = fErr;
+        }
+        fTotalErr += fBestErr;
+    }
+
+    return fTotalErr;
+}
+
+_Use_decl_annotations_
+float D3DX_BC6H::RoughMSE(EncodeParams* pEP) const noexcept
+{
+    assert(pEP);
+    assert(pEP->uShape < BC6H_MAX_SHAPES);
+    _Analysis_assume_(pEP->uShape < BC6H_MAX_SHAPES);
+    assert(pEP->uMode < c_NumModes);
+    _Analysis_assume_(pEP->uMode < c_NumModes);
+
+    INTEndPntPair* aEndPts = pEP->aUnqEndPts[pEP->uShape];
+
+    const uint8_t uPartitions = ms_aInfo[pEP->uMode].uPartitions;
+    assert(uPartitions < BC6H_MAX_REGIONS);
+    _Analysis_assume_(uPartitions < BC6H_MAX_REGIONS);
+
+    size_t auPixIdx[NUM_PIXELS_PER_BLOCK];
+
+    float fError = 0.0f;
+    for (size_t p = 0; p <= uPartitions; ++p)
+    {
+        size_t np = 0;
+        for (size_t i = 0; i < NUM_PIXELS_PER_BLOCK; ++i)
+        {
+            if (g_aPartitionTable[uPartitions][pEP->uShape][i] == p)
+            {
+                auPixIdx[np++] = i;
+            }
+        }
+
+        // handle simple cases
+        assert(np > 0);
+        if (np == 1)
+        {
+            aEndPts[p].A = pEP->aIPixels[auPixIdx[0]];
+            aEndPts[p].B = pEP->aIPixels[auPixIdx[0]];
+            continue;
+        }
+        else if (np == 2)
+        {
+            aEndPts[p].A = pEP->aIPixels[auPixIdx[0]];
+            aEndPts[p].B = pEP->aIPixels[auPixIdx[1]];
+            continue;
+        }
+
+        HDRColorA epA, epB;
+        OptimizeRGB(pEP->aHDRPixels, &epA, &epB, 4, np, auPixIdx);
+        aEndPts[p].A.Set(epA, pEP->bSigned);
+        aEndPts[p].B.Set(epB, pEP->bSigned);
+        if (pEP->bSigned)
+        {
+            aEndPts[p].A.Clamp(-F16MAX, F16MAX);
+            aEndPts[p].B.Clamp(-F16MAX, F16MAX);
+        }
+        else
+        {
+            aEndPts[p].A.Clamp(0, F16MAX);
+            aEndPts[p].B.Clamp(0, F16MAX);
+        }
+
+        fError += MapColors(pEP, p, np, auPixIdx);
+    }
+
+    return fError;
+}
+
+
+//-------------------------------------------------------------------------------------
+// BC7 Compression
+//-------------------------------------------------------------------------------------
+_Use_decl_annotations_
+void D3DX_BC7::Decode(HDRColorA* pOut) const noexcept
+{
+    assert(pOut);
+
+    size_t uFirst = 0;
+    while (uFirst < 128 && !GetBit(uFirst)) {}
+    const uint8_t uMode = uint8_t(uFirst - 1);
+
+    if (uMode < 8)
+    {
+        const uint8_t uPartitions = ms_aInfo[uMode].uPartitions;
+        assert(uPartitions < BC7_MAX_REGIONS);
+        _Analysis_assume_(uPartitions < BC7_MAX_REGIONS);
+
+        auto const uNumEndPts = static_cast<const uint8_t>((unsigned(uPartitions) + 1u) << 1);
+        const uint8_t uIndexPrec = ms_aInfo[uMode].uIndexPrec;
+        const uint8_t uIndexPrec2 = ms_aInfo[uMode].uIndexPrec2;
+        size_t i;
+        size_t uStartBit = size_t(uMode) + 1;
+        uint8_t P[6];
+        const uint8_t uShape = GetBits(uStartBit, ms_aInfo[uMode].uPartitionBits);
+        assert(uShape < BC7_MAX_SHAPES);
+        _Analysis_assume_(uShape < BC7_MAX_SHAPES);
+
+        const uint8_t uRotation = GetBits(uStartBit, ms_aInfo[uMode].uRotationBits);
+        assert(uRotation < 4);
+
+        const uint8_t uIndexMode = GetBits(uStartBit, ms_aInfo[uMode].uIndexModeBits);
+        assert(uIndexMode < 2);
+
+        LDRColorA c[BC7_MAX_REGIONS << 1];
+        const LDRColorA RGBAPrec = ms_aInfo[uMode].RGBAPrec;
+        const LDRColorA RGBAPrecWithP = ms_aInfo[uMode].RGBAPrecWithP;
+
+        assert(uNumEndPts <= (BC7_MAX_REGIONS << 1));
+
+        // Red channel
+        for (i = 0; i < uNumEndPts; i++)
+        {
+            if (uStartBit + RGBAPrec.r > 128)
+            {
+            #if defined(_WIN32) && defined(_DEBUG)
+                OutputDebugStringA("BC7: Invalid block encountered during decoding\n");
+            #endif
+                FillWithErrorColors(pOut);
+                return;
+            }
+
+            c[i].r = GetBits(uStartBit, RGBAPrec.r);
+        }
+
+        // Green channel
+        for (i = 0; i < uNumEndPts; i++)
+        {
+            if (uStartBit + RGBAPrec.g > 128)
+            {
+            #if defined(_WIN32) && defined(_DEBUG)
+                OutputDebugStringA("BC7: Invalid block encountered during decoding\n");
+            #endif
+                FillWithErrorColors(pOut);
+                return;
+            }
+
+            c[i].g = GetBits(uStartBit, RGBAPrec.g);
+        }
+
+        // Blue channel
+        for (i = 0; i < uNumEndPts; i++)
+        {
+            if (uStartBit + RGBAPrec.b > 128)
+            {
+            #if defined(_WIN32) && defined(_DEBUG)
+                OutputDebugStringA("BC7: Invalid block encountered during decoding\n");
+            #endif
+                FillWithErrorColors(pOut);
+                return;
+            }
+
+            c[i].b = GetBits(uStartBit, RGBAPrec.b);
+        }
+
+        // Alpha channel
+        for (i = 0; i < uNumEndPts; i++)
+        {
+            if (uStartBit + RGBAPrec.a > 128)
+            {
+            #if defined(_WIN32) && defined(_DEBUG)
+                OutputDebugStringA("BC7: Invalid block encountered during decoding\n");
+            #endif
+                FillWithErrorColors(pOut);
+                return;
+            }
+
+            c[i].a = RGBAPrec.a ? GetBits(uStartBit, RGBAPrec.a) : 255u;
+        }
+
+        // P-bits
+        assert(ms_aInfo[uMode].uPBits <= 6);
+        _Analysis_assume_(ms_aInfo[uMode].uPBits <= 6);
+        for (i = 0; i < ms_aInfo[uMode].uPBits; i++)
+        {
+            if (uStartBit > 127)
+            {
+            #if defined(_WIN32) && defined(_DEBUG)
+                OutputDebugStringA("BC7: Invalid block encountered during decoding\n");
+            #endif
+                FillWithErrorColors(pOut);
+                return;
+            }
+
+            P[i] = GetBit(uStartBit);
+        }
+
+        if (ms_aInfo[uMode].uPBits)
+        {
+            for (i = 0; i < uNumEndPts; i++)
+            {
+                size_t pi = i * ms_aInfo[uMode].uPBits / uNumEndPts;
+                for (uint8_t ch = 0; ch < BC7_NUM_CHANNELS; ch++)
+                {
+                    if (RGBAPrec[ch] != RGBAPrecWithP[ch])
+                    {
+                        c[i][ch] = static_cast<uint8_t>((unsigned(c[i][ch]) << 1) | P[pi]);
+                    }
+                }
+            }
+        }
+
+        for (i = 0; i < uNumEndPts; i++)
+        {
+#ifdef __GNUC__
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wstringop-overflow"
+#endif
+            c[i] = Unquantize(c[i], RGBAPrecWithP);
+#ifdef __GNUC_
+#pragma GCC diagnostic pop
+#endif
+        }
+
+        uint8_t w1[NUM_PIXELS_PER_BLOCK], w2[NUM_PIXELS_PER_BLOCK];
+
+        // read color indices
+        for (i = 0; i < NUM_PIXELS_PER_BLOCK; i++)
+        {
+            const size_t uNumBits = IsFixUpOffset(ms_aInfo[uMode].uPartitions, uShape, i) ? uIndexPrec - 1u : uIndexPrec;
+            if (uStartBit + uNumBits > 128)
+            {
+            #if defined(_WIN32) && defined(_DEBUG)
+                OutputDebugStringA("BC7: Invalid block encountered during decoding\n");
+            #endif
+                FillWithErrorColors(pOut);
+                return;
+            }
+            w1[i] = GetBits(uStartBit, uNumBits);
+        }
+
+        // read alpha indices
+        if (uIndexPrec2)
+        {
+            for (i = 0; i < NUM_PIXELS_PER_BLOCK; i++)
+            {
+                const size_t uNumBits = i ? uIndexPrec2 : uIndexPrec2 - 1u;
+                if (uStartBit + uNumBits > 128)
+                {
+                #if defined(_WIN32) && defined(_DEBUG)
+                    OutputDebugStringA("BC7: Invalid block encountered during decoding\n");
+                #endif
+                    FillWithErrorColors(pOut);
+                    return;
+                }
+                w2[i] = GetBits(uStartBit, uNumBits);
+            }
+        }
+
+        for (i = 0; i < NUM_PIXELS_PER_BLOCK; ++i)
+        {
+            const uint8_t uRegion = g_aPartitionTable[uPartitions][uShape][i];
+            LDRColorA outPixel;
+            if (uIndexPrec2 == 0)
+            {
+                LDRColorA::Interpolate(c[uRegion << 1], c[(uRegion << 1) + 1], w1[i], w1[i], uIndexPrec, uIndexPrec, outPixel);
+            }
+            else
+            {
+                if (uIndexMode == 0)
+                {
+                    LDRColorA::Interpolate(c[uRegion << 1], c[(uRegion << 1) + 1], w1[i], w2[i], uIndexPrec, uIndexPrec2, outPixel);
+                }
+                else
+                {
+                    LDRColorA::Interpolate(c[uRegion << 1], c[(uRegion << 1) + 1], w2[i], w1[i], uIndexPrec2, uIndexPrec, outPixel);
+                }
+            }
+
+            switch (uRotation)
+            {
+            case 1: std::swap(outPixel.r, outPixel.a); break;
+            case 2: std::swap(outPixel.g, outPixel.a); break;
+            case 3: std::swap(outPixel.b, outPixel.a); break;
+            default: break;
+            }
+
+            pOut[i] = HDRColorA(outPixel);
+        }
+    }
+    else
+    {
+    #if defined(_WIN32) && defined(_DEBUG)
+        OutputDebugStringA("BC7: Reserved mode 8 encountered during decoding\n");
+    #endif
+        // Per the BC7 format spec, we must return transparent black
+        memset(pOut, 0, sizeof(HDRColorA) * NUM_PIXELS_PER_BLOCK);
+    }
+}
+
+_Use_decl_annotations_
+void D3DX_BC7::Encode(uint32_t flags, const HDRColorA* const pIn) noexcept
+{
+    assert(pIn);
+
+    D3DX_BC7 final = *this;
+    EncodeParams EP(pIn);
+    float fMSEBest = FLT_MAX;
+    uint32_t alphaMask = 0xFF;
+
+    for (size_t i = 0; i < NUM_PIXELS_PER_BLOCK; ++i)
+    {
+        EP.aLDRPixels[i].r = uint8_t(std::max<float>(0.0f, std::min<float>(255.0f, pIn[i].r * 255.0f + 0.01f)));
+        EP.aLDRPixels[i].g = uint8_t(std::max<float>(0.0f, std::min<float>(255.0f, pIn[i].g * 255.0f + 0.01f)));
+        EP.aLDRPixels[i].b = uint8_t(std::max<float>(0.0f, std::min<float>(255.0f, pIn[i].b * 255.0f + 0.01f)));
+        EP.aLDRPixels[i].a = uint8_t(std::max<float>(0.0f, std::min<float>(255.0f, pIn[i].a * 255.0f + 0.01f)));
+        alphaMask &= EP.aLDRPixels[i].a;
+    }
+
+    const bool bHasAlpha = (alphaMask != 0xFF);
+
+    for (EP.uMode = 0; EP.uMode < 8 && fMSEBest > 0; ++EP.uMode)
+    {
+        if (!(flags & BC_FLAGS_USE_3SUBSETS) && (EP.uMode == 0 || EP.uMode == 2))
+        {
+            // 3 subset modes tend to be used rarely and add significant compression time
+            continue;
+        }
+
+        if ((flags & TEX_COMPRESS_BC7_QUICK) && (EP.uMode != 6))
+        {
+            // Use only mode 6
+            continue;
+        }
+
+        if ((!bHasAlpha) && (EP.uMode == 7))
+        {
+            // There is no value in using mode 7 for completely opaque blocks (the other 2 subset modes handle this case for opaque blocks), so skip it for a small perf win.
+            continue;
+        }
+
+        const size_t uShapes = size_t(1) << ms_aInfo[EP.uMode].uPartitionBits;
+        assert(uShapes <= BC7_MAX_SHAPES);
+        _Analysis_assume_(uShapes <= BC7_MAX_SHAPES);
+
+        const size_t uNumRots = size_t(1) << ms_aInfo[EP.uMode].uRotationBits;
+        const size_t uNumIdxMode = size_t(1) << ms_aInfo[EP.uMode].uIndexModeBits;
+        // Number of rough cases to look at. reasonable values of this are 1, uShapes/4, and uShapes
+        // uShapes/4 gets nearly all the cases; you can increase that a bit (say by 3 or 4) if you really want to squeeze the last bit out
+        const size_t uItems = std::max<size_t>(1, uShapes >> 2);
+        float afRoughMSE[BC7_MAX_SHAPES];
+        size_t auShape[BC7_MAX_SHAPES];
+
+        for (size_t r = 0; r < uNumRots && fMSEBest > 0; ++r)
+        {
+            switch (r)
+            {
+            case 1: for (size_t i = 0; i < NUM_PIXELS_PER_BLOCK; i++) std::swap(EP.aLDRPixels[i].r, EP.aLDRPixels[i].a); break;
+            case 2: for (size_t i = 0; i < NUM_PIXELS_PER_BLOCK; i++) std::swap(EP.aLDRPixels[i].g, EP.aLDRPixels[i].a); break;
+            case 3: for (size_t i = 0; i < NUM_PIXELS_PER_BLOCK; i++) std::swap(EP.aLDRPixels[i].b, EP.aLDRPixels[i].a); break;
+            default: break;
+            }
+
+            for (size_t im = 0; im < uNumIdxMode && fMSEBest > 0; ++im)
+            {
+                // pick the best uItems shapes and refine these.
+                for (size_t s = 0; s < uShapes; s++)
+                {
+                    afRoughMSE[s] = RoughMSE(&EP, s, im);
+                    auShape[s] = s;
+                }
+
+                // Bubble up the first uItems items
+                for (size_t i = 0; i < uItems; i++)
+                {
+                    for (size_t j = i + 1; j < uShapes; j++)
+                    {
+                        if (afRoughMSE[i] > afRoughMSE[j])
+                        {
+                            std::swap(afRoughMSE[i], afRoughMSE[j]);
+                            std::swap(auShape[i], auShape[j]);
+                        }
+                    }
+                }
+
+                for (size_t i = 0; i < uItems && fMSEBest > 0; i++)
+                {
+                    const float fMSE = Refine(&EP, auShape[i], r, im);
+                    if (fMSE < fMSEBest)
+                    {
+                        final = *this;
+                        fMSEBest = fMSE;
+                    }
+                }
+            }
+
+            switch (r)
+            {
+            case 1: for (size_t i = 0; i < NUM_PIXELS_PER_BLOCK; i++) std::swap(EP.aLDRPixels[i].r, EP.aLDRPixels[i].a); break;
+            case 2: for (size_t i = 0; i < NUM_PIXELS_PER_BLOCK; i++) std::swap(EP.aLDRPixels[i].g, EP.aLDRPixels[i].a); break;
+            case 3: for (size_t i = 0; i < NUM_PIXELS_PER_BLOCK; i++) std::swap(EP.aLDRPixels[i].b, EP.aLDRPixels[i].a); break;
+            default: break;
+            }
+        }
+    }
+
+    *this = final;
+}
+
+
+//-------------------------------------------------------------------------------------
+_Use_decl_annotations_
+void D3DX_BC7::GeneratePaletteQuantized(const EncodeParams* pEP, size_t uIndexMode, const LDREndPntPair& endPts, LDRColorA aPalette[]) const noexcept
+{
+    assert(pEP);
+    assert(pEP->uMode < c_NumModes);
+    _Analysis_assume_(pEP->uMode < c_NumModes);
+
+    const size_t uIndexPrec = uIndexMode ? ms_aInfo[pEP->uMode].uIndexPrec2 : ms_aInfo[pEP->uMode].uIndexPrec;
+    const size_t uIndexPrec2 = uIndexMode ? ms_aInfo[pEP->uMode].uIndexPrec : ms_aInfo[pEP->uMode].uIndexPrec2;
+    const size_t uNumIndices = size_t(1) << uIndexPrec;
+    const size_t uNumIndices2 = size_t(1) << uIndexPrec2;
+    assert(uNumIndices > 0 && uNumIndices2 > 0);
+    _Analysis_assume_(uNumIndices > 0 && uNumIndices2 > 0);
+    assert((uNumIndices <= BC7_MAX_INDICES) && (uNumIndices2 <= BC7_MAX_INDICES));
+    _Analysis_assume_((uNumIndices <= BC7_MAX_INDICES) && (uNumIndices2 <= BC7_MAX_INDICES));
+
+    const LDRColorA a = Unquantize(endPts.A, ms_aInfo[pEP->uMode].RGBAPrecWithP);
+    const LDRColorA b = Unquantize(endPts.B, ms_aInfo[pEP->uMode].RGBAPrecWithP);
+    if (uIndexPrec2 == 0)
+    {
+        for (size_t i = 0; i < uNumIndices; i++)
+            LDRColorA::Interpolate(a, b, i, i, uIndexPrec, uIndexPrec, aPalette[i]);
+    }
+    else
+    {
+        for (size_t i = 0; i < uNumIndices; i++)
+            LDRColorA::InterpolateRGB(a, b, i, uIndexPrec, aPalette[i]);
+        for (size_t i = 0; i < uNumIndices2; i++)
+            LDRColorA::InterpolateA(a, b, i, uIndexPrec2, aPalette[i]);
+    }
+}
+
+_Use_decl_annotations_
+float D3DX_BC7::PerturbOne(const EncodeParams* pEP, const LDRColorA aColors[], size_t np, size_t uIndexMode, size_t ch,
+    const LDREndPntPair &oldEndPts, LDREndPntPair &newEndPts, float fOldErr, uint8_t do_b) const noexcept
+{
+    assert(pEP);
+    assert(pEP->uMode < c_NumModes);
+    _Analysis_assume_(pEP->uMode < c_NumModes);
+
+    const int prec = ms_aInfo[pEP->uMode].RGBAPrecWithP[ch];
+    LDREndPntPair tmp_endPts = newEndPts = oldEndPts;
+    float fMinErr = fOldErr;
+    uint8_t* pnew_c = (do_b ? &newEndPts.B[ch] : &newEndPts.A[ch]);
+    uint8_t* ptmp_c = (do_b ? &tmp_endPts.B[ch] : &tmp_endPts.A[ch]);
+
+    // do a logarithmic search for the best error for this endpoint (which)
+    for (int step = 1 << (prec - 1); step; step >>= 1)
+    {
+        bool bImproved = false;
+        int beststep = 0;
+        for (int sign = -1; sign <= 1; sign += 2)
+        {
+            int tmp = int(*pnew_c) + sign * step;
+            if (tmp < 0 || tmp >= (1 << prec))
+                continue;
+            else
+                *ptmp_c = static_cast<uint8_t>(tmp);
+
+            const float fTotalErr = MapColors(pEP, aColors, np, uIndexMode, tmp_endPts, fMinErr);
+            if (fTotalErr < fMinErr)
+            {
+                bImproved = true;
+                fMinErr = fTotalErr;
+                beststep = sign * step;
+            }
+        }
+
+        // if this was an improvement, move the endpoint and continue search from there
+        if (bImproved)
+            *pnew_c = uint8_t(int(*pnew_c) + beststep);
+    }
+    return fMinErr;
+}
+
+// perturb the endpoints at least -3 to 3.
+// always ensure endpoint ordering is preserved (no need to overlap the scan)
+_Use_decl_annotations_
+void D3DX_BC7::Exhaustive(const EncodeParams* pEP, const LDRColorA aColors[], size_t np, size_t uIndexMode, size_t ch,
+    float& fOrgErr, LDREndPntPair& optEndPt) const noexcept
+{
+    assert(pEP);
+    assert(pEP->uMode < c_NumModes);
+    _Analysis_assume_(pEP->uMode < c_NumModes);
+
+    const uint8_t uPrec = ms_aInfo[pEP->uMode].RGBAPrecWithP[ch];
+    LDREndPntPair tmpEndPt;
+    if (fOrgErr == 0)
+        return;
+
+    constexpr int delta = 5;
+
+    // ok figure out the range of A and B
+    tmpEndPt = optEndPt;
+    const int alow = std::max<int>(0, int(optEndPt.A[ch]) - delta);
+    const int ahigh = std::min<int>((1 << uPrec) - 1, int(optEndPt.A[ch]) + delta);
+    const int blow = std::max<int>(0, int(optEndPt.B[ch]) - delta);
+    const int bhigh = std::min<int>((1 << uPrec) - 1, int(optEndPt.B[ch]) + delta);
+    int amin = 0;
+    int bmin = 0;
+
+    float fBestErr = fOrgErr;
+    if (optEndPt.A[ch] <= optEndPt.B[ch])
+    {
+        // keep a <= b
+        for (int a = alow; a <= ahigh; ++a)
+        {
+            for (int b = std::max<int>(a, blow); b < bhigh; ++b)
+            {
+                tmpEndPt.A[ch] = static_cast<uint8_t>(a);
+                tmpEndPt.B[ch] = static_cast<uint8_t>(b);
+
+                const float fErr = MapColors(pEP, aColors, np, uIndexMode, tmpEndPt, fBestErr);
+                if (fErr < fBestErr)
+                {
+                    amin = a;
+                    bmin = b;
+                    fBestErr = fErr;
+                }
+            }
+        }
+    }
+    else
+    {
+        // keep b <= a
+        for (int b = blow; b < bhigh; ++b)
+        {
+            for (int a = std::max<int>(b, alow); a <= ahigh; ++a)
+            {
+                tmpEndPt.A[ch] = static_cast<uint8_t>(a);
+                tmpEndPt.B[ch] = static_cast<uint8_t>(b);
+
+                const float fErr = MapColors(pEP, aColors, np, uIndexMode, tmpEndPt, fBestErr);
+                if (fErr < fBestErr)
+                {
+                    amin = a;
+                    bmin = b;
+                    fBestErr = fErr;
+                }
+            }
+        }
+    }
+
+    if (fBestErr < fOrgErr)
+    {
+        optEndPt.A[ch] = static_cast<uint8_t>(amin);
+        optEndPt.B[ch] = static_cast<uint8_t>(bmin);
+        fOrgErr = fBestErr;
+    }
+}
+
+_Use_decl_annotations_
+void D3DX_BC7::OptimizeOne(const EncodeParams* pEP, const LDRColorA aColors[], size_t np, size_t uIndexMode,
+    float fOrgErr, const LDREndPntPair& org, LDREndPntPair& opt) const noexcept
+{
+    assert(pEP);
+    assert(pEP->uMode < c_NumModes);
+    _Analysis_assume_(pEP->uMode < c_NumModes);
+
+    float fOptErr = fOrgErr;
+    opt = org;
+
+    LDREndPntPair new_a, new_b;
+    LDREndPntPair newEndPts;
+    uint8_t do_b;
+
+    // now optimize each channel separately
+    for (size_t ch = 0; ch < BC7_NUM_CHANNELS; ++ch)
+    {
+        if (ms_aInfo[pEP->uMode].RGBAPrecWithP[ch] == 0)
+            continue;
+
+        // figure out which endpoint when perturbed gives the most improvement and start there
+        // if we just alternate, we can easily end up in a local minima
+        const float fErr0 = PerturbOne(pEP, aColors, np, uIndexMode, ch, opt, new_a, fOptErr, 0);	// perturb endpt A
+        const float fErr1 = PerturbOne(pEP, aColors, np, uIndexMode, ch, opt, new_b, fOptErr, 1);	// perturb endpt B
+
+        uint8_t& copt_a = opt.A[ch];
+        uint8_t& copt_b = opt.B[ch];
+        uint8_t& cnew_a = new_a.A[ch];
+        uint8_t& cnew_b = new_a.B[ch];
+
+        if (fErr0 < fErr1)
+        {
+            if (fErr0 >= fOptErr)
+                continue;
+            copt_a = cnew_a;
+            fOptErr = fErr0;
+            do_b = 1;		// do B next
+        }
+        else
+        {
+            if (fErr1 >= fOptErr)
+                continue;
+            copt_b = cnew_b;
+            fOptErr = fErr1;
+            do_b = 0;		// do A next
+        }
+
+        // now alternate endpoints and keep trying until there is no improvement
+        for (; ; )
+        {
+            const float fErr = PerturbOne(pEP, aColors, np, uIndexMode, ch, opt, newEndPts, fOptErr, do_b);
+            if (fErr >= fOptErr)
+                break;
+            if (do_b == 0)
+                copt_a = cnew_a;
+            else
+                copt_b = cnew_b;
+            fOptErr = fErr;
+            do_b = 1u - do_b;	// now move the other endpoint
+        }
+    }
+
+    // finally, do a small exhaustive search around what we think is the global minima to be sure
+    for (size_t ch = 0; ch < BC7_NUM_CHANNELS; ch++)
+        Exhaustive(pEP, aColors, np, uIndexMode, ch, fOptErr, opt);
+}
+
+_Use_decl_annotations_
+void D3DX_BC7::OptimizeEndPoints(const EncodeParams* pEP, size_t uShape, size_t uIndexMode, const float afOrgErr[],
+    const LDREndPntPair aOrgEndPts[], LDREndPntPair aOptEndPts[]) const noexcept
+{
+    assert(pEP);
+    assert(pEP->uMode < c_NumModes);
+    _Analysis_assume_(pEP->uMode < c_NumModes);
+
+    const uint8_t uPartitions = ms_aInfo[pEP->uMode].uPartitions;
+    assert(uPartitions < BC7_MAX_REGIONS && uShape < BC7_MAX_SHAPES);
+    _Analysis_assume_(uPartitions < BC7_MAX_REGIONS && uShape < BC7_MAX_SHAPES);
+
+    LDRColorA aPixels[NUM_PIXELS_PER_BLOCK];
+
+    for (size_t p = 0; p <= uPartitions; ++p)
+    {
+        // collect the pixels in the region
+        size_t np = 0;
+        for (size_t i = 0; i < NUM_PIXELS_PER_BLOCK; ++i)
+            if (g_aPartitionTable[uPartitions][uShape][i] == p)
+                aPixels[np++] = pEP->aLDRPixels[i];
+
+        OptimizeOne(pEP, aPixels, np, uIndexMode, afOrgErr[p], aOrgEndPts[p], aOptEndPts[p]);
+    }
+}
+
+_Use_decl_annotations_
+void D3DX_BC7::AssignIndices(const EncodeParams* pEP, size_t uShape, size_t uIndexMode, LDREndPntPair endPts[], size_t aIndices[], size_t aIndices2[],
+    float afTotErr[]) const noexcept
+{
+    assert(pEP);
+    assert(uShape < BC7_MAX_SHAPES);
+    _Analysis_assume_(uShape < BC7_MAX_SHAPES);
+    assert(pEP->uMode < c_NumModes);
+    _Analysis_assume_(pEP->uMode < c_NumModes);
+
+    const uint8_t uPartitions = ms_aInfo[pEP->uMode].uPartitions;
+    assert(uPartitions < BC7_MAX_REGIONS);
+    _Analysis_assume_(uPartitions < BC7_MAX_REGIONS);
+
+    const uint8_t uIndexPrec = uIndexMode ? ms_aInfo[pEP->uMode].uIndexPrec2 : ms_aInfo[pEP->uMode].uIndexPrec;
+    const uint8_t uIndexPrec2 = uIndexMode ? ms_aInfo[pEP->uMode].uIndexPrec : ms_aInfo[pEP->uMode].uIndexPrec2;
+    auto const uNumIndices = static_cast<const uint8_t>(1u << uIndexPrec);
+    auto const uNumIndices2 = static_cast<const uint8_t>(1u << uIndexPrec2);
+
+    assert((uNumIndices <= BC7_MAX_INDICES) && (uNumIndices2 <= BC7_MAX_INDICES));
+    _Analysis_assume_((uNumIndices <= BC7_MAX_INDICES) && (uNumIndices2 <= BC7_MAX_INDICES));
+
+    const uint8_t uHighestIndexBit = uint8_t(uNumIndices >> 1);
+    const uint8_t uHighestIndexBit2 = uint8_t(uNumIndices2 >> 1);
+    LDRColorA aPalette[BC7_MAX_REGIONS][BC7_MAX_INDICES];
+
+    // build list of possibles
+    for (size_t p = 0; p <= uPartitions; p++)
+    {
+        GeneratePaletteQuantized(pEP, uIndexMode, endPts[p], aPalette[p]);
+        afTotErr[p] = 0;
+    }
+
+    for (size_t i = 0; i < NUM_PIXELS_PER_BLOCK; i++)
+    {
+        uint8_t uRegion = g_aPartitionTable[uPartitions][uShape][i];
+        assert(uRegion < BC7_MAX_REGIONS);
+        _Analysis_assume_(uRegion < BC7_MAX_REGIONS);
+        afTotErr[uRegion] += ComputeError(pEP->aLDRPixels[i], aPalette[uRegion], uIndexPrec, uIndexPrec2, &(aIndices[i]), &(aIndices2[i]));
+    }
+
+    // swap endpoints as needed to ensure that the indices at index_positions have a 0 high-order bit
+    if (uIndexPrec2 == 0)
+    {
+        for (size_t p = 0; p <= uPartitions; p++)
+        {
+            if (aIndices[g_aFixUp[uPartitions][uShape][p]] & uHighestIndexBit)
+            {
+                std::swap(endPts[p].A, endPts[p].B);
+                for (size_t i = 0; i < NUM_PIXELS_PER_BLOCK; i++)
+                    if (g_aPartitionTable[uPartitions][uShape][i] == p)
+                        aIndices[i] = uNumIndices - 1 - aIndices[i];
+            }
+            assert((aIndices[g_aFixUp[uPartitions][uShape][p]] & uHighestIndexBit) == 0);
+        }
+    }
+    else
+    {
+        for (size_t p = 0; p <= uPartitions; p++)
+        {
+            if (aIndices[g_aFixUp[uPartitions][uShape][p]] & uHighestIndexBit)
+            {
+                std::swap(endPts[p].A.r, endPts[p].B.r);
+                std::swap(endPts[p].A.g, endPts[p].B.g);
+                std::swap(endPts[p].A.b, endPts[p].B.b);
+                for (size_t i = 0; i < NUM_PIXELS_PER_BLOCK; i++)
+                    if (g_aPartitionTable[uPartitions][uShape][i] == p)
+                        aIndices[i] = uNumIndices - 1 - aIndices[i];
+            }
+            assert((aIndices[g_aFixUp[uPartitions][uShape][p]] & uHighestIndexBit) == 0);
+
+            if (aIndices2[0] & uHighestIndexBit2)
+            {
+                std::swap(endPts[p].A.a, endPts[p].B.a);
+                for (size_t i = 0; i < NUM_PIXELS_PER_BLOCK; i++)
+                    aIndices2[i] = uNumIndices2 - 1 - aIndices2[i];
+            }
+            assert((aIndices2[0] & uHighestIndexBit2) == 0);
+        }
+    }
+}
+
+_Use_decl_annotations_
+void D3DX_BC7::EmitBlock(const EncodeParams* pEP, size_t uShape, size_t uRotation, size_t uIndexMode, const LDREndPntPair aEndPts[], const size_t aIndex[], const size_t aIndex2[]) noexcept
+{
+    assert(pEP);
+    assert(pEP->uMode < c_NumModes);
+    _Analysis_assume_(pEP->uMode < c_NumModes);
+
+    const uint8_t uPartitions = ms_aInfo[pEP->uMode].uPartitions;
+    assert(uPartitions < BC7_MAX_REGIONS);
+    _Analysis_assume_(uPartitions < BC7_MAX_REGIONS);
+
+    const size_t uPBits = ms_aInfo[pEP->uMode].uPBits;
+    const size_t uIndexPrec = ms_aInfo[pEP->uMode].uIndexPrec;
+    const size_t uIndexPrec2 = ms_aInfo[pEP->uMode].uIndexPrec2;
+    const LDRColorA RGBAPrec = ms_aInfo[pEP->uMode].RGBAPrec;
+    const LDRColorA RGBAPrecWithP = ms_aInfo[pEP->uMode].RGBAPrecWithP;
+    size_t i;
+    size_t uStartBit = 0;
+    SetBits(uStartBit, pEP->uMode, 0);
+    SetBits(uStartBit, 1, 1);
+    SetBits(uStartBit, ms_aInfo[pEP->uMode].uRotationBits, static_cast<uint8_t>(uRotation));
+    SetBits(uStartBit, ms_aInfo[pEP->uMode].uIndexModeBits, static_cast<uint8_t>(uIndexMode));
+    SetBits(uStartBit, ms_aInfo[pEP->uMode].uPartitionBits, static_cast<uint8_t>(uShape));
+
+    if (uPBits)
+    {
+        const size_t uNumEP = (size_t(uPartitions) + 1) << 1;
+        uint8_t aPVote[BC7_MAX_REGIONS << 1] = { 0,0,0,0,0,0 };
+        uint8_t aCount[BC7_MAX_REGIONS << 1] = { 0,0,0,0,0,0 };
+        for (uint8_t ch = 0; ch < BC7_NUM_CHANNELS; ch++)
+        {
+            uint8_t ep = 0;
+            for (i = 0; i <= uPartitions; i++)
+            {
+                if (RGBAPrec[ch] == RGBAPrecWithP[ch])
+                {
+                    SetBits(uStartBit, RGBAPrec[ch], aEndPts[i].A[ch]);
+                    SetBits(uStartBit, RGBAPrec[ch], aEndPts[i].B[ch]);
+                }
+                else
+                {
+                    SetBits(uStartBit, RGBAPrec[ch], uint8_t(aEndPts[i].A[ch] >> 1));
+                    SetBits(uStartBit, RGBAPrec[ch], uint8_t(aEndPts[i].B[ch] >> 1));
+                    size_t idx = ep++ * uPBits / uNumEP;
+                    assert(idx < (BC7_MAX_REGIONS << 1));
+                    _Analysis_assume_(idx < (BC7_MAX_REGIONS << 1));
+                    aPVote[idx] += aEndPts[i].A[ch] & 0x01;
+                    aCount[idx]++;
+                    idx = ep++ * uPBits / uNumEP;
+                    assert(idx < (BC7_MAX_REGIONS << 1));
+                    _Analysis_assume_(idx < (BC7_MAX_REGIONS << 1));
+                    aPVote[idx] += aEndPts[i].B[ch] & 0x01;
+                    aCount[idx]++;
+                }
+            }
+        }
+
+        for (i = 0; i < uPBits; i++)
+        {
+            SetBits(uStartBit, 1, (aPVote[i] >(aCount[i] >> 1)) ? 1u : 0u);
+        }
+    }
+    else
+    {
+        for (size_t ch = 0; ch < BC7_NUM_CHANNELS; ch++)
+        {
+            for (i = 0; i <= uPartitions; i++)
+            {
+                SetBits(uStartBit, RGBAPrec[ch], aEndPts[i].A[ch]);
+                SetBits(uStartBit, RGBAPrec[ch], aEndPts[i].B[ch]);
+            }
+        }
+    }
+
+    const size_t* aI1 = uIndexMode ? aIndex2 : aIndex;
+    const size_t* aI2 = uIndexMode ? aIndex : aIndex2;
+    for (i = 0; i < NUM_PIXELS_PER_BLOCK; i++)
+    {
+        if (IsFixUpOffset(ms_aInfo[pEP->uMode].uPartitions, uShape, i))
+            SetBits(uStartBit, uIndexPrec - 1, static_cast<uint8_t>(aI1[i]));
+        else
+            SetBits(uStartBit, uIndexPrec, static_cast<uint8_t>(aI1[i]));
+    }
+    if (uIndexPrec2)
+        for (i = 0; i < NUM_PIXELS_PER_BLOCK; i++)
+            SetBits(uStartBit, i ? uIndexPrec2 : uIndexPrec2 - 1, static_cast<uint8_t>(aI2[i]));
+
+    assert(uStartBit == 128);
+}
+
+_Use_decl_annotations_
+void D3DX_BC7::FixEndpointPBits(const EncodeParams* pEP, const LDREndPntPair *pOrigEndpoints, LDREndPntPair *pFixedEndpoints) noexcept
+{
+    assert(pEP);
+    assert(pEP->uMode < c_NumModes);
+    _Analysis_assume_(pEP->uMode < c_NumModes);
+
+    const size_t uPartitions = ms_aInfo[pEP->uMode].uPartitions;
+    assert(uPartitions < BC7_MAX_REGIONS);
+    _Analysis_assume_(uPartitions < BC7_MAX_REGIONS);
+
+    pFixedEndpoints[0] = pOrigEndpoints[0];
+    pFixedEndpoints[1] = pOrigEndpoints[1];
+    pFixedEndpoints[2] = pOrigEndpoints[2];
+
+    const size_t uPBits = ms_aInfo[pEP->uMode].uPBits;
+
+    if (uPBits)
+    {
+        const size_t uNumEP = size_t(1 + uPartitions) << 1;
+        uint8_t aPVote[BC7_MAX_REGIONS << 1] = { 0,0,0,0,0,0 };
+        uint8_t aCount[BC7_MAX_REGIONS << 1] = { 0,0,0,0,0,0 };
+
+        const LDRColorA RGBAPrec = ms_aInfo[pEP->uMode].RGBAPrec;
+        const LDRColorA RGBAPrecWithP = ms_aInfo[pEP->uMode].RGBAPrecWithP;
+
+        for (uint8_t ch = 0; ch < BC7_NUM_CHANNELS; ch++)
+        {
+            uint8_t ep = 0;
+            for (size_t i = 0; i <= uPartitions; i++)
+            {
+                if (RGBAPrec[ch] == RGBAPrecWithP[ch])
+                {
+                    pFixedEndpoints[i].A[ch] = pOrigEndpoints[i].A[ch];
+                    pFixedEndpoints[i].B[ch] = pOrigEndpoints[i].B[ch];
+                }
+                else
+                {
+                    pFixedEndpoints[i].A[ch] = uint8_t(pOrigEndpoints[i].A[ch] >> 1);
+                    pFixedEndpoints[i].B[ch] = uint8_t(pOrigEndpoints[i].B[ch] >> 1);
+
+                    size_t idx = ep++ * uPBits / uNumEP;
+                    assert(idx < (BC7_MAX_REGIONS << 1));
+                    _Analysis_assume_(idx < (BC7_MAX_REGIONS << 1));
+                    aPVote[idx] += pOrigEndpoints[i].A[ch] & 0x01;
+                    aCount[idx]++;
+                    idx = ep++ * uPBits / uNumEP;
+                    assert(idx < (BC7_MAX_REGIONS << 1));
+                    _Analysis_assume_(idx < (BC7_MAX_REGIONS << 1));
+                    aPVote[idx] += pOrigEndpoints[i].B[ch] & 0x01;
+                    aCount[idx]++;
+                }
+            }
+        }
+
+        // Compute the actual pbits we'll use when we encode block. Note this is not
+        // rounding the component indices correctly in cases the pbits != a component's LSB.
+        int pbits[BC7_MAX_REGIONS << 1];
+        for (size_t i = 0; i < uPBits; i++)
+            pbits[i] = aPVote[i] >(aCount[i] >> 1) ? 1 : 0;
+
+        // Now calculate the actual endpoints with proper pbits, so error calculations are accurate.
+        if (pEP->uMode == 1)
+        {
+            // shared pbits
+            for (uint8_t ch = 0; ch < BC7_NUM_CHANNELS; ch++)
+            {
+                for (size_t i = 0; i <= uPartitions; i++)
+                {
+                    pFixedEndpoints[i].A[ch] = static_cast<uint8_t>((pFixedEndpoints[i].A[ch] << 1) | pbits[i]);
+                    pFixedEndpoints[i].B[ch] = static_cast<uint8_t>((pFixedEndpoints[i].B[ch] << 1) | pbits[i]);
+                }
+            }
+        }
+        else
+        {
+            for (uint8_t ch = 0; ch < BC7_NUM_CHANNELS; ch++)
+            {
+                for (size_t i = 0; i <= uPartitions; i++)
+                {
+                    pFixedEndpoints[i].A[ch] = static_cast<uint8_t>((pFixedEndpoints[i].A[ch] << 1) | pbits[i * 2 + 0]);
+                    pFixedEndpoints[i].B[ch] = static_cast<uint8_t>((pFixedEndpoints[i].B[ch] << 1) | pbits[i * 2 + 1]);
+                }
+            }
+        }
+    }
+}
+
+_Use_decl_annotations_
+float D3DX_BC7::Refine(const EncodeParams* pEP, size_t uShape, size_t uRotation, size_t uIndexMode) noexcept
+{
+    assert(pEP);
+    assert(uShape < BC7_MAX_SHAPES);
+    _Analysis_assume_(uShape < BC7_MAX_SHAPES);
+    assert(pEP->uMode < c_NumModes);
+    _Analysis_assume_(pEP->uMode < c_NumModes);
+
+    const size_t uPartitions = ms_aInfo[pEP->uMode].uPartitions;
+    assert(uPartitions < BC7_MAX_REGIONS);
+    _Analysis_assume_(uPartitions < BC7_MAX_REGIONS);
+
+    LDREndPntPair aOrgEndPts[BC7_MAX_REGIONS];
+    LDREndPntPair aOptEndPts[BC7_MAX_REGIONS];
+    size_t aOrgIdx[NUM_PIXELS_PER_BLOCK];
+    size_t aOrgIdx2[NUM_PIXELS_PER_BLOCK];
+    size_t aOptIdx[NUM_PIXELS_PER_BLOCK];
+    size_t aOptIdx2[NUM_PIXELS_PER_BLOCK];
+    float aOrgErr[BC7_MAX_REGIONS];
+    float aOptErr[BC7_MAX_REGIONS];
+
+    const LDREndPntPair* aEndPts = &pEP->aEndPts[uShape][0];
+
+    for (size_t p = 0; p <= uPartitions; p++)
+    {
+#ifdef __GNUC__
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wstringop-overflow"
+#endif
+        aOrgEndPts[p].A = Quantize(aEndPts[p].A, ms_aInfo[pEP->uMode].RGBAPrecWithP);
+        aOrgEndPts[p].B = Quantize(aEndPts[p].B, ms_aInfo[pEP->uMode].RGBAPrecWithP);
+#ifdef __GNUC_
+#pragma GCC diagnostic pop
+#endif
+    }
+
+    LDREndPntPair newEndPts1[BC7_MAX_REGIONS];
+    FixEndpointPBits(pEP, aOrgEndPts, newEndPts1);
+
+    AssignIndices(pEP, uShape, uIndexMode, newEndPts1, aOrgIdx, aOrgIdx2, aOrgErr);
+
+    OptimizeEndPoints(pEP, uShape, uIndexMode, aOrgErr, newEndPts1, aOptEndPts);
+
+    LDREndPntPair newEndPts2[BC7_MAX_REGIONS];
+    FixEndpointPBits(pEP, aOptEndPts, newEndPts2);
+
+    AssignIndices(pEP, uShape, uIndexMode, newEndPts2, aOptIdx, aOptIdx2, aOptErr);
+
+    float fOrgTotErr = 0, fOptTotErr = 0;
+    for (size_t p = 0; p <= uPartitions; p++)
+    {
+        fOrgTotErr += aOrgErr[p];
+        fOptTotErr += aOptErr[p];
+    }
+    if (fOptTotErr < fOrgTotErr)
+    {
+        EmitBlock(pEP, uShape, uRotation, uIndexMode, newEndPts2, aOptIdx, aOptIdx2);
+        return fOptTotErr;
+    }
+    else
+    {
+        EmitBlock(pEP, uShape, uRotation, uIndexMode, newEndPts1, aOrgIdx, aOrgIdx2);
+        return fOrgTotErr;
+    }
+}
+
+_Use_decl_annotations_
+float D3DX_BC7::MapColors(const EncodeParams* pEP, const LDRColorA aColors[], size_t np, size_t uIndexMode, const LDREndPntPair& endPts, float fMinErr) const noexcept
+{
+    assert(pEP);
+    assert(pEP->uMode < c_NumModes);
+    _Analysis_assume_(pEP->uMode < c_NumModes);
+
+    const uint8_t uIndexPrec = uIndexMode ? ms_aInfo[pEP->uMode].uIndexPrec2 : ms_aInfo[pEP->uMode].uIndexPrec;
+    const uint8_t uIndexPrec2 = uIndexMode ? ms_aInfo[pEP->uMode].uIndexPrec : ms_aInfo[pEP->uMode].uIndexPrec2;
+    LDRColorA aPalette[BC7_MAX_INDICES];
+    float fTotalErr = 0;
+
+    GeneratePaletteQuantized(pEP, uIndexMode, endPts, aPalette);
+    for (size_t i = 0; i < np; ++i)
+    {
+        fTotalErr += ComputeError(aColors[i], aPalette, uIndexPrec, uIndexPrec2);
+        if (fTotalErr > fMinErr)   // check for early exit
+        {
+            fTotalErr = FLT_MAX;
+            break;
+        }
+    }
+
+    return fTotalErr;
+}
+
+_Use_decl_annotations_
+float D3DX_BC7::RoughMSE(EncodeParams* pEP, size_t uShape, size_t uIndexMode) noexcept
+{
+    assert(pEP);
+    assert(uShape < BC7_MAX_SHAPES);
+    _Analysis_assume_(uShape < BC7_MAX_SHAPES);
+    assert(pEP->uMode < c_NumModes);
+    _Analysis_assume_(pEP->uMode < c_NumModes);
+
+    LDREndPntPair* aEndPts = pEP->aEndPts[uShape];
+
+    const uint8_t uPartitions = ms_aInfo[pEP->uMode].uPartitions;
+    assert(uPartitions < BC7_MAX_REGIONS);
+    _Analysis_assume_(uPartitions < BC7_MAX_REGIONS);
+
+    const uint8_t uIndexPrec = uIndexMode ? ms_aInfo[pEP->uMode].uIndexPrec2 : ms_aInfo[pEP->uMode].uIndexPrec;
+    const uint8_t uIndexPrec2 = uIndexMode ? ms_aInfo[pEP->uMode].uIndexPrec : ms_aInfo[pEP->uMode].uIndexPrec2;
+    auto const uNumIndices = static_cast<const uint8_t>(1u << uIndexPrec);
+    auto const uNumIndices2 = static_cast<const uint8_t>(1u << uIndexPrec2);
+    size_t auPixIdx[NUM_PIXELS_PER_BLOCK];
+    LDRColorA aPalette[BC7_MAX_REGIONS][BC7_MAX_INDICES];
+
+    for (size_t p = 0; p <= uPartitions; p++)
+    {
+        size_t np = 0;
+        for (size_t i = 0; i < NUM_PIXELS_PER_BLOCK; i++)
+        {
+            if (g_aPartitionTable[uPartitions][uShape][i] == p)
+            {
+                auPixIdx[np++] = i;
+            }
+        }
+
+        // handle simple cases
+        assert(np > 0);
+        if (np == 1)
+        {
+            aEndPts[p].A = pEP->aLDRPixels[auPixIdx[0]];
+            aEndPts[p].B = pEP->aLDRPixels[auPixIdx[0]];
+            continue;
+        }
+        else if (np == 2)
+        {
+            aEndPts[p].A = pEP->aLDRPixels[auPixIdx[0]];
+            aEndPts[p].B = pEP->aLDRPixels[auPixIdx[1]];
+            continue;
+        }
+
+        if (uIndexPrec2 == 0)
+        {
+            HDRColorA epA, epB;
+            OptimizeRGBA(pEP->aHDRPixels, &epA, &epB, 4, np, auPixIdx);
+            epA.Clamp(0.0f, 1.0f);
+            epB.Clamp(0.0f, 1.0f);
+            epA *= 255.0f;
+            epB *= 255.0f;
+            aEndPts[p].A = epA.ToLDRColorA();
+            aEndPts[p].B = epB.ToLDRColorA();
+        }
+        else
+        {
+            uint8_t uMinAlpha = 255, uMaxAlpha = 0;
+            for (size_t i = 0; i < NUM_PIXELS_PER_BLOCK; ++i)
+            {
+                uMinAlpha = std::min<uint8_t>(uMinAlpha, pEP->aLDRPixels[auPixIdx[i]].a);
+                uMaxAlpha = std::max<uint8_t>(uMaxAlpha, pEP->aLDRPixels[auPixIdx[i]].a);
+            }
+
+            HDRColorA epA, epB;
+            OptimizeRGB(pEP->aHDRPixels, &epA, &epB, 4, np, auPixIdx);
+            epA.Clamp(0.0f, 1.0f);
+            epB.Clamp(0.0f, 1.0f);
+            epA *= 255.0f;
+            epB *= 255.0f;
+            aEndPts[p].A = epA.ToLDRColorA();
+            aEndPts[p].B = epB.ToLDRColorA();
+            aEndPts[p].A.a = uMinAlpha;
+            aEndPts[p].B.a = uMaxAlpha;
+        }
+    }
+
+    if (uIndexPrec2 == 0)
+    {
+        for (size_t p = 0; p <= uPartitions; p++)
+            for (size_t i = 0; i < uNumIndices; i++)
+                LDRColorA::Interpolate(aEndPts[p].A, aEndPts[p].B, i, i, uIndexPrec, uIndexPrec, aPalette[p][i]);
+    }
+    else
+    {
+        for (size_t p = 0; p <= uPartitions; p++)
+        {
+            for (size_t i = 0; i < uNumIndices; i++)
+                LDRColorA::InterpolateRGB(aEndPts[p].A, aEndPts[p].B, i, uIndexPrec, aPalette[p][i]);
+            for (size_t i = 0; i < uNumIndices2; i++)
+                LDRColorA::InterpolateA(aEndPts[p].A, aEndPts[p].B, i, uIndexPrec2, aPalette[p][i]);
+        }
+    }
+
+    float fTotalErr = 0;
+    for (size_t i = 0; i < NUM_PIXELS_PER_BLOCK; i++)
+    {
+        const uint8_t uRegion = g_aPartitionTable[uPartitions][uShape][i];
+        fTotalErr += ComputeError(pEP->aLDRPixels[i], aPalette[uRegion], uIndexPrec, uIndexPrec2);
+    }
+
+    return fTotalErr;
+}
+
+
+//=====================================================================================
+// Entry points
+//=====================================================================================
+
+//-------------------------------------------------------------------------------------
+// BC6H Compression
+//-------------------------------------------------------------------------------------
+_Use_decl_annotations_
+void DirectX::D3DXDecodeBC6HU(XMVECTOR *pColor, const uint8_t *pBC) noexcept
+{
+    assert(pColor && pBC);
+    static_assert(sizeof(D3DX_BC6H) == 16, "D3DX_BC6H should be 16 bytes");
+    reinterpret_cast<const D3DX_BC6H*>(pBC)->Decode(false, reinterpret_cast<HDRColorA*>(pColor));
+}
+
+_Use_decl_annotations_
+void DirectX::D3DXDecodeBC6HS(XMVECTOR *pColor, const uint8_t *pBC) noexcept
+{
+    assert(pColor && pBC);
+    static_assert(sizeof(D3DX_BC6H) == 16, "D3DX_BC6H should be 16 bytes");
+    reinterpret_cast<const D3DX_BC6H*>(pBC)->Decode(true, reinterpret_cast<HDRColorA*>(pColor));
+}
+
+_Use_decl_annotations_
+void DirectX::D3DXEncodeBC6HU(uint8_t *pBC, const XMVECTOR *pColor, uint32_t flags) noexcept
+{
+    UNREFERENCED_PARAMETER(flags);
+    assert(pBC && pColor);
+    static_assert(sizeof(D3DX_BC6H) == 16, "D3DX_BC6H should be 16 bytes");
+    reinterpret_cast<D3DX_BC6H*>(pBC)->Encode(false, reinterpret_cast<const HDRColorA*>(pColor));
+}
+
+_Use_decl_annotations_
+void DirectX::D3DXEncodeBC6HS(uint8_t *pBC, const XMVECTOR *pColor, uint32_t flags) noexcept
+{
+    UNREFERENCED_PARAMETER(flags);
+    assert(pBC && pColor);
+    static_assert(sizeof(D3DX_BC6H) == 16, "D3DX_BC6H should be 16 bytes");
+    reinterpret_cast<D3DX_BC6H*>(pBC)->Encode(true, reinterpret_cast<const HDRColorA*>(pColor));
+}
+
+
+//-------------------------------------------------------------------------------------
+// BC7 Compression
+//-------------------------------------------------------------------------------------
+_Use_decl_annotations_
+void DirectX::D3DXDecodeBC7(XMVECTOR *pColor, const uint8_t *pBC) noexcept
+{
+    assert(pColor && pBC);
+    static_assert(sizeof(D3DX_BC7) == 16, "D3DX_BC7 should be 16 bytes");
+    reinterpret_cast<const D3DX_BC7*>(pBC)->Decode(reinterpret_cast<HDRColorA*>(pColor));
+}
+
+_Use_decl_annotations_
+void DirectX::D3DXEncodeBC7(uint8_t *pBC, const XMVECTOR *pColor, uint32_t flags) noexcept
+{
+    assert(pBC && pColor);
+    static_assert(sizeof(D3DX_BC7) == 16, "D3DX_BC7 should be 16 bytes");
+    reinterpret_cast<D3DX_BC7*>(pBC)->Encode(flags, reinterpret_cast<const HDRColorA*>(pColor));
+}

--- a/DirectXTex/DirectXTex/DDS.h
+++ b/DirectXTex/DirectXTex/DDS.h
@@ -1,0 +1,291 @@
+//--------------------------------------------------------------------------------------
+// DDS.h
+//
+// This header defines constants and structures that are useful when parsing
+// DDS files.  DDS files were originally designed to use several structures
+// and constants that are native to DirectDraw and are defined in ddraw.h,
+// such as DDSURFACEDESC2 and DDSCAPS2.  This file defines similar
+// (compatible) constants and structures so that one can use DDS files
+// without needing to include ddraw.h.
+//
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+//
+// http://go.microsoft.com/fwlink/?LinkId=248926
+// http://go.microsoft.com/fwlink/?LinkId=248929
+// http://go.microsoft.com/fwlink/?LinkID=615561
+//--------------------------------------------------------------------------------------
+
+#pragma once
+
+#include <cstdint>
+
+namespace DirectX
+{
+
+#pragma pack(push,1)
+
+    constexpr uint32_t DDS_MAGIC = 0x20534444; // "DDS "
+
+    struct DDS_PIXELFORMAT
+    {
+        uint32_t    size;
+        uint32_t    flags;
+        uint32_t    fourCC;
+        uint32_t    RGBBitCount;
+        uint32_t    RBitMask;
+        uint32_t    GBitMask;
+        uint32_t    BBitMask;
+        uint32_t    ABitMask;
+    };
+
+#define DDS_FOURCC      0x00000004  // DDPF_FOURCC
+#define DDS_RGB         0x00000040  // DDPF_RGB
+#define DDS_RGBA        0x00000041  // DDPF_RGB | DDPF_ALPHAPIXELS
+#define DDS_LUMINANCE   0x00020000  // DDPF_LUMINANCE
+#define DDS_LUMINANCEA  0x00020001  // DDPF_LUMINANCE | DDPF_ALPHAPIXELS
+#define DDS_ALPHAPIXELS 0x00000001  // DDPF_ALPHAPIXELS
+#define DDS_ALPHA       0x00000002  // DDPF_ALPHA
+#define DDS_PAL8        0x00000020  // DDPF_PALETTEINDEXED8
+#define DDS_PAL8A       0x00000021  // DDPF_PALETTEINDEXED8 | DDPF_ALPHAPIXELS
+#define DDS_BUMPDUDV    0x00080000  // DDPF_BUMPDUDV
+// DDS_BUMPLUMINANCE 0x00040000
+
+#ifndef MAKEFOURCC
+#define MAKEFOURCC(ch0, ch1, ch2, ch3) \
+                (static_cast<uint32_t>(static_cast<uint8_t>(ch0)) \
+                | (static_cast<uint32_t>(static_cast<uint8_t>(ch1)) << 8) \
+                | (static_cast<uint32_t>(static_cast<uint8_t>(ch2)) << 16) \
+                | (static_cast<uint32_t>(static_cast<uint8_t>(ch3)) << 24))
+#endif /* MAKEFOURCC */
+
+#ifndef DDSGLOBALCONST
+#if defined(__GNUC__) && !defined(__MINGW32__)
+#define DDSGLOBALCONST extern const __attribute__((weak))
+#else
+#define DDSGLOBALCONST extern const __declspec(selectany)
+#endif
+#endif /* DDSGLOBALCONST */
+
+    DDSGLOBALCONST DDS_PIXELFORMAT DDSPF_DXT1 =
+    { sizeof(DDS_PIXELFORMAT), DDS_FOURCC, MAKEFOURCC('D','X','T','1'), 0, 0, 0, 0, 0 };
+
+    DDSGLOBALCONST DDS_PIXELFORMAT DDSPF_DXT2 =
+    { sizeof(DDS_PIXELFORMAT), DDS_FOURCC, MAKEFOURCC('D','X','T','2'), 0, 0, 0, 0, 0 };
+
+    DDSGLOBALCONST DDS_PIXELFORMAT DDSPF_DXT3 =
+    { sizeof(DDS_PIXELFORMAT), DDS_FOURCC, MAKEFOURCC('D','X','T','3'), 0, 0, 0, 0, 0 };
+
+    DDSGLOBALCONST DDS_PIXELFORMAT DDSPF_DXT4 =
+    { sizeof(DDS_PIXELFORMAT), DDS_FOURCC, MAKEFOURCC('D','X','T','4'), 0, 0, 0, 0, 0 };
+
+    DDSGLOBALCONST DDS_PIXELFORMAT DDSPF_DXT5 =
+    { sizeof(DDS_PIXELFORMAT), DDS_FOURCC, MAKEFOURCC('D','X','T','5'), 0, 0, 0, 0, 0 };
+
+    DDSGLOBALCONST DDS_PIXELFORMAT DDSPF_BC4_UNORM =
+    { sizeof(DDS_PIXELFORMAT), DDS_FOURCC, MAKEFOURCC('B','C','4','U'), 0, 0, 0, 0, 0 };
+
+    DDSGLOBALCONST DDS_PIXELFORMAT DDSPF_BC4_SNORM =
+    { sizeof(DDS_PIXELFORMAT), DDS_FOURCC, MAKEFOURCC('B','C','4','S'), 0, 0, 0, 0, 0 };
+
+    DDSGLOBALCONST DDS_PIXELFORMAT DDSPF_BC5_UNORM =
+    { sizeof(DDS_PIXELFORMAT), DDS_FOURCC, MAKEFOURCC('B','C','5','U'), 0, 0, 0, 0, 0 };
+
+    DDSGLOBALCONST DDS_PIXELFORMAT DDSPF_BC5_SNORM =
+    { sizeof(DDS_PIXELFORMAT), DDS_FOURCC, MAKEFOURCC('B','C','5','S'), 0, 0, 0, 0, 0 };
+
+    DDSGLOBALCONST DDS_PIXELFORMAT DDSPF_R8G8_B8G8 =
+    { sizeof(DDS_PIXELFORMAT), DDS_FOURCC, MAKEFOURCC('R','G','B','G'), 0, 0, 0, 0, 0 };
+
+    DDSGLOBALCONST DDS_PIXELFORMAT DDSPF_G8R8_G8B8 =
+    { sizeof(DDS_PIXELFORMAT), DDS_FOURCC, MAKEFOURCC('G','R','G','B'), 0, 0, 0, 0, 0 };
+
+    DDSGLOBALCONST DDS_PIXELFORMAT DDSPF_YUY2 =
+    { sizeof(DDS_PIXELFORMAT), DDS_FOURCC, MAKEFOURCC('Y','U','Y','2'), 0, 0, 0, 0, 0 };
+
+    DDSGLOBALCONST DDS_PIXELFORMAT DDSPF_UYVY =
+    { sizeof(DDS_PIXELFORMAT), DDS_FOURCC, MAKEFOURCC('U','Y','V','Y'), 0, 0, 0, 0, 0 };
+
+    DDSGLOBALCONST DDS_PIXELFORMAT DDSPF_A8R8G8B8 =
+    { sizeof(DDS_PIXELFORMAT), DDS_RGBA, 0, 32, 0x00ff0000, 0x0000ff00, 0x000000ff, 0xff000000 };
+
+    DDSGLOBALCONST DDS_PIXELFORMAT DDSPF_X8R8G8B8 =
+    { sizeof(DDS_PIXELFORMAT), DDS_RGB,  0, 32, 0x00ff0000, 0x0000ff00, 0x000000ff, 0 };
+
+    DDSGLOBALCONST DDS_PIXELFORMAT DDSPF_A8B8G8R8 =
+    { sizeof(DDS_PIXELFORMAT), DDS_RGBA, 0, 32, 0x000000ff, 0x0000ff00, 0x00ff0000, 0xff000000 };
+
+    DDSGLOBALCONST DDS_PIXELFORMAT DDSPF_X8B8G8R8 =
+    { sizeof(DDS_PIXELFORMAT), DDS_RGB,  0, 32, 0x000000ff, 0x0000ff00, 0x00ff0000, 0 };
+
+    DDSGLOBALCONST DDS_PIXELFORMAT DDSPF_G16R16 =
+    { sizeof(DDS_PIXELFORMAT), DDS_RGB,  0, 32, 0x0000ffff, 0xffff0000, 0, 0 };
+
+    DDSGLOBALCONST DDS_PIXELFORMAT DDSPF_R5G6B5 =
+    { sizeof(DDS_PIXELFORMAT), DDS_RGB, 0, 16, 0xf800, 0x07e0, 0x001f, 0 };
+
+    DDSGLOBALCONST DDS_PIXELFORMAT DDSPF_A1R5G5B5 =
+    { sizeof(DDS_PIXELFORMAT), DDS_RGBA, 0, 16, 0x7c00, 0x03e0, 0x001f, 0x8000 };
+
+    DDSGLOBALCONST DDS_PIXELFORMAT DDSPF_X1R5G5B5 =
+    { sizeof(DDS_PIXELFORMAT), DDS_RGB, 0, 16, 0x7c00, 0x03e0, 0x001f, 0 };
+
+    DDSGLOBALCONST DDS_PIXELFORMAT DDSPF_A4R4G4B4 =
+    { sizeof(DDS_PIXELFORMAT), DDS_RGBA, 0, 16, 0x0f00, 0x00f0, 0x000f, 0xf000 };
+
+    DDSGLOBALCONST DDS_PIXELFORMAT DDSPF_X4R4G4B4 =
+    { sizeof(DDS_PIXELFORMAT), DDS_RGB, 0, 16, 0x0f00, 0x00f0, 0x000f, 0 };
+
+    DDSGLOBALCONST DDS_PIXELFORMAT DDSPF_R8G8B8 =
+    { sizeof(DDS_PIXELFORMAT), DDS_RGB, 0, 24, 0xff0000, 0x00ff00, 0x0000ff, 0 };
+
+    DDSGLOBALCONST DDS_PIXELFORMAT DDSPF_A8R3G3B2 =
+    { sizeof(DDS_PIXELFORMAT), DDS_RGBA, 0, 16, 0x00e0, 0x001c, 0x0003, 0xff00 };
+
+    DDSGLOBALCONST DDS_PIXELFORMAT DDSPF_R3G3B2 =
+    { sizeof(DDS_PIXELFORMAT), DDS_RGB, 0, 8, 0xe0, 0x1c, 0x03, 0 };
+
+    DDSGLOBALCONST DDS_PIXELFORMAT DDSPF_A4L4 =
+    { sizeof(DDS_PIXELFORMAT), DDS_LUMINANCEA, 0, 8, 0x0f, 0, 0, 0xf0 };
+
+    DDSGLOBALCONST DDS_PIXELFORMAT DDSPF_L8 =
+    { sizeof(DDS_PIXELFORMAT), DDS_LUMINANCE, 0, 8, 0xff, 0, 0, 0 };
+
+    DDSGLOBALCONST DDS_PIXELFORMAT DDSPF_L16 =
+    { sizeof(DDS_PIXELFORMAT), DDS_LUMINANCE, 0, 16, 0xffff, 0, 0, 0 };
+
+    DDSGLOBALCONST DDS_PIXELFORMAT DDSPF_A8L8 =
+    { sizeof(DDS_PIXELFORMAT), DDS_LUMINANCEA, 0, 16, 0x00ff, 0, 0, 0xff00 };
+
+    DDSGLOBALCONST DDS_PIXELFORMAT DDSPF_A8L8_ALT =
+    { sizeof(DDS_PIXELFORMAT), DDS_LUMINANCEA, 0, 8, 0x00ff, 0, 0, 0xff00 };
+
+    DDSGLOBALCONST DDS_PIXELFORMAT DDSPF_L8_NVTT1 =
+    { sizeof(DDS_PIXELFORMAT), DDS_RGB, 0, 8, 0xff, 0, 0, 0 };
+
+    DDSGLOBALCONST DDS_PIXELFORMAT DDSPF_L16_NVTT1 =
+    { sizeof(DDS_PIXELFORMAT), DDS_RGB, 0, 16, 0xffff, 0, 0, 0 };
+
+    DDSGLOBALCONST DDS_PIXELFORMAT DDSPF_A8L8_NVTT1 =
+    { sizeof(DDS_PIXELFORMAT), DDS_RGBA, 0, 16, 0x00ff, 0, 0, 0xff00 };
+
+    DDSGLOBALCONST DDS_PIXELFORMAT DDSPF_A8 =
+    { sizeof(DDS_PIXELFORMAT), DDS_ALPHA, 0, 8, 0, 0, 0, 0xff };
+
+    DDSGLOBALCONST DDS_PIXELFORMAT DDSPF_V8U8 =
+    { sizeof(DDS_PIXELFORMAT), DDS_BUMPDUDV, 0, 16, 0x00ff, 0xff00, 0, 0 };
+
+    DDSGLOBALCONST DDS_PIXELFORMAT DDSPF_Q8W8V8U8 =
+    { sizeof(DDS_PIXELFORMAT), DDS_BUMPDUDV, 0, 32, 0x000000ff, 0x0000ff00, 0x00ff0000, 0xff000000 };
+
+    DDSGLOBALCONST DDS_PIXELFORMAT DDSPF_V16U16 =
+    { sizeof(DDS_PIXELFORMAT), DDS_BUMPDUDV, 0, 32, 0x0000ffff, 0xffff0000, 0, 0 };
+
+// D3DFMT_A2R10G10B10/D3DFMT_A2B10G10R10 should be written using DX10 extension to avoid D3DX 10:10:10:2 reversal issue
+    DDSGLOBALCONST DDS_PIXELFORMAT DDSPF_A2R10G10B10 =
+    { sizeof(DDS_PIXELFORMAT), DDS_RGBA, 0, 32, 0x000003ff, 0x000ffc00, 0x3ff00000, 0xc0000000 };
+    DDSGLOBALCONST DDS_PIXELFORMAT DDSPF_A2B10G10R10 =
+    { sizeof(DDS_PIXELFORMAT), DDS_RGBA, 0, 32, 0x3ff00000, 0x000ffc00, 0x000003ff, 0xc0000000 };
+
+// We do not support the following legacy Direct3D 9 formats:
+// DDSPF_A2W10V10U10 = { sizeof(DDS_PIXELFORMAT), DDS_BUMPDUDV, 0, 32, 0x3ff00000, 0x000ffc00, 0x000003ff, 0xc0000000 };
+// DDSPF_L6V5U5 = { sizeof(DDS_PIXELFORMAT), DDS_BUMPLUMINANCE, 0, 16, 0x001f, 0x03e0, 0xfc00, 0 };
+// DDSPF_X8L8V8U8 = { sizeof(DDS_PIXELFORMAT), DDS_BUMPLUMINANCE, 0, 32, 0x000000ff, 0x0000ff00, 0x00ff0000, 0 };
+
+// This indicates the DDS_HEADER_DXT10 extension is present (the format is in dxgiFormat)
+    DDSGLOBALCONST DDS_PIXELFORMAT DDSPF_DX10 =
+    { sizeof(DDS_PIXELFORMAT), DDS_FOURCC, MAKEFOURCC('D','X','1','0'), 0, 0, 0, 0, 0 };
+
+#define DDS_HEADER_FLAGS_TEXTURE        0x00001007  // DDSD_CAPS | DDSD_HEIGHT | DDSD_WIDTH | DDSD_PIXELFORMAT
+#define DDS_HEADER_FLAGS_MIPMAP         0x00020000  // DDSD_MIPMAPCOUNT
+#define DDS_HEADER_FLAGS_VOLUME         0x00800000  // DDSD_DEPTH
+#define DDS_HEADER_FLAGS_PITCH          0x00000008  // DDSD_PITCH
+#define DDS_HEADER_FLAGS_LINEARSIZE     0x00080000  // DDSD_LINEARSIZE
+
+#define DDS_HEIGHT 0x00000002 // DDSD_HEIGHT
+#define DDS_WIDTH  0x00000004 // DDSD_WIDTH
+
+#define DDS_SURFACE_FLAGS_TEXTURE 0x00001000 // DDSCAPS_TEXTURE
+#define DDS_SURFACE_FLAGS_MIPMAP  0x00400008 // DDSCAPS_COMPLEX | DDSCAPS_MIPMAP
+#define DDS_SURFACE_FLAGS_CUBEMAP 0x00000008 // DDSCAPS_COMPLEX
+
+#define DDS_CUBEMAP_POSITIVEX 0x00000600 // DDSCAPS2_CUBEMAP | DDSCAPS2_CUBEMAP_POSITIVEX
+#define DDS_CUBEMAP_NEGATIVEX 0x00000a00 // DDSCAPS2_CUBEMAP | DDSCAPS2_CUBEMAP_NEGATIVEX
+#define DDS_CUBEMAP_POSITIVEY 0x00001200 // DDSCAPS2_CUBEMAP | DDSCAPS2_CUBEMAP_POSITIVEY
+#define DDS_CUBEMAP_NEGATIVEY 0x00002200 // DDSCAPS2_CUBEMAP | DDSCAPS2_CUBEMAP_NEGATIVEY
+#define DDS_CUBEMAP_POSITIVEZ 0x00004200 // DDSCAPS2_CUBEMAP | DDSCAPS2_CUBEMAP_POSITIVEZ
+#define DDS_CUBEMAP_NEGATIVEZ 0x00008200 // DDSCAPS2_CUBEMAP | DDSCAPS2_CUBEMAP_NEGATIVEZ
+
+#define DDS_CUBEMAP_ALLFACES ( DDS_CUBEMAP_POSITIVEX | DDS_CUBEMAP_NEGATIVEX |\
+                               DDS_CUBEMAP_POSITIVEY | DDS_CUBEMAP_NEGATIVEY |\
+                               DDS_CUBEMAP_POSITIVEZ | DDS_CUBEMAP_NEGATIVEZ )
+
+#define DDS_CUBEMAP 0x00000200 // DDSCAPS2_CUBEMAP
+
+#define DDS_FLAGS_VOLUME 0x00200000 // DDSCAPS2_VOLUME
+
+// Subset here matches D3D10_RESOURCE_DIMENSION and D3D11_RESOURCE_DIMENSION
+    enum DDS_RESOURCE_DIMENSION : uint32_t
+    {
+        DDS_DIMENSION_TEXTURE1D = 2,
+        DDS_DIMENSION_TEXTURE2D = 3,
+        DDS_DIMENSION_TEXTURE3D = 4,
+    };
+
+    // Subset here matches D3D10_RESOURCE_MISC_FLAG and D3D11_RESOURCE_MISC_FLAG
+    enum DDS_RESOURCE_MISC_FLAG : uint32_t
+    {
+        DDS_RESOURCE_MISC_TEXTURECUBE = 0x4L,
+    };
+
+    enum DDS_MISC_FLAGS2 : uint32_t
+    {
+        DDS_MISC_FLAGS2_ALPHA_MODE_MASK = 0x7L,
+    };
+
+#ifndef DDS_ALPHA_MODE_DEFINED
+#define DDS_ALPHA_MODE_DEFINED
+    enum DDS_ALPHA_MODE : uint32_t
+    {
+        DDS_ALPHA_MODE_UNKNOWN = 0,
+        DDS_ALPHA_MODE_STRAIGHT = 1,
+        DDS_ALPHA_MODE_PREMULTIPLIED = 2,
+        DDS_ALPHA_MODE_OPAQUE = 3,
+        DDS_ALPHA_MODE_CUSTOM = 4,
+    };
+#endif
+
+    struct DDS_HEADER
+    {
+        uint32_t        size;
+        uint32_t        flags;
+        uint32_t        height;
+        uint32_t        width;
+        uint32_t        pitchOrLinearSize;
+        uint32_t        depth; // only if DDS_HEADER_FLAGS_VOLUME is set in flags
+        uint32_t        mipMapCount;
+        uint32_t        reserved1[11];
+        DDS_PIXELFORMAT ddspf;
+        uint32_t        caps;
+        uint32_t        caps2;
+        uint32_t        caps3;
+        uint32_t        caps4;
+        uint32_t        reserved2;
+    };
+
+    struct DDS_HEADER_DXT10
+    {
+        DXGI_FORMAT     dxgiFormat;
+        uint32_t        resourceDimension;
+        uint32_t        miscFlag; // see D3D11_RESOURCE_MISC_FLAG
+        uint32_t        arraySize;
+        uint32_t        miscFlags2; // see DDS_MISC_FLAGS2
+    };
+
+#pragma pack(pop)
+
+    static_assert(sizeof(DDS_PIXELFORMAT) == 32, "DDS pixel format size mismatch");
+    static_assert(sizeof(DDS_HEADER) == 124, "DDS Header size mismatch");
+    static_assert(sizeof(DDS_HEADER_DXT10) == 20, "DDS DX10 Extended Header size mismatch");
+
+} // namespace

--- a/DirectXTex/DirectXTex/DirectXTex.h
+++ b/DirectXTex/DirectXTex/DirectXTex.h
@@ -1,0 +1,1036 @@
+//-------------------------------------------------------------------------------------
+// DirectXTex.h
+//
+// DirectX Texture Library
+//
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+//
+// http://go.microsoft.com/fwlink/?LinkId=248926
+//-------------------------------------------------------------------------------------
+
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+#include <functional>
+#include <utility>
+#include <vector>
+
+#ifdef _WIN32
+#if !defined(__d3d11_h__) && !defined(__d3d11_x_h__) && !defined(__d3d12_h__) && !defined(__d3d12_x_h__) && !defined(__XBOX_D3D12_X__)
+#ifdef _GAMING_XBOX_SCARLETT
+#include <d3d12_xs.h>
+#elif defined(_GAMING_XBOX)
+#include <d3d12_x.h>
+#elif defined(_XBOX_ONE) && defined(_TITLE)
+#include <d3d11_x.h>
+#else
+#include <d3d11_1.h>
+#endif
+#endif
+#else // !WIN32
+#include <directx/dxgiformat.h>
+#include <wsl/winadapter.h>
+#endif
+
+#include <DirectXMath.h>
+
+#ifdef _WIN32
+#if defined(NTDDI_WIN10_FE) || defined(__MINGW32__)
+#include <ocidl.h>
+#else
+#include <OCIdl.h>
+#endif
+
+struct IWICImagingFactory;
+struct IWICMetadataQueryReader;
+#endif
+
+#define DIRECTX_TEX_VERSION 203
+
+
+namespace DirectX
+{
+
+    //---------------------------------------------------------------------------------
+    // DXGI Format Utilities
+    constexpr bool __cdecl IsValid(_In_ DXGI_FORMAT fmt) noexcept;
+    bool __cdecl IsCompressed(_In_ DXGI_FORMAT fmt) noexcept;
+    bool __cdecl IsPacked(_In_ DXGI_FORMAT fmt) noexcept;
+    bool __cdecl IsVideo(_In_ DXGI_FORMAT fmt) noexcept;
+    bool __cdecl IsPlanar(_In_ DXGI_FORMAT fmt) noexcept;
+    bool __cdecl IsPalettized(_In_ DXGI_FORMAT fmt) noexcept;
+    bool __cdecl IsDepthStencil(_In_ DXGI_FORMAT fmt) noexcept;
+    bool __cdecl IsSRGB(_In_ DXGI_FORMAT fmt) noexcept;
+    bool __cdecl IsBGR(_In_ DXGI_FORMAT fmt) noexcept;
+    bool __cdecl IsTypeless(_In_ DXGI_FORMAT fmt, _In_ bool partialTypeless = true) noexcept;
+
+    bool __cdecl HasAlpha(_In_ DXGI_FORMAT fmt) noexcept;
+
+    size_t __cdecl BitsPerPixel(_In_ DXGI_FORMAT fmt) noexcept;
+
+    size_t __cdecl BitsPerColor(_In_ DXGI_FORMAT fmt) noexcept;
+
+    enum FORMAT_TYPE
+    {
+        FORMAT_TYPE_TYPELESS,
+        FORMAT_TYPE_FLOAT,
+        FORMAT_TYPE_UNORM,
+        FORMAT_TYPE_SNORM,
+        FORMAT_TYPE_UINT,
+        FORMAT_TYPE_SINT,
+    };
+
+    FORMAT_TYPE __cdecl FormatDataType(_In_ DXGI_FORMAT fmt) noexcept;
+
+    enum CP_FLAGS : unsigned long
+    {
+        CP_FLAGS_NONE = 0x0,
+        // Normal operation
+
+        CP_FLAGS_LEGACY_DWORD = 0x1,
+        // Assume pitch is DWORD aligned instead of BYTE aligned
+
+        CP_FLAGS_PARAGRAPH = 0x2,
+        // Assume pitch is 16-byte aligned instead of BYTE aligned
+
+        CP_FLAGS_YMM = 0x4,
+        // Assume pitch is 32-byte aligned instead of BYTE aligned
+
+        CP_FLAGS_ZMM = 0x8,
+        // Assume pitch is 64-byte aligned instead of BYTE aligned
+
+        CP_FLAGS_PAGE4K = 0x200,
+        // Assume pitch is 4096-byte aligned instead of BYTE aligned
+
+        CP_FLAGS_BAD_DXTN_TAILS = 0x1000,
+        // BC formats with malformed mipchain blocks smaller than 4x4
+
+        CP_FLAGS_24BPP = 0x10000,
+        // Override with a legacy 24 bits-per-pixel format size
+
+        CP_FLAGS_16BPP = 0x20000,
+        // Override with a legacy 16 bits-per-pixel format size
+
+        CP_FLAGS_8BPP = 0x40000,
+        // Override with a legacy 8 bits-per-pixel format size
+
+        CP_FLAGS_LIMIT_4GB = 0x10000000,
+        // Don't allow pixel allocations in excess of 4GB (always true for 32-bit)
+    };
+
+    HRESULT __cdecl ComputePitch(
+        _In_ DXGI_FORMAT fmt, _In_ size_t width, _In_ size_t height,
+        _Out_ size_t& rowPitch, _Out_ size_t& slicePitch, _In_ CP_FLAGS flags = CP_FLAGS_NONE) noexcept;
+
+    size_t __cdecl ComputeScanlines(_In_ DXGI_FORMAT fmt, _In_ size_t height) noexcept;
+
+    DXGI_FORMAT __cdecl MakeSRGB(_In_ DXGI_FORMAT fmt) noexcept;
+    DXGI_FORMAT __cdecl MakeLinear(_In_ DXGI_FORMAT fmt) noexcept;
+    DXGI_FORMAT __cdecl MakeTypeless(_In_ DXGI_FORMAT fmt) noexcept;
+    DXGI_FORMAT __cdecl MakeTypelessUNORM(_In_ DXGI_FORMAT fmt) noexcept;
+    DXGI_FORMAT __cdecl MakeTypelessFLOAT(_In_ DXGI_FORMAT fmt) noexcept;
+
+    //---------------------------------------------------------------------------------
+    // Texture metadata
+    enum TEX_DIMENSION
+        // Subset here matches D3D10_RESOURCE_DIMENSION and D3D11_RESOURCE_DIMENSION
+    {
+        TEX_DIMENSION_TEXTURE1D = 2,
+        TEX_DIMENSION_TEXTURE2D = 3,
+        TEX_DIMENSION_TEXTURE3D = 4,
+    };
+
+    enum TEX_MISC_FLAG : unsigned long
+        // Subset here matches D3D10_RESOURCE_MISC_FLAG and D3D11_RESOURCE_MISC_FLAG
+    {
+        TEX_MISC_TEXTURECUBE = 0x4L,
+    };
+
+    enum TEX_MISC_FLAG2 : unsigned long
+    {
+        TEX_MISC2_ALPHA_MODE_MASK = 0x7L,
+    };
+
+    enum TEX_ALPHA_MODE
+        // Matches DDS_ALPHA_MODE, encoded in MISC_FLAGS2
+    {
+        TEX_ALPHA_MODE_UNKNOWN = 0,
+        TEX_ALPHA_MODE_STRAIGHT = 1,
+        TEX_ALPHA_MODE_PREMULTIPLIED = 2,
+        TEX_ALPHA_MODE_OPAQUE = 3,
+        TEX_ALPHA_MODE_CUSTOM = 4,
+    };
+
+    struct TexMetadata
+    {
+        size_t          width;
+        size_t          height;     // Should be 1 for 1D textures
+        size_t          depth;      // Should be 1 for 1D or 2D textures
+        size_t          arraySize;  // For cubemap, this is a multiple of 6
+        size_t          mipLevels;
+        uint32_t        miscFlags;
+        uint32_t        miscFlags2;
+        DXGI_FORMAT     format;
+        TEX_DIMENSION   dimension;
+
+        size_t __cdecl ComputeIndex(size_t mip, size_t item, size_t slice) const noexcept;
+            // Returns size_t(-1) to indicate an out-of-range error
+
+        bool __cdecl IsCubemap() const noexcept { return (miscFlags & TEX_MISC_TEXTURECUBE) != 0; }
+            // Helper for miscFlags
+
+        bool __cdecl IsPMAlpha() const noexcept { return ((miscFlags2 & TEX_MISC2_ALPHA_MODE_MASK) == TEX_ALPHA_MODE_PREMULTIPLIED) != 0; }
+        void __cdecl SetAlphaMode(TEX_ALPHA_MODE mode) noexcept { miscFlags2 = (miscFlags2 & ~static_cast<uint32_t>(TEX_MISC2_ALPHA_MODE_MASK)) | static_cast<uint32_t>(mode); }
+        TEX_ALPHA_MODE __cdecl GetAlphaMode() const noexcept { return static_cast<TEX_ALPHA_MODE>(miscFlags2 & TEX_MISC2_ALPHA_MODE_MASK); }
+            // Helpers for miscFlags2
+
+        bool __cdecl IsVolumemap() const noexcept { return (dimension == TEX_DIMENSION_TEXTURE3D); }
+            // Helper for dimension
+
+        uint32_t __cdecl CalculateSubresource(size_t mip, size_t item) const noexcept;
+        uint32_t __cdecl CalculateSubresource(size_t mip, size_t item, size_t plane) const noexcept;
+            // Returns size_t(-1) to indicate an out-of-range error
+    };
+
+    struct DDSMetaData
+    {
+        uint32_t    size;           // DDPIXELFORMAT.dwSize
+        uint32_t    flags;          // DDPIXELFORMAT.dwFlags
+        uint32_t    fourCC;         // DDPIXELFORMAT.dwFourCC
+        uint32_t    RGBBitCount;    // DDPIXELFORMAT.dwRGBBitCount/dwYUVBitCount/dwAlphaBitDepth/dwLuminanceBitCount/dwBumpBitCount
+        uint32_t    RBitMask;       // DDPIXELFORMAT.dwRBitMask/dwYBitMask/dwLuminanceBitMask/dwBumpDuBitMask
+        uint32_t    GBitMask;       // DDPIXELFORMAT.dwGBitMask/dwUBitMask/dwBumpDvBitMask
+        uint32_t    BBitMask;       // DDPIXELFORMAT.dwBBitMask/dwVBitMask/dwBumpLuminanceBitMask
+        uint32_t    ABitMask;       // DDPIXELFORMAT.dwRGBAlphaBitMask/dwYUVAlphaBitMask/dwLuminanceAlphaBitMask
+
+        bool __cdecl IsDX10() const noexcept { return (fourCC == 0x30315844); }
+    };
+
+    enum DDS_FLAGS : unsigned long
+    {
+        DDS_FLAGS_NONE = 0x0,
+
+        DDS_FLAGS_LEGACY_DWORD = 0x1,
+        // Assume pitch is DWORD aligned instead of BYTE aligned (used by some legacy DDS files)
+
+        DDS_FLAGS_NO_LEGACY_EXPANSION = 0x2,
+        // Do not implicitly convert legacy formats that result in larger pixel sizes (24 bpp, 3:3:2, A8L8, A4L4, P8, A8P8)
+
+        DDS_FLAGS_NO_R10B10G10A2_FIXUP = 0x4,
+        // Do not use work-around for long-standing D3DX DDS file format issue which reversed the 10:10:10:2 color order masks
+
+        DDS_FLAGS_FORCE_RGB = 0x8,
+        // Convert DXGI 1.1 BGR formats to DXGI_FORMAT_R8G8B8A8_UNORM to avoid use of optional WDDM 1.1 formats
+
+        DDS_FLAGS_NO_16BPP = 0x10,
+        // Conversions avoid use of 565, 5551, and 4444 formats and instead expand to 8888 to avoid use of optional WDDM 1.2 formats
+
+        DDS_FLAGS_EXPAND_LUMINANCE = 0x20,
+        // When loading legacy luminance formats expand replicating the color channels rather than leaving them packed (L8, L16, A8L8)
+
+        DDS_FLAGS_BAD_DXTN_TAILS = 0x40,
+        // Some older DXTn DDS files incorrectly handle mipchain tails for blocks smaller than 4x4
+
+        DDS_FLAGS_PERMISSIVE = 0x80,
+        // Allow some file variants due to common bugs in the header written by various leagcy DDS writers
+
+        DDS_FLAGS_FORCE_DX10_EXT = 0x10000,
+        // Always use the 'DX10' header extension for DDS writer (i.e. don't try to write DX9 compatible DDS files)
+
+        DDS_FLAGS_FORCE_DX10_EXT_MISC2 = 0x20000,
+        // DDS_FLAGS_FORCE_DX10_EXT including miscFlags2 information (result may not be compatible with D3DX10 or D3DX11)
+
+        DDS_FLAGS_FORCE_DX9_LEGACY = 0x40000,
+        // Force use of legacy header for DDS writer (will fail if unable to write as such)
+
+        DDS_FLAGS_FORCE_DXT5_RXGB = 0x80000,
+        // Force use of 'RXGB' instead of 'DXT5' for DDS write of BC3_UNORM data
+
+        DDS_FLAGS_ALLOW_LARGE_FILES = 0x1000000,
+        // Enables the loader to read large dimension .dds files (i.e. greater than known hardware requirements)
+    };
+
+    enum TGA_FLAGS : unsigned long
+    {
+        TGA_FLAGS_NONE = 0x0,
+
+        TGA_FLAGS_BGR = 0x1,
+        // 24bpp files are returned as BGRX; 32bpp files are returned as BGRA
+
+        TGA_FLAGS_ALLOW_ALL_ZERO_ALPHA = 0x2,
+        // If the loaded image has an all zero alpha channel, normally we assume it should be opaque. This flag leaves it alone.
+
+        TGA_FLAGS_IGNORE_SRGB = 0x10,
+        // Ignores sRGB TGA 2.0 metadata if present in the file
+
+        TGA_FLAGS_FORCE_SRGB = 0x20,
+        // Writes sRGB metadata into the file reguardless of format (TGA 2.0 only)
+
+        TGA_FLAGS_FORCE_LINEAR = 0x40,
+        // Writes linear gamma metadata into the file reguardless of format (TGA 2.0 only)
+
+        TGA_FLAGS_DEFAULT_SRGB = 0x80,
+        // If no colorspace is specified in TGA 2.0 metadata, assume sRGB
+    };
+
+    enum WIC_FLAGS : unsigned long
+    {
+        WIC_FLAGS_NONE = 0x0,
+
+        WIC_FLAGS_FORCE_RGB = 0x1,
+        // Loads DXGI 1.1 BGR formats as DXGI_FORMAT_R8G8B8A8_UNORM to avoid use of optional WDDM 1.1 formats
+
+        WIC_FLAGS_NO_X2_BIAS = 0x2,
+        // Loads DXGI 1.1 X2 10:10:10:2 format as DXGI_FORMAT_R10G10B10A2_UNORM
+
+        WIC_FLAGS_NO_16BPP = 0x4,
+        // Loads 565, 5551, and 4444 formats as 8888 to avoid use of optional WDDM 1.2 formats
+
+        WIC_FLAGS_ALLOW_MONO = 0x8,
+        // Loads 1-bit monochrome (black & white) as R1_UNORM rather than 8-bit grayscale
+
+        WIC_FLAGS_ALL_FRAMES = 0x10,
+        // Loads all images in a multi-frame file, converting/resizing to match the first frame as needed, defaults to 0th frame otherwise
+
+        WIC_FLAGS_IGNORE_SRGB = 0x20,
+        // Ignores sRGB metadata if present in the file
+
+        WIC_FLAGS_FORCE_SRGB = 0x40,
+        // Writes sRGB metadata into the file reguardless of format
+
+        WIC_FLAGS_FORCE_LINEAR = 0x80,
+        // Writes linear gamma metadata into the file reguardless of format
+
+        WIC_FLAGS_DEFAULT_SRGB = 0x100,
+        // If no colorspace is specified, assume sRGB
+
+        WIC_FLAGS_DITHER = 0x10000,
+        // Use ordered 4x4 dithering for any required conversions
+
+        WIC_FLAGS_DITHER_DIFFUSION = 0x20000,
+        // Use error-diffusion dithering for any required conversions
+
+        WIC_FLAGS_FILTER_POINT = 0x100000,
+        WIC_FLAGS_FILTER_LINEAR = 0x200000,
+        WIC_FLAGS_FILTER_CUBIC = 0x300000,
+        WIC_FLAGS_FILTER_FANT = 0x400000, // Combination of Linear and Box filter
+            // Filtering mode to use for any required image resizing (only needed when loading arrays of differently sized images; defaults to Fant)
+    };
+
+    HRESULT __cdecl GetMetadataFromDDSMemory(
+        _In_reads_bytes_(size) const void* pSource, _In_ size_t size,
+        _In_ DDS_FLAGS flags,
+        _Out_ TexMetadata& metadata) noexcept;
+    HRESULT __cdecl GetMetadataFromDDSFile(
+        _In_z_ const wchar_t* szFile,
+        _In_ DDS_FLAGS flags,
+        _Out_ TexMetadata& metadata) noexcept;
+
+    HRESULT __cdecl GetMetadataFromDDSMemoryEx(
+        _In_reads_bytes_(size) const void* pSource, _In_ size_t size,
+        _In_ DDS_FLAGS flags,
+        _Out_ TexMetadata& metadata,
+        _Out_opt_ DDSMetaData* ddPixelFormat) noexcept;
+    HRESULT __cdecl GetMetadataFromDDSFileEx(
+        _In_z_ const wchar_t* szFile,
+        _In_ DDS_FLAGS flags,
+        _Out_ TexMetadata& metadata,
+        _Out_opt_ DDSMetaData* ddPixelFormat) noexcept;
+
+    HRESULT __cdecl GetMetadataFromHDRMemory(
+        _In_reads_bytes_(size) const void* pSource, _In_ size_t size,
+        _Out_ TexMetadata& metadata) noexcept;
+    HRESULT __cdecl GetMetadataFromHDRFile(
+        _In_z_ const wchar_t* szFile,
+        _Out_ TexMetadata& metadata) noexcept;
+
+    HRESULT __cdecl GetMetadataFromTGAMemory(
+        _In_reads_bytes_(size) const void* pSource, _In_ size_t size,
+        _In_ TGA_FLAGS flags,
+        _Out_ TexMetadata& metadata) noexcept;
+    HRESULT __cdecl GetMetadataFromTGAFile(
+        _In_z_ const wchar_t* szFile,
+        _In_ TGA_FLAGS flags,
+        _Out_ TexMetadata& metadata) noexcept;
+
+#ifdef _WIN32
+    HRESULT __cdecl GetMetadataFromWICMemory(
+        _In_reads_bytes_(size) const void* pSource, _In_ size_t size,
+        _In_ WIC_FLAGS flags,
+        _Out_ TexMetadata& metadata,
+        _In_ std::function<void __cdecl(IWICMetadataQueryReader*)> getMQR = nullptr);
+
+    HRESULT __cdecl GetMetadataFromWICFile(
+        _In_z_ const wchar_t* szFile,
+        _In_ WIC_FLAGS flags,
+        _Out_ TexMetadata& metadata,
+        _In_ std::function<void __cdecl(IWICMetadataQueryReader*)> getMQR = nullptr);
+#endif
+
+    // Compatability helpers
+    HRESULT __cdecl GetMetadataFromTGAMemory(
+        _In_reads_bytes_(size) const void* pSource, _In_ size_t size,
+        _Out_ TexMetadata& metadata) noexcept;
+    HRESULT __cdecl GetMetadataFromTGAFile(
+        _In_z_ const wchar_t* szFile,
+        _Out_ TexMetadata& metadata) noexcept;
+
+    //---------------------------------------------------------------------------------
+    // Bitmap image container
+    struct Image
+    {
+        size_t      width;
+        size_t      height;
+        DXGI_FORMAT format;
+        size_t      rowPitch;
+        size_t      slicePitch;
+        uint8_t*    pixels;
+    };
+
+    class ScratchImage
+    {
+    public:
+        ScratchImage() noexcept
+            : m_nimages(0), m_size(0), m_metadata{}, m_image(nullptr), m_memory(nullptr) {}
+        ScratchImage(ScratchImage&& moveFrom) noexcept
+            : m_nimages(0), m_size(0), m_metadata{}, m_image(nullptr), m_memory(nullptr) { *this = std::move(moveFrom); }
+        ~ScratchImage() { Release(); }
+
+        ScratchImage& __cdecl operator= (ScratchImage&& moveFrom) noexcept;
+
+        ScratchImage(const ScratchImage&) = delete;
+        ScratchImage& operator=(const ScratchImage&) = delete;
+
+        HRESULT __cdecl Initialize(_In_ const TexMetadata& mdata, _In_ CP_FLAGS flags = CP_FLAGS_NONE) noexcept;
+
+        HRESULT __cdecl Initialize1D(_In_ DXGI_FORMAT fmt, _In_ size_t length, _In_ size_t arraySize, _In_ size_t mipLevels, _In_ CP_FLAGS flags = CP_FLAGS_NONE) noexcept;
+        HRESULT __cdecl Initialize2D(_In_ DXGI_FORMAT fmt, _In_ size_t width, _In_ size_t height, _In_ size_t arraySize, _In_ size_t mipLevels, _In_ CP_FLAGS flags = CP_FLAGS_NONE) noexcept;
+        HRESULT __cdecl Initialize3D(_In_ DXGI_FORMAT fmt, _In_ size_t width, _In_ size_t height, _In_ size_t depth, _In_ size_t mipLevels, _In_ CP_FLAGS flags = CP_FLAGS_NONE) noexcept;
+        HRESULT __cdecl InitializeCube(_In_ DXGI_FORMAT fmt, _In_ size_t width, _In_ size_t height, _In_ size_t nCubes, _In_ size_t mipLevels, _In_ CP_FLAGS flags = CP_FLAGS_NONE) noexcept;
+
+        HRESULT __cdecl InitializeFromImage(_In_ const Image& srcImage, _In_ bool allow1D = false, _In_ CP_FLAGS flags = CP_FLAGS_NONE) noexcept;
+        HRESULT __cdecl InitializeArrayFromImages(_In_reads_(nImages) const Image* images, _In_ size_t nImages, _In_ bool allow1D = false, _In_ CP_FLAGS flags = CP_FLAGS_NONE) noexcept;
+        HRESULT __cdecl InitializeCubeFromImages(_In_reads_(nImages) const Image* images, _In_ size_t nImages, _In_ CP_FLAGS flags = CP_FLAGS_NONE) noexcept;
+        HRESULT __cdecl Initialize3DFromImages(_In_reads_(depth) const Image* images, _In_ size_t depth, _In_ CP_FLAGS flags = CP_FLAGS_NONE) noexcept;
+
+        void __cdecl Release() noexcept;
+
+        bool __cdecl OverrideFormat(_In_ DXGI_FORMAT f) noexcept;
+
+        const TexMetadata& __cdecl GetMetadata() const noexcept { return m_metadata; }
+        const Image* __cdecl GetImage(_In_ size_t mip, _In_ size_t item, _In_ size_t slice) const noexcept;
+
+        const Image* __cdecl GetImages() const noexcept { return m_image; }
+        size_t __cdecl GetImageCount() const noexcept { return m_nimages; }
+
+        uint8_t* __cdecl GetPixels() const noexcept { return m_memory; }
+        size_t __cdecl GetPixelsSize() const noexcept { return m_size; }
+
+        bool __cdecl IsAlphaAllOpaque() const noexcept;
+
+    private:
+        size_t      m_nimages;
+        size_t      m_size;
+        TexMetadata m_metadata;
+        Image*      m_image;
+        uint8_t*    m_memory;
+    };
+
+    //---------------------------------------------------------------------------------
+    // Memory blob (allocated buffer pointer is always 16-byte aligned)
+    class Blob
+    {
+    public:
+        Blob() noexcept : m_buffer(nullptr), m_size(0) {}
+        Blob(Blob&& moveFrom) noexcept : m_buffer(nullptr), m_size(0) { *this = std::move(moveFrom); }
+        ~Blob() { Release(); }
+
+        Blob& __cdecl operator= (Blob&& moveFrom) noexcept;
+
+        Blob(const Blob&) = delete;
+        Blob& operator=(const Blob&) = delete;
+
+        HRESULT __cdecl Initialize(_In_ size_t size) noexcept;
+
+        void __cdecl Release() noexcept;
+
+        void *__cdecl GetBufferPointer() const noexcept { return m_buffer; }
+        size_t __cdecl GetBufferSize() const noexcept { return m_size; }
+
+        HRESULT __cdecl Resize(size_t size) noexcept;
+            // Reallocate for a new size
+
+        HRESULT __cdecl Trim(size_t size) noexcept;
+            // Shorten size without reallocation
+
+    private:
+        void*   m_buffer;
+        size_t  m_size;
+    };
+
+    //---------------------------------------------------------------------------------
+    // Image I/O
+
+    // DDS operations
+    HRESULT __cdecl LoadFromDDSMemory(
+        _In_reads_bytes_(size) const void* pSource, _In_ size_t size,
+        _In_ DDS_FLAGS flags,
+        _Out_opt_ TexMetadata* metadata, _Out_ ScratchImage& image) noexcept;
+    HRESULT __cdecl LoadFromDDSFile(
+        _In_z_ const wchar_t* szFile,
+        _In_ DDS_FLAGS flags,
+        _Out_opt_ TexMetadata* metadata, _Out_ ScratchImage& image) noexcept;
+
+    HRESULT __cdecl LoadFromDDSMemoryEx(
+        _In_reads_bytes_(size) const void* pSource, _In_ size_t size,
+        _In_ DDS_FLAGS flags,
+        _Out_opt_ TexMetadata* metadata,
+        _Out_opt_ DDSMetaData* ddPixelFormat,
+        _Out_ ScratchImage& image) noexcept;
+    HRESULT __cdecl LoadFromDDSFileEx(
+        _In_z_ const wchar_t* szFile,
+        _In_ DDS_FLAGS flags,
+        _Out_opt_ TexMetadata* metadata,
+        _Out_opt_ DDSMetaData* ddPixelFormat,
+        _Out_ ScratchImage& image) noexcept;
+
+    HRESULT __cdecl SaveToDDSMemory(
+        _In_ const Image& image,
+        _In_ DDS_FLAGS flags,
+        _Out_ Blob& blob) noexcept;
+    HRESULT __cdecl SaveToDDSMemory(
+        _In_reads_(nimages) const Image* images, _In_ size_t nimages, _In_ const TexMetadata& metadata,
+        _In_ DDS_FLAGS flags,
+        _Out_ Blob& blob) noexcept;
+
+    HRESULT __cdecl SaveToDDSFile(_In_ const Image& image, _In_ DDS_FLAGS flags, _In_z_ const wchar_t* szFile) noexcept;
+    HRESULT __cdecl SaveToDDSFile(
+        _In_reads_(nimages) const Image* images, _In_ size_t nimages, _In_ const TexMetadata& metadata,
+        _In_ DDS_FLAGS flags, _In_z_ const wchar_t* szFile) noexcept;
+
+    // HDR operations
+    HRESULT __cdecl LoadFromHDRMemory(
+        _In_reads_bytes_(size) const void* pSource, _In_ size_t size,
+        _Out_opt_ TexMetadata* metadata, _Out_ ScratchImage& image) noexcept;
+    HRESULT __cdecl LoadFromHDRFile(
+        _In_z_ const wchar_t* szFile,
+        _Out_opt_ TexMetadata* metadata, _Out_ ScratchImage& image) noexcept;
+
+    HRESULT __cdecl SaveToHDRMemory(_In_ const Image& image, _Out_ Blob& blob) noexcept;
+    HRESULT __cdecl SaveToHDRFile(_In_ const Image& image, _In_z_ const wchar_t* szFile) noexcept;
+
+    // TGA operations
+    HRESULT __cdecl LoadFromTGAMemory(
+        _In_reads_bytes_(size) const void* pSource, _In_ size_t size,
+        _In_ TGA_FLAGS flags,
+        _Out_opt_ TexMetadata* metadata, _Out_ ScratchImage& image) noexcept;
+    HRESULT __cdecl LoadFromTGAFile(
+        _In_z_ const wchar_t* szFile,
+        _In_ TGA_FLAGS flags,
+        _Out_opt_ TexMetadata* metadata, _Out_ ScratchImage& image) noexcept;
+
+    HRESULT __cdecl SaveToTGAMemory(_In_ const Image& image,
+        _In_ TGA_FLAGS flags,
+        _Out_ Blob& blob, _In_opt_ const TexMetadata* metadata = nullptr) noexcept;
+    HRESULT __cdecl SaveToTGAFile(_In_ const Image& image,
+        _In_ TGA_FLAGS flags,
+        _In_z_ const wchar_t* szFile, _In_opt_ const TexMetadata* metadata = nullptr) noexcept;
+
+    // WIC operations
+#ifdef _WIN32
+    HRESULT __cdecl LoadFromWICMemory(
+        _In_reads_bytes_(size) const void* pSource, _In_ size_t size,
+        _In_ WIC_FLAGS flags,
+        _Out_opt_ TexMetadata* metadata, _Out_ ScratchImage& image,
+        _In_ std::function<void __cdecl(IWICMetadataQueryReader*)> getMQR = nullptr);
+    HRESULT __cdecl LoadFromWICFile(
+        _In_z_ const wchar_t* szFile, _In_ WIC_FLAGS flags,
+        _Out_opt_ TexMetadata* metadata, _Out_ ScratchImage& image,
+        _In_ std::function<void __cdecl(IWICMetadataQueryReader*)> getMQR = nullptr);
+
+    HRESULT __cdecl SaveToWICMemory(
+        _In_ const Image& image, _In_ WIC_FLAGS flags, _In_ REFGUID guidContainerFormat,
+        _Out_ Blob& blob, _In_opt_ const GUID* targetFormat = nullptr,
+        _In_ std::function<void __cdecl(IPropertyBag2*)> setCustomProps = nullptr);
+    HRESULT __cdecl SaveToWICMemory(
+        _In_count_(nimages) const Image* images, _In_ size_t nimages,
+        _In_ WIC_FLAGS flags, _In_ REFGUID guidContainerFormat,
+        _Out_ Blob& blob, _In_opt_ const GUID* targetFormat = nullptr,
+        _In_ std::function<void __cdecl(IPropertyBag2*)> setCustomProps = nullptr);
+
+    HRESULT __cdecl SaveToWICFile(
+        _In_ const Image& image, _In_ WIC_FLAGS flags, _In_ REFGUID guidContainerFormat,
+        _In_z_ const wchar_t* szFile, _In_opt_ const GUID* targetFormat = nullptr,
+        _In_ std::function<void __cdecl(IPropertyBag2*)> setCustomProps = nullptr);
+    HRESULT __cdecl SaveToWICFile(
+        _In_count_(nimages) const Image* images, _In_ size_t nimages,
+        _In_ WIC_FLAGS flags, _In_ REFGUID guidContainerFormat,
+        _In_z_ const wchar_t* szFile, _In_opt_ const GUID* targetFormat = nullptr,
+        _In_ std::function<void __cdecl(IPropertyBag2*)> setCustomProps = nullptr);
+#endif // WIN32
+
+    // Compatability helpers
+    HRESULT __cdecl LoadFromTGAMemory(
+        _In_reads_bytes_(size) const void* pSource, _In_ size_t size,
+        _Out_opt_ TexMetadata* metadata, _Out_ ScratchImage& image) noexcept;
+    HRESULT __cdecl LoadFromTGAFile(
+        _In_z_ const wchar_t* szFile,
+        _Out_opt_ TexMetadata* metadata, _Out_ ScratchImage& image) noexcept;
+
+    HRESULT __cdecl SaveToTGAMemory(_In_ const Image& image, _Out_ Blob& blob, _In_opt_ const TexMetadata* metadata = nullptr) noexcept;
+    HRESULT __cdecl SaveToTGAFile(_In_ const Image& image, _In_z_ const wchar_t* szFile, _In_opt_ const TexMetadata* metadata = nullptr) noexcept;
+
+    //---------------------------------------------------------------------------------
+    // Texture conversion, resizing, mipmap generation, and block compression
+
+    enum TEX_FR_FLAGS : unsigned long
+    {
+        TEX_FR_ROTATE0 = 0x0,
+        TEX_FR_ROTATE90 = 0x1,
+        TEX_FR_ROTATE180 = 0x2,
+        TEX_FR_ROTATE270 = 0x3,
+        TEX_FR_FLIP_HORIZONTAL = 0x08,
+        TEX_FR_FLIP_VERTICAL = 0x10,
+    };
+
+#ifdef _WIN32
+    HRESULT __cdecl FlipRotate(_In_ const Image& srcImage, _In_ TEX_FR_FLAGS flags, _Out_ ScratchImage& image) noexcept;
+    HRESULT __cdecl FlipRotate(
+        _In_reads_(nimages) const Image* srcImages, _In_ size_t nimages, _In_ const TexMetadata& metadata,
+        _In_ TEX_FR_FLAGS flags, _Out_ ScratchImage& result) noexcept;
+        // Flip and/or rotate image
+#endif
+
+    enum TEX_FILTER_FLAGS : unsigned long
+    {
+        TEX_FILTER_DEFAULT = 0,
+
+        TEX_FILTER_WRAP_U = 0x1,
+        TEX_FILTER_WRAP_V = 0x2,
+        TEX_FILTER_WRAP_W = 0x4,
+        TEX_FILTER_WRAP = (TEX_FILTER_WRAP_U | TEX_FILTER_WRAP_V | TEX_FILTER_WRAP_W),
+        TEX_FILTER_MIRROR_U = 0x10,
+        TEX_FILTER_MIRROR_V = 0x20,
+        TEX_FILTER_MIRROR_W = 0x40,
+        TEX_FILTER_MIRROR = (TEX_FILTER_MIRROR_U | TEX_FILTER_MIRROR_V | TEX_FILTER_MIRROR_W),
+        // Wrap vs. Mirror vs. Clamp filtering options
+
+        TEX_FILTER_SEPARATE_ALPHA = 0x100,
+        // Resize color and alpha channel independently
+
+        TEX_FILTER_FLOAT_X2BIAS = 0x200,
+        // Enable *2 - 1 conversion cases for unorm<->float and positive-only float formats
+
+        TEX_FILTER_RGB_COPY_RED = 0x1000,
+        TEX_FILTER_RGB_COPY_GREEN = 0x2000,
+        TEX_FILTER_RGB_COPY_BLUE = 0x4000,
+        TEX_FILTER_RGB_COPY_ALPHA = 0x8000,
+        // When converting RGB(A) to R, defaults to using grayscale. These flags indicate copying a specific channel instead
+        // When converting RGB(A) to RG, defaults to copying RED | GREEN. These flags control which channels are selected instead.
+
+        TEX_FILTER_DITHER = 0x10000,
+        // Use ordered 4x4 dithering for any required conversions
+        TEX_FILTER_DITHER_DIFFUSION = 0x20000,
+        // Use error-diffusion dithering for any required conversions
+
+        TEX_FILTER_POINT = 0x100000,
+        TEX_FILTER_LINEAR = 0x200000,
+        TEX_FILTER_CUBIC = 0x300000,
+        TEX_FILTER_BOX = 0x400000,
+        TEX_FILTER_FANT = 0x400000, // Equiv to Box filtering for mipmap generation
+        TEX_FILTER_TRIANGLE = 0x500000,
+        // Filtering mode to use for any required image resizing
+
+        TEX_FILTER_SRGB_IN = 0x1000000,
+        TEX_FILTER_SRGB_OUT = 0x2000000,
+        TEX_FILTER_SRGB = (TEX_FILTER_SRGB_IN | TEX_FILTER_SRGB_OUT),
+        // sRGB <-> RGB for use in conversion operations
+        // if the input format type is IsSRGB(), then SRGB_IN is on by default
+        // if the output format type is IsSRGB(), then SRGB_OUT is on by default
+
+        TEX_FILTER_FORCE_NON_WIC = 0x10000000,
+        // Forces use of the non-WIC path when both are an option
+
+        TEX_FILTER_FORCE_WIC = 0x20000000,
+        // Forces use of the WIC path even when logic would have picked a non-WIC path when both are an option
+    };
+
+    constexpr unsigned long TEX_FILTER_DITHER_MASK = 0xF0000;
+    constexpr unsigned long TEX_FILTER_MODE_MASK = 0xF00000;
+    constexpr unsigned long TEX_FILTER_SRGB_MASK = 0xF000000;
+
+    HRESULT __cdecl Resize(
+        _In_ const Image& srcImage, _In_ size_t width, _In_ size_t height,
+        _In_ TEX_FILTER_FLAGS filter,
+        _Out_ ScratchImage& image) noexcept;
+    HRESULT __cdecl Resize(
+        _In_reads_(nimages) const Image* srcImages, _In_ size_t nimages, _In_ const TexMetadata& metadata,
+        _In_ size_t width, _In_ size_t height, _In_ TEX_FILTER_FLAGS filter, _Out_ ScratchImage& result) noexcept;
+        // Resize the image to width x height. Defaults to Fant filtering.
+        // Note for a complex resize, the result will always have mipLevels == 1
+
+    constexpr float TEX_THRESHOLD_DEFAULT = 0.5f;
+        // Default value for alpha threshold used when converting to 1-bit alpha
+
+    struct ConvertOptions
+    {
+        TEX_FILTER_FLAGS filter;
+        float            threshold;
+    };
+
+    HRESULT __cdecl Convert(
+        _In_ const Image& srcImage, _In_ DXGI_FORMAT format, _In_ TEX_FILTER_FLAGS filter, _In_ float threshold,
+        _Out_ ScratchImage& image) noexcept;
+    HRESULT __cdecl Convert(
+        _In_reads_(nimages) const Image* srcImages, _In_ size_t nimages, _In_ const TexMetadata& metadata,
+        _In_ DXGI_FORMAT format, _In_ TEX_FILTER_FLAGS filter, _In_ float threshold, _Out_ ScratchImage& result) noexcept;
+
+    HRESULT __cdecl ConvertEx(
+        _In_ const Image& srcImage, _In_ DXGI_FORMAT format, _In_ const ConvertOptions& options,
+        _Out_ ScratchImage& image,
+        _In_ std::function<bool __cdecl(size_t, size_t)> statusCallBack = nullptr);
+    HRESULT __cdecl ConvertEx(
+        _In_reads_(nimages) const Image* srcImages, _In_ size_t nimages, _In_ const TexMetadata& metadata,
+        _In_ DXGI_FORMAT format, _In_ const ConvertOptions& options, _Out_ ScratchImage& result,
+        _In_ std::function<bool __cdecl(size_t, size_t)> statusCallBack = nullptr);
+        // Convert the image to a new format
+
+    HRESULT __cdecl ConvertToSinglePlane(_In_ const Image& srcImage, _Out_ ScratchImage& image) noexcept;
+    HRESULT __cdecl ConvertToSinglePlane(
+        _In_reads_(nimages) const Image* srcImages, _In_ size_t nimages, _In_ const TexMetadata& metadata,
+        _Out_ ScratchImage& image) noexcept;
+        // Converts the image from a planar format to an equivalent non-planar format
+
+    HRESULT __cdecl GenerateMipMaps(
+        _In_ const Image& baseImage, _In_ TEX_FILTER_FLAGS filter, _In_ size_t levels,
+        _Inout_ ScratchImage& mipChain, _In_ bool allow1D = false) noexcept;
+    HRESULT __cdecl GenerateMipMaps(
+        _In_reads_(nimages) const Image* srcImages, _In_ size_t nimages, _In_ const TexMetadata& metadata,
+        _In_ TEX_FILTER_FLAGS filter, _In_ size_t levels, _Inout_ ScratchImage& mipChain);
+        // levels of '0' indicates a full mipchain, otherwise is generates that number of total levels (including the source base image)
+        // Defaults to Fant filtering which is equivalent to a box filter
+
+    HRESULT __cdecl GenerateMipMaps3D(
+        _In_reads_(depth) const Image* baseImages, _In_ size_t depth, _In_ TEX_FILTER_FLAGS filter, _In_ size_t levels,
+        _Out_ ScratchImage& mipChain) noexcept;
+    HRESULT __cdecl GenerateMipMaps3D(
+        _In_reads_(nimages) const Image* srcImages, _In_ size_t nimages, _In_ const TexMetadata& metadata,
+        _In_ TEX_FILTER_FLAGS filter, _In_ size_t levels, _Out_ ScratchImage& mipChain);
+        // levels of '0' indicates a full mipchain, otherwise is generates that number of total levels (including the source base image)
+        // Defaults to Fant filtering which is equivalent to a box filter
+
+    HRESULT __cdecl ScaleMipMapsAlphaForCoverage(
+        _In_reads_(nimages) const Image* srcImages, _In_ size_t nimages, _In_ const TexMetadata& metadata, _In_ size_t item,
+        _In_ float alphaReference, _Inout_ ScratchImage& mipChain) noexcept;
+
+
+    enum TEX_PMALPHA_FLAGS : unsigned long
+    {
+        TEX_PMALPHA_DEFAULT = 0,
+
+        TEX_PMALPHA_IGNORE_SRGB = 0x1,
+        // ignores sRGB colorspace conversions
+
+        TEX_PMALPHA_REVERSE = 0x2,
+        // converts from premultiplied alpha back to straight alpha
+
+        TEX_PMALPHA_SRGB_IN = 0x1000000,
+        TEX_PMALPHA_SRGB_OUT = 0x2000000,
+        TEX_PMALPHA_SRGB = (TEX_PMALPHA_SRGB_IN | TEX_PMALPHA_SRGB_OUT),
+        // if the input format type is IsSRGB(), then SRGB_IN is on by default
+        // if the output format type is IsSRGB(), then SRGB_OUT is on by default
+    };
+
+    HRESULT __cdecl PremultiplyAlpha(_In_ const Image& srcImage, _In_ TEX_PMALPHA_FLAGS flags, _Out_ ScratchImage& image) noexcept;
+    HRESULT __cdecl PremultiplyAlpha(
+        _In_reads_(nimages) const Image* srcImages, _In_ size_t nimages, _In_ const TexMetadata& metadata,
+        _In_ TEX_PMALPHA_FLAGS flags, _Out_ ScratchImage& result) noexcept;
+        // Converts to/from a premultiplied alpha version of the texture
+
+    enum TEX_COMPRESS_FLAGS : unsigned long
+    {
+        TEX_COMPRESS_DEFAULT = 0,
+
+        TEX_COMPRESS_RGB_DITHER = 0x10000,
+        // Enables dithering RGB colors for BC1-3 compression
+
+        TEX_COMPRESS_A_DITHER = 0x20000,
+        // Enables dithering alpha for BC1-3 compression
+
+        TEX_COMPRESS_DITHER = 0x30000,
+        // Enables both RGB and alpha dithering for BC1-3 compression
+
+        TEX_COMPRESS_UNIFORM = 0x40000,
+        // Uniform color weighting for BC1-3 compression; by default uses perceptual weighting
+
+        TEX_COMPRESS_BC7_USE_3SUBSETS = 0x80000,
+        // Enables exhaustive search for BC7 compress for mode 0 and 2; by default skips trying these modes
+
+        TEX_COMPRESS_BC7_QUICK = 0x100000,
+        // Minimal modes (usually mode 6) for BC7 compression
+
+        TEX_COMPRESS_SRGB_IN = 0x1000000,
+        TEX_COMPRESS_SRGB_OUT = 0x2000000,
+        TEX_COMPRESS_SRGB = (TEX_COMPRESS_SRGB_IN | TEX_COMPRESS_SRGB_OUT),
+        // if the input format type is IsSRGB(), then SRGB_IN is on by default
+        // if the output format type is IsSRGB(), then SRGB_OUT is on by default
+
+        TEX_COMPRESS_PARALLEL = 0x10000000,
+        // Compress is free to use multithreading to improve performance (by default it does not use multithreading)
+    };
+
+    constexpr float TEX_ALPHA_WEIGHT_DEFAULT = 1.0f;
+        // Default value for alpha weight used for GPU BC7 compression
+
+    struct CompressOptions
+    {
+        TEX_COMPRESS_FLAGS flags;
+        float              threshold;
+        float              alphaWeight;
+    };
+
+    HRESULT __cdecl Compress(
+        _In_ const Image& srcImage, _In_ DXGI_FORMAT format, _In_ TEX_COMPRESS_FLAGS compress, _In_ float threshold,
+        _Out_ ScratchImage& cImage) noexcept;
+    HRESULT __cdecl Compress(
+        _In_reads_(nimages) const Image* srcImages, _In_ size_t nimages, _In_ const TexMetadata& metadata,
+        _In_ DXGI_FORMAT format, _In_ TEX_COMPRESS_FLAGS compress, _In_ float threshold, _Out_ ScratchImage& cImages) noexcept;
+        // Note that threshold is only used by BC1. TEX_THRESHOLD_DEFAULT is a typical value to use
+
+    HRESULT __cdecl CompressEx(
+        _In_ const Image& srcImage, _In_ DXGI_FORMAT format, _In_ const CompressOptions& options,
+        _Out_ ScratchImage& cImage,
+        _In_ std::function<bool __cdecl(size_t, size_t)> statusCallBack = nullptr);
+    HRESULT __cdecl CompressEx(
+        _In_reads_(nimages) const Image* srcImages, _In_ size_t nimages, _In_ const TexMetadata& metadata,
+        _In_ DXGI_FORMAT format, _In_ const CompressOptions& options, _Out_ ScratchImage& cImages,
+        _In_ std::function<bool __cdecl(size_t, size_t)> statusCallBack = nullptr);
+
+#if defined(__d3d11_h__) || defined(__d3d11_x_h__)
+    HRESULT __cdecl Compress(
+        _In_ ID3D11Device* pDevice, _In_ const Image& srcImage, _In_ DXGI_FORMAT format, _In_ TEX_COMPRESS_FLAGS compress,
+        _In_ float alphaWeight, _Out_ ScratchImage& image) noexcept;
+    HRESULT __cdecl Compress(
+        _In_ ID3D11Device* pDevice, _In_ const Image* srcImages, _In_ size_t nimages, _In_ const TexMetadata& metadata,
+        _In_ DXGI_FORMAT format, _In_ TEX_COMPRESS_FLAGS compress, _In_ float alphaWeight, _Out_ ScratchImage& cImages) noexcept;
+        // DirectCompute-based compression (alphaWeight is only used by BC7. 1.0 is the typical value to use)
+
+    HRESULT __cdecl CompressEx(
+        _In_ ID3D11Device* pDevice, _In_ const Image& srcImage, _In_ DXGI_FORMAT format, _In_ const CompressOptions& options,
+        _Out_ ScratchImage& image,
+        _In_ std::function<bool __cdecl(size_t, size_t)> statusCallBack = nullptr);
+    HRESULT __cdecl CompressEx(
+        _In_ ID3D11Device* pDevice, _In_ const Image* srcImages, _In_ size_t nimages, _In_ const TexMetadata& metadata,
+        _In_ DXGI_FORMAT format, _In_ const CompressOptions& options, _Out_ ScratchImage& cImages,
+        _In_ std::function<bool __cdecl(size_t, size_t)> statusCallBack = nullptr);
+#endif
+
+    HRESULT __cdecl Decompress(_In_ const Image& cImage, _In_ DXGI_FORMAT format, _Out_ ScratchImage& image) noexcept;
+    HRESULT __cdecl Decompress(
+        _In_reads_(nimages) const Image* cImages, _In_ size_t nimages, _In_ const TexMetadata& metadata,
+        _In_ DXGI_FORMAT format, _Out_ ScratchImage& images) noexcept;
+
+    //---------------------------------------------------------------------------------
+    // Normal map operations
+
+    enum CNMAP_FLAGS : unsigned long
+    {
+        CNMAP_DEFAULT = 0,
+
+        CNMAP_CHANNEL_RED = 0x1,
+        CNMAP_CHANNEL_GREEN = 0x2,
+        CNMAP_CHANNEL_BLUE = 0x3,
+        CNMAP_CHANNEL_ALPHA = 0x4,
+        CNMAP_CHANNEL_LUMINANCE = 0x5,
+        // Channel selection when evaluting color value for height
+        // Luminance is a combination of red, green, and blue
+
+        CNMAP_MIRROR_U = 0x1000,
+        CNMAP_MIRROR_V = 0x2000,
+        CNMAP_MIRROR = 0x3000,
+        // Use mirror semantics for scanline references (defaults to wrap)
+
+        CNMAP_INVERT_SIGN = 0x4000,
+        // Inverts normal sign
+
+        CNMAP_COMPUTE_OCCLUSION = 0x8000,
+        // Computes a crude occlusion term stored in the alpha channel
+    };
+
+    HRESULT __cdecl ComputeNormalMap(
+        _In_ const Image& srcImage, _In_ CNMAP_FLAGS flags, _In_ float amplitude,
+        _In_ DXGI_FORMAT format, _Out_ ScratchImage& normalMap) noexcept;
+    HRESULT __cdecl ComputeNormalMap(
+        _In_reads_(nimages) const Image* srcImages, _In_ size_t nimages, _In_ const TexMetadata& metadata,
+        _In_ CNMAP_FLAGS flags, _In_ float amplitude, _In_ DXGI_FORMAT format, _Out_ ScratchImage& normalMaps) noexcept;
+
+    //---------------------------------------------------------------------------------
+    // Misc image operations
+
+    struct Rect
+    {
+        size_t x;
+        size_t y;
+        size_t w;
+        size_t h;
+
+        Rect() = default;
+        Rect(size_t _x, size_t _y, size_t _w, size_t _h) noexcept : x(_x), y(_y), w(_w), h(_h) {}
+    };
+
+    HRESULT __cdecl CopyRectangle(
+        _In_ const Image& srcImage, _In_ const Rect& srcRect, _In_ const Image& dstImage,
+        _In_ TEX_FILTER_FLAGS filter, _In_ size_t xOffset, _In_ size_t yOffset) noexcept;
+
+    enum CMSE_FLAGS : unsigned long
+    {
+        CMSE_DEFAULT = 0,
+
+        CMSE_IMAGE1_SRGB = 0x1,
+        CMSE_IMAGE2_SRGB = 0x2,
+        // Indicates that image needs gamma correction before comparision
+
+        CMSE_IGNORE_RED = 0x10,
+        CMSE_IGNORE_GREEN = 0x20,
+        CMSE_IGNORE_BLUE = 0x40,
+        CMSE_IGNORE_ALPHA = 0x80,
+        // Ignore the channel when computing MSE
+
+        CMSE_IMAGE1_X2_BIAS = 0x100,
+        CMSE_IMAGE2_X2_BIAS = 0x200,
+        // Indicates that image should be scaled and biased before comparison (i.e. UNORM -> SNORM)
+    };
+
+    HRESULT __cdecl ComputeMSE(_In_ const Image& image1, _In_ const Image& image2, _Out_ float& mse, _Out_writes_opt_(4) float* mseV, _In_ CMSE_FLAGS flags = CMSE_DEFAULT) noexcept;
+
+    HRESULT __cdecl EvaluateImage(
+        _In_ const Image& image,
+        _In_ std::function<void __cdecl(_In_reads_(width) const XMVECTOR* pixels, size_t width, size_t y)> pixelFunc);
+    HRESULT __cdecl EvaluateImage(
+        _In_reads_(nimages) const Image* images, _In_ size_t nimages, _In_ const TexMetadata& metadata,
+        _In_ std::function<void __cdecl(_In_reads_(width) const XMVECTOR* pixels, size_t width, size_t y)> pixelFunc);
+
+    HRESULT __cdecl TransformImage(
+        _In_ const Image& image,
+        _In_ std::function<void __cdecl(_Out_writes_(width) XMVECTOR* outPixels,
+            _In_reads_(width) const XMVECTOR* inPixels, size_t width, size_t y)> pixelFunc,
+        ScratchImage& result);
+    HRESULT __cdecl TransformImage(
+        _In_reads_(nimages) const Image* srcImages, _In_ size_t nimages, _In_ const TexMetadata& metadata,
+        _In_ std::function<void __cdecl(_Out_writes_(width) XMVECTOR* outPixels,
+            _In_reads_(width) const XMVECTOR* inPixels, size_t width, size_t y)> pixelFunc,
+        ScratchImage& result);
+
+    //---------------------------------------------------------------------------------
+    // WIC utility code
+#ifdef _WIN32
+    enum WICCodecs
+    {
+        WIC_CODEC_BMP = 1,          // Windows Bitmap (.bmp)
+        WIC_CODEC_JPEG,             // Joint Photographic Experts Group (.jpg, .jpeg)
+        WIC_CODEC_PNG,              // Portable Network Graphics (.png)
+        WIC_CODEC_TIFF,             // Tagged Image File Format  (.tif, .tiff)
+        WIC_CODEC_GIF,              // Graphics Interchange Format  (.gif)
+        WIC_CODEC_WMP,              // Windows Media Photo / HD Photo / JPEG XR (.hdp, .jxr, .wdp)
+        WIC_CODEC_ICO,              // Windows Icon (.ico)
+        WIC_CODEC_HEIF,             // High Efficiency Image File (.heif, .heic)
+    };
+
+    REFGUID __cdecl GetWICCodec(_In_ WICCodecs codec) noexcept;
+
+    IWICImagingFactory* __cdecl GetWICFactory(bool& iswic2) noexcept;
+    void __cdecl SetWICFactory(_In_opt_ IWICImagingFactory* pWIC) noexcept;
+#endif
+
+    //---------------------------------------------------------------------------------
+    // DDS helper functions
+    HRESULT __cdecl EncodeDDSHeader(
+        _In_ const TexMetadata& metadata, DDS_FLAGS flags,
+        _Out_writes_bytes_to_opt_(maxsize, required) void* pDestination, _In_ size_t maxsize,
+        _Out_ size_t& required) noexcept;
+
+    //---------------------------------------------------------------------------------
+    // Direct3D interop
+
+    enum CREATETEX_FLAGS : uint32_t
+    {
+        CREATETEX_DEFAULT = 0,
+        CREATETEX_FORCE_SRGB = 0x1,
+        CREATETEX_IGNORE_SRGB = 0x2,
+    };
+
+    // Direct3D 11 functions
+#if defined(__d3d11_h__) || defined(__d3d11_x_h__)
+    bool __cdecl IsSupportedTexture(_In_ ID3D11Device* pDevice, _In_ const TexMetadata& metadata) noexcept;
+
+    HRESULT __cdecl CreateTexture(
+        _In_ ID3D11Device* pDevice, _In_reads_(nimages) const Image* srcImages, _In_ size_t nimages, _In_ const TexMetadata& metadata,
+        _Outptr_ ID3D11Resource** ppResource) noexcept;
+
+    HRESULT __cdecl CreateShaderResourceView(
+        _In_ ID3D11Device* pDevice, _In_reads_(nimages) const Image* srcImages, _In_ size_t nimages, _In_ const TexMetadata& metadata,
+        _Outptr_ ID3D11ShaderResourceView** ppSRV) noexcept;
+
+    HRESULT __cdecl CreateTextureEx(
+        _In_ ID3D11Device* pDevice, _In_reads_(nimages) const Image* srcImages, _In_ size_t nimages, _In_ const TexMetadata& metadata,
+        _In_ D3D11_USAGE usage, _In_ unsigned int bindFlags, _In_ unsigned int cpuAccessFlags, _In_ unsigned int miscFlags, _In_ CREATETEX_FLAGS flags,
+        _Outptr_ ID3D11Resource** ppResource) noexcept;
+
+    HRESULT __cdecl CreateShaderResourceViewEx(
+        _In_ ID3D11Device* pDevice, _In_reads_(nimages) const Image* srcImages, _In_ size_t nimages, _In_ const TexMetadata& metadata,
+        _In_ D3D11_USAGE usage, _In_ unsigned int bindFlags, _In_ unsigned int cpuAccessFlags, _In_ unsigned int miscFlags, _In_ CREATETEX_FLAGS flags,
+        _Outptr_ ID3D11ShaderResourceView** ppSRV) noexcept;
+
+    HRESULT __cdecl CaptureTexture(_In_ ID3D11Device* pDevice, _In_ ID3D11DeviceContext* pContext, _In_ ID3D11Resource* pSource, _Out_ ScratchImage& result) noexcept;
+#endif
+
+    // Direct3D 12 functions
+#if defined(__d3d12_h__) || defined(__d3d12_x_h__) || defined(__XBOX_D3D12_X__)
+    bool __cdecl IsSupportedTexture(_In_ ID3D12Device* pDevice, _In_ const TexMetadata& metadata) noexcept;
+
+    HRESULT __cdecl CreateTexture(
+        _In_ ID3D12Device* pDevice, _In_ const TexMetadata& metadata,
+        _Outptr_ ID3D12Resource** ppResource) noexcept;
+
+    HRESULT __cdecl CreateTextureEx(
+        _In_ ID3D12Device* pDevice, _In_ const TexMetadata& metadata,
+        _In_ D3D12_RESOURCE_FLAGS resFlags, _In_ CREATETEX_FLAGS flags,
+        _Outptr_ ID3D12Resource** ppResource) noexcept;
+
+    HRESULT __cdecl PrepareUpload(
+        _In_ ID3D12Device* pDevice,
+        _In_reads_(nimages) const Image* srcImages, _In_ size_t nimages, _In_ const TexMetadata& metadata,
+        std::vector<D3D12_SUBRESOURCE_DATA>& subresources);
+
+    HRESULT __cdecl CaptureTexture(
+        _In_ ID3D12CommandQueue* pCommandQueue, _In_ ID3D12Resource* pSource, _In_ bool isCubeMap,
+        _Out_ ScratchImage& result,
+        _In_ D3D12_RESOURCE_STATES beforeState = D3D12_RESOURCE_STATE_RENDER_TARGET,
+        _In_ D3D12_RESOURCE_STATES afterState = D3D12_RESOURCE_STATE_RENDER_TARGET) noexcept;
+#endif
+
+#ifdef __clang__
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wcovered-switch-default"
+#pragma clang diagnostic ignored "-Wdeprecated-dynamic-exception-spec"
+#pragma clang diagnostic ignored "-Wswitch-enum"
+#endif
+
+#ifdef  _MSC_VER
+#pragma warning(push)
+#pragma warning(disable : 4619 4616 4061)
+#endif
+
+#include "DirectXTex.inl"
+
+#ifdef  _MSC_VER
+#pragma warning(pop)
+#endif
+
+#ifdef __clang__
+#pragma clang diagnostic pop
+#endif
+
+} // namespace

--- a/DirectXTex/DirectXTex/DirectXTex.inl
+++ b/DirectXTex/DirectXTex/DirectXTex.inl
@@ -1,0 +1,192 @@
+//-------------------------------------------------------------------------------------
+// DirectXTex.inl
+//
+// DirectX Texture Library
+//
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+//
+// http://go.microsoft.com/fwlink/?LinkId=248926
+//-------------------------------------------------------------------------------------
+
+#pragma once
+
+//=====================================================================================
+// Bitmask flags enumerator operators
+//=====================================================================================
+DEFINE_ENUM_FLAG_OPERATORS(CP_FLAGS);
+DEFINE_ENUM_FLAG_OPERATORS(DDS_FLAGS);
+DEFINE_ENUM_FLAG_OPERATORS(TGA_FLAGS);
+DEFINE_ENUM_FLAG_OPERATORS(WIC_FLAGS);
+DEFINE_ENUM_FLAG_OPERATORS(TEX_FR_FLAGS);
+DEFINE_ENUM_FLAG_OPERATORS(TEX_FILTER_FLAGS);
+DEFINE_ENUM_FLAG_OPERATORS(TEX_PMALPHA_FLAGS);
+DEFINE_ENUM_FLAG_OPERATORS(TEX_COMPRESS_FLAGS);
+DEFINE_ENUM_FLAG_OPERATORS(CNMAP_FLAGS);
+DEFINE_ENUM_FLAG_OPERATORS(CMSE_FLAGS);
+DEFINE_ENUM_FLAG_OPERATORS(CREATETEX_FLAGS);
+
+// WIC_FILTER modes match TEX_FILTER modes
+constexpr WIC_FLAGS operator|(WIC_FLAGS a, TEX_FILTER_FLAGS b) { return static_cast<WIC_FLAGS>(static_cast<unsigned long>(a) | static_cast<unsigned long>(b & TEX_FILTER_MODE_MASK)); }
+constexpr WIC_FLAGS operator|(TEX_FILTER_FLAGS a, WIC_FLAGS b) { return static_cast<WIC_FLAGS>(static_cast<unsigned long>(a & TEX_FILTER_MODE_MASK) | static_cast<unsigned long>(b)); }
+
+// TEX_PMALPHA_SRGB match TEX_FILTER_SRGB
+constexpr TEX_PMALPHA_FLAGS operator|(TEX_PMALPHA_FLAGS a, TEX_FILTER_FLAGS b) { return static_cast<TEX_PMALPHA_FLAGS>(static_cast<unsigned long>(a) | static_cast<unsigned long>(b & TEX_FILTER_SRGB_MASK)); }
+constexpr TEX_PMALPHA_FLAGS operator|(TEX_FILTER_FLAGS a, TEX_PMALPHA_FLAGS b) { return static_cast<TEX_PMALPHA_FLAGS>(static_cast<unsigned long>(a & TEX_FILTER_SRGB_MASK) | static_cast<unsigned long>(b)); }
+
+// TEX_COMPRESS_SRGB match TEX_FILTER_SRGB
+constexpr TEX_COMPRESS_FLAGS operator|(TEX_COMPRESS_FLAGS a, TEX_FILTER_FLAGS b) { return static_cast<TEX_COMPRESS_FLAGS>(static_cast<unsigned long>(a) | static_cast<unsigned long>(b & TEX_FILTER_SRGB_MASK)); }
+constexpr TEX_COMPRESS_FLAGS operator|(TEX_FILTER_FLAGS a, TEX_COMPRESS_FLAGS b) { return static_cast<TEX_COMPRESS_FLAGS>(static_cast<unsigned long>(a & TEX_FILTER_SRGB_MASK) | static_cast<unsigned long>(b)); }
+
+
+//=====================================================================================
+// DXGI Format Utilities
+//=====================================================================================
+
+_Use_decl_annotations_
+constexpr bool __cdecl IsValid(DXGI_FORMAT fmt) noexcept
+{
+    return (static_cast<size_t>(fmt) >= 1 && static_cast<size_t>(fmt) <= 191);
+}
+
+_Use_decl_annotations_
+inline bool __cdecl IsCompressed(DXGI_FORMAT fmt) noexcept
+{
+    switch (fmt)
+    {
+    case DXGI_FORMAT_BC1_TYPELESS:
+    case DXGI_FORMAT_BC1_UNORM:
+    case DXGI_FORMAT_BC1_UNORM_SRGB:
+    case DXGI_FORMAT_BC2_TYPELESS:
+    case DXGI_FORMAT_BC2_UNORM:
+    case DXGI_FORMAT_BC2_UNORM_SRGB:
+    case DXGI_FORMAT_BC3_TYPELESS:
+    case DXGI_FORMAT_BC3_UNORM:
+    case DXGI_FORMAT_BC3_UNORM_SRGB:
+    case DXGI_FORMAT_BC4_TYPELESS:
+    case DXGI_FORMAT_BC4_UNORM:
+    case DXGI_FORMAT_BC4_SNORM:
+    case DXGI_FORMAT_BC5_TYPELESS:
+    case DXGI_FORMAT_BC5_UNORM:
+    case DXGI_FORMAT_BC5_SNORM:
+    case DXGI_FORMAT_BC6H_TYPELESS:
+    case DXGI_FORMAT_BC6H_UF16:
+    case DXGI_FORMAT_BC6H_SF16:
+    case DXGI_FORMAT_BC7_TYPELESS:
+    case DXGI_FORMAT_BC7_UNORM:
+    case DXGI_FORMAT_BC7_UNORM_SRGB:
+        return true;
+
+    default:
+        return false;
+    }
+}
+
+_Use_decl_annotations_
+inline bool __cdecl IsPalettized(DXGI_FORMAT fmt) noexcept
+{
+    switch (fmt)
+    {
+    case DXGI_FORMAT_AI44:
+    case DXGI_FORMAT_IA44:
+    case DXGI_FORMAT_P8:
+    case DXGI_FORMAT_A8P8:
+        return true;
+
+    default:
+        return false;
+    }
+}
+
+_Use_decl_annotations_
+inline bool __cdecl IsSRGB(DXGI_FORMAT fmt) noexcept
+{
+    switch (fmt)
+    {
+    case DXGI_FORMAT_R8G8B8A8_UNORM_SRGB:
+    case DXGI_FORMAT_BC1_UNORM_SRGB:
+    case DXGI_FORMAT_BC2_UNORM_SRGB:
+    case DXGI_FORMAT_BC3_UNORM_SRGB:
+    case DXGI_FORMAT_B8G8R8A8_UNORM_SRGB:
+    case DXGI_FORMAT_B8G8R8X8_UNORM_SRGB:
+    case DXGI_FORMAT_BC7_UNORM_SRGB:
+        return true;
+
+    default:
+        return false;
+    }
+}
+
+
+//=====================================================================================
+// Image I/O
+//=====================================================================================
+_Use_decl_annotations_
+inline HRESULT __cdecl SaveToDDSMemory(const Image& image, DDS_FLAGS flags, Blob& blob) noexcept
+{
+    TexMetadata mdata = {};
+    mdata.width = image.width;
+    mdata.height = image.height;
+    mdata.depth = 1;
+    mdata.arraySize = 1;
+    mdata.mipLevels = 1;
+    mdata.format = image.format;
+    mdata.dimension = TEX_DIMENSION_TEXTURE2D;
+
+    return SaveToDDSMemory(&image, 1, mdata, flags, blob);
+}
+
+_Use_decl_annotations_
+inline HRESULT __cdecl SaveToDDSFile(const Image& image, DDS_FLAGS flags, const wchar_t* szFile) noexcept
+{
+    TexMetadata mdata = {};
+    mdata.width = image.width;
+    mdata.height = image.height;
+    mdata.depth = 1;
+    mdata.arraySize = 1;
+    mdata.mipLevels = 1;
+    mdata.format = image.format;
+    mdata.dimension = TEX_DIMENSION_TEXTURE2D;
+
+    return SaveToDDSFile(&image, 1, mdata, flags, szFile);
+}
+
+
+//=====================================================================================
+// Compatability helpers
+//=====================================================================================
+_Use_decl_annotations_
+inline HRESULT __cdecl GetMetadataFromTGAMemory(const void* pSource, size_t size, TexMetadata& metadata) noexcept
+{
+    return GetMetadataFromTGAMemory(pSource, size, TGA_FLAGS_NONE, metadata);
+}
+
+_Use_decl_annotations_
+inline HRESULT __cdecl GetMetadataFromTGAFile(const wchar_t* szFile, TexMetadata& metadata) noexcept
+{
+    return GetMetadataFromTGAFile(szFile, TGA_FLAGS_NONE, metadata);
+}
+
+_Use_decl_annotations_
+inline HRESULT __cdecl LoadFromTGAMemory(const void* pSource, size_t size, TexMetadata* metadata, ScratchImage& image) noexcept
+{
+    return LoadFromTGAMemory(pSource, size, TGA_FLAGS_NONE, metadata, image);
+}
+
+_Use_decl_annotations_
+inline HRESULT __cdecl LoadFromTGAFile(const wchar_t* szFile, TexMetadata* metadata, ScratchImage& image) noexcept
+{
+    return LoadFromTGAFile(szFile, TGA_FLAGS_NONE, metadata, image);
+}
+
+_Use_decl_annotations_
+inline HRESULT __cdecl SaveToTGAMemory(const Image& image, Blob& blob, const TexMetadata* metadata) noexcept
+{
+    return SaveToTGAMemory(image, TGA_FLAGS_NONE, blob, metadata);
+}
+
+_Use_decl_annotations_
+inline HRESULT __cdecl SaveToTGAFile(const Image& image, const wchar_t* szFile, const TexMetadata* metadata) noexcept
+{
+    return SaveToTGAFile(image, TGA_FLAGS_NONE, szFile, metadata);
+}

--- a/DirectXTex/DirectXTex/DirectXTexCompress.cpp
+++ b/DirectXTex/DirectXTex/DirectXTexCompress.cpp
@@ -1,0 +1,979 @@
+//-------------------------------------------------------------------------------------
+// DirectXTexCompress.cpp
+//
+// DirectX Texture Library - Texture compression
+//
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+//
+// http://go.microsoft.com/fwlink/?LinkId=248926
+//-------------------------------------------------------------------------------------
+
+#include "DirectXTexP.h"
+
+#ifdef _OPENMP
+#include <omp.h>
+#pragma warning(disable : 4616 6993)
+#endif
+
+#include "BC.h"
+
+using namespace DirectX;
+using namespace DirectX::Internal;
+
+namespace
+{
+    constexpr uint32_t GetBCFlags(_In_ TEX_COMPRESS_FLAGS compress) noexcept
+    {
+        static_assert(static_cast<int>(TEX_COMPRESS_RGB_DITHER) == static_cast<int>(BC_FLAGS_DITHER_RGB), "TEX_COMPRESS_* flags should match BC_FLAGS_*");
+        static_assert(static_cast<int>(TEX_COMPRESS_A_DITHER) == static_cast<int>(BC_FLAGS_DITHER_A), "TEX_COMPRESS_* flags should match BC_FLAGS_*");
+        static_assert(static_cast<int>(TEX_COMPRESS_DITHER) == static_cast<int>(BC_FLAGS_DITHER_RGB | BC_FLAGS_DITHER_A), "TEX_COMPRESS_* flags should match BC_FLAGS_*");
+        static_assert(static_cast<int>(TEX_COMPRESS_UNIFORM) == static_cast<int>(BC_FLAGS_UNIFORM), "TEX_COMPRESS_* flags should match BC_FLAGS_*");
+        static_assert(static_cast<int>(TEX_COMPRESS_BC7_USE_3SUBSETS) == static_cast<int>(BC_FLAGS_USE_3SUBSETS), "TEX_COMPRESS_* flags should match BC_FLAGS_*");
+        static_assert(static_cast<int>(TEX_COMPRESS_BC7_QUICK) == static_cast<int>(BC_FLAGS_FORCE_BC7_MODE6), "TEX_COMPRESS_* flags should match BC_FLAGS_*");
+        return (compress & (BC_FLAGS_DITHER_RGB | BC_FLAGS_DITHER_A | BC_FLAGS_UNIFORM | BC_FLAGS_USE_3SUBSETS | BC_FLAGS_FORCE_BC7_MODE6));
+    }
+
+    constexpr TEX_FILTER_FLAGS GetSRGBFlags(_In_ TEX_COMPRESS_FLAGS compress) noexcept
+    {
+        static_assert(TEX_FILTER_SRGB_IN == 0x1000000, "TEX_FILTER_SRGB flag values don't match TEX_FILTER_SRGB_MASK");
+        static_assert(static_cast<int>(TEX_COMPRESS_SRGB_IN) == static_cast<int>(TEX_FILTER_SRGB_IN), "TEX_COMPRESS_SRGB* should match TEX_FILTER_SRGB*");
+        static_assert(static_cast<int>(TEX_COMPRESS_SRGB_OUT) == static_cast<int>(TEX_FILTER_SRGB_OUT), "TEX_COMPRESS_SRGB* should match TEX_FILTER_SRGB*");
+        static_assert(static_cast<int>(TEX_COMPRESS_SRGB) == static_cast<int>(TEX_FILTER_SRGB), "TEX_COMPRESS_SRGB* should match TEX_FILTER_SRGB*");
+        return static_cast<TEX_FILTER_FLAGS>(compress & TEX_FILTER_SRGB_MASK);
+    }
+
+    inline bool DetermineEncoderSettings(_In_ DXGI_FORMAT format, _Out_ BC_ENCODE& pfEncode, _Out_ size_t& blocksize, _Out_ TEX_FILTER_FLAGS& cflags) noexcept
+    {
+        switch (format)
+        {
+        case DXGI_FORMAT_BC1_UNORM:
+        case DXGI_FORMAT_BC1_UNORM_SRGB:    pfEncode = nullptr;         blocksize = 8;   cflags = TEX_FILTER_DEFAULT; break;
+        case DXGI_FORMAT_BC2_UNORM:
+        case DXGI_FORMAT_BC2_UNORM_SRGB:    pfEncode = D3DXEncodeBC2;   blocksize = 16;  cflags = TEX_FILTER_DEFAULT; break;
+        case DXGI_FORMAT_BC3_UNORM:
+        case DXGI_FORMAT_BC3_UNORM_SRGB:    pfEncode = D3DXEncodeBC3;   blocksize = 16;  cflags = TEX_FILTER_DEFAULT; break;
+        case DXGI_FORMAT_BC4_UNORM:         pfEncode = D3DXEncodeBC4U;  blocksize = 8;   cflags = TEX_FILTER_RGB_COPY_RED; break;
+        case DXGI_FORMAT_BC4_SNORM:         pfEncode = D3DXEncodeBC4S;  blocksize = 8;   cflags = TEX_FILTER_RGB_COPY_RED; break;
+        case DXGI_FORMAT_BC5_UNORM:         pfEncode = D3DXEncodeBC5U;  blocksize = 16;  cflags = TEX_FILTER_RGB_COPY_RED | TEX_FILTER_RGB_COPY_GREEN; break;
+        case DXGI_FORMAT_BC5_SNORM:         pfEncode = D3DXEncodeBC5S;  blocksize = 16;  cflags = TEX_FILTER_RGB_COPY_RED | TEX_FILTER_RGB_COPY_GREEN; break;
+        case DXGI_FORMAT_BC6H_UF16:         pfEncode = D3DXEncodeBC6HU; blocksize = 16;  cflags = TEX_FILTER_DEFAULT; break;
+        case DXGI_FORMAT_BC6H_SF16:         pfEncode = D3DXEncodeBC6HS; blocksize = 16;  cflags = TEX_FILTER_DEFAULT; break;
+        case DXGI_FORMAT_BC7_UNORM:
+        case DXGI_FORMAT_BC7_UNORM_SRGB:    pfEncode = D3DXEncodeBC7;   blocksize = 16;  cflags = TEX_FILTER_DEFAULT; break;
+        default:                            pfEncode = nullptr;         blocksize = 0;   cflags = TEX_FILTER_DEFAULT; return false;
+        }
+
+        return true;
+    }
+
+
+    //-------------------------------------------------------------------------------------
+    HRESULT CompressBC(
+        const Image& image,
+        const Image& result,
+        uint32_t bcflags,
+        TEX_FILTER_FLAGS srgb,
+        float threshold,
+        const std::function<bool __cdecl(size_t, size_t)>& statusCallback) noexcept
+    {
+        if (!image.pixels || !result.pixels)
+            return E_POINTER;
+
+        assert(image.width == result.width);
+        assert(image.height == result.height);
+
+        const DXGI_FORMAT format = image.format;
+        size_t sbpp = BitsPerPixel(format);
+        if (!sbpp)
+            return E_FAIL;
+
+        if (sbpp < 8)
+        {
+            // We don't support compressing from monochrome (DXGI_FORMAT_R1_UNORM)
+            return HRESULT_E_NOT_SUPPORTED;
+        }
+
+        // Round to bytes
+        sbpp = (sbpp + 7) / 8;
+
+        uint8_t *pDest = result.pixels;
+
+        // Determine BC format encoder
+        BC_ENCODE pfEncode;
+        size_t blocksize;
+        TEX_FILTER_FLAGS cflags;
+        if (!DetermineEncoderSettings(result.format, pfEncode, blocksize, cflags))
+            return HRESULT_E_NOT_SUPPORTED;
+
+        XM_ALIGNED_DATA(16) XMVECTOR temp[16];
+        const uint8_t *pSrc = image.pixels;
+        const uint8_t *pEnd = image.pixels + image.slicePitch;
+        const size_t rowPitch = image.rowPitch;
+        for (size_t h = 0; h < image.height; h += 4)
+        {
+            if (statusCallback)
+            {
+                if (!statusCallback(h, image.height))
+                {
+                    return E_ABORT;
+                }
+            }
+
+            const uint8_t *sptr = pSrc;
+            uint8_t* dptr = pDest;
+            const size_t ph = std::min<size_t>(4, image.height - h);
+            size_t w = 0;
+            for (size_t count = 0; (count < result.rowPitch) && (w < image.width); count += blocksize, w += 4)
+            {
+                const size_t pw = std::min<size_t>(4, image.width - w);
+                assert(pw > 0 && ph > 0);
+
+                const ptrdiff_t bytesLeft = pEnd - sptr;
+                assert(bytesLeft > 0);
+                size_t bytesToRead = std::min<size_t>(rowPitch, static_cast<size_t>(bytesLeft));
+                if (!LoadScanline(&temp[0], pw, sptr, bytesToRead, format))
+                    return E_FAIL;
+
+                if (ph > 1)
+                {
+                    bytesToRead = std::min<size_t>(rowPitch, static_cast<size_t>(bytesLeft) - rowPitch);
+                    if (!LoadScanline(&temp[4], pw, sptr + rowPitch, bytesToRead, format))
+                        return E_FAIL;
+
+                    if (ph > 2)
+                    {
+                        bytesToRead = std::min<size_t>(rowPitch, static_cast<size_t>(bytesLeft) - rowPitch * 2);
+                        if (!LoadScanline(&temp[8], pw, sptr + rowPitch * 2, bytesToRead, format))
+                            return E_FAIL;
+
+                        if (ph > 3)
+                        {
+                            bytesToRead = std::min<size_t>(rowPitch, static_cast<size_t>(bytesLeft) - rowPitch * 3);
+                            if (!LoadScanline(&temp[12], pw, sptr + rowPitch * 3, bytesToRead, format))
+                                return E_FAIL;
+                        }
+                    }
+                }
+
+                if (pw != 4 || ph != 4)
+                {
+                    // Replicate pixels for partial block
+                    static const size_t uSrc[] = { 0, 0, 0, 1 };
+
+                    if (pw < 4)
+                    {
+                        for (size_t t = 0; t < ph && t < 4; ++t)
+                        {
+                            for (size_t s = pw; s < 4; ++s)
+                            {
+                            #pragma prefast(suppress: 26000, "PREFAST false positive")
+                                temp[(t << 2) | s] = temp[(t << 2) | uSrc[s]];
+                            }
+                        }
+                    }
+
+                    if (ph < 4)
+                    {
+                        for (size_t t = ph; t < 4; ++t)
+                        {
+                            for (size_t s = 0; s < 4; ++s)
+                            {
+                            #pragma prefast(suppress: 26000, "PREFAST false positive")
+                                temp[(t << 2) | s] = temp[(uSrc[t] << 2) | s];
+                            }
+                        }
+                    }
+                }
+
+                ConvertScanline(temp, 16, result.format, format, cflags | srgb);
+
+                if (pfEncode)
+                    pfEncode(dptr, temp, bcflags);
+                else
+                    D3DXEncodeBC1(dptr, temp, threshold, bcflags);
+
+                sptr += sbpp * 4;
+                dptr += blocksize;
+            }
+
+            pSrc += rowPitch * 4;
+            pDest += result.rowPitch;
+        }
+
+        return S_OK;
+    }
+
+
+    //-------------------------------------------------------------------------------------
+#ifdef _OPENMP
+    HRESULT CompressBC_Parallel(
+        const Image& image,
+        const Image& result,
+        uint32_t bcflags,
+        TEX_FILTER_FLAGS srgb,
+        float threshold,
+        const std::function<bool __cdecl(size_t, size_t)>& statusCallback) noexcept
+    {
+        if (!image.pixels || !result.pixels)
+            return E_POINTER;
+
+        assert(image.width == result.width);
+        assert(image.height == result.height);
+
+        const DXGI_FORMAT format = image.format;
+        size_t sbpp = BitsPerPixel(format);
+        if (!sbpp)
+            return E_FAIL;
+
+        if (sbpp < 8)
+        {
+            // We don't support compressing from monochrome (DXGI_FORMAT_R1_UNORM)
+            return HRESULT_E_NOT_SUPPORTED;
+        }
+
+        // Round to bytes
+        sbpp = (sbpp + 7) / 8;
+
+        const uint8_t *pEnd = image.pixels + image.slicePitch;
+
+        // Determine BC format encoder
+        BC_ENCODE pfEncode;
+        size_t blocksize;
+        TEX_FILTER_FLAGS cflags;
+        if (!DetermineEncoderSettings(result.format, pfEncode, blocksize, cflags))
+            return HRESULT_E_NOT_SUPPORTED;
+
+        // Refactored version of loop to support parallel independance
+        const size_t nBlocks = std::max<size_t>(1, (image.width + 3) / 4) * std::max<size_t>(1, (image.height + 3) / 4);
+
+        bool fail = false;
+
+        size_t progress = 0;
+        bool abort = false;
+
+        const size_t progressTotal = std::max<size_t>(1, (image.height + 3) / 4);
+
+#pragma omp parallel for shared(progress)
+        for (int nb = 0; nb < static_cast<int>(nBlocks); ++nb)
+        {
+#pragma omp flush (abort)
+            if (abort)
+            {
+                // Short circuit the loop body if an abort is requested.
+                // OpenMP 2.0 does not support cancellation of a 'parallel for' loop.
+                continue;
+            }
+
+            const int nbWidth = std::max<int>(1, int((image.width + 3) / 4));
+
+            int y = nb / nbWidth;
+            const int x = (nb - (y*nbWidth)) * 4;
+            y *= 4;
+
+            assert((x >= 0) && (x < int(image.width)));
+            assert((y >= 0) && (y < int(image.height)));
+
+            const size_t rowPitch = image.rowPitch;
+            const uint8_t *pSrc = image.pixels + (size_t(y)*rowPitch) + (size_t(x)*sbpp);
+
+            uint8_t *pDest = result.pixels + (size_t(nb)*blocksize);
+
+            const size_t ph = std::min<size_t>(4, image.height - size_t(y));
+            const size_t pw = std::min<size_t>(4, image.width - size_t(x));
+            assert(pw > 0 && ph > 0);
+
+            const ptrdiff_t bytesLeft = pEnd - pSrc;
+            assert(bytesLeft > 0);
+            size_t bytesToRead = std::min<size_t>(rowPitch, size_t(bytesLeft));
+
+            XM_ALIGNED_DATA(16) XMVECTOR temp[16];
+            if (!LoadScanline(&temp[0], pw, pSrc, bytesToRead, format))
+                fail = true;
+
+            if (ph > 1)
+            {
+                bytesToRead = std::min<size_t>(rowPitch, size_t(bytesLeft) - rowPitch);
+                if (!LoadScanline(&temp[4], pw, pSrc + rowPitch, bytesToRead, format))
+                    fail = true;
+
+                if (ph > 2)
+                {
+                    bytesToRead = std::min<size_t>(rowPitch, size_t(bytesLeft) - rowPitch * 2);
+                    if (!LoadScanline(&temp[8], pw, pSrc + rowPitch * 2, bytesToRead, format))
+                        fail = true;
+
+                    if (ph > 3)
+                    {
+                        bytesToRead = std::min<size_t>(rowPitch, size_t(bytesLeft) - rowPitch * 3);
+                        if (!LoadScanline(&temp[12], pw, pSrc + rowPitch * 3, bytesToRead, format))
+                            fail = true;
+                    }
+                }
+            }
+
+            if (pw != 4 || ph != 4)
+            {
+                // Replicate pixels for partial block
+                static const size_t uSrc[] = { 0, 0, 0, 1 };
+
+                if (pw < 4)
+                {
+                    for (size_t t = 0; t < ph && t < 4; ++t)
+                    {
+                        for (size_t s = pw; s < 4; ++s)
+                        {
+                            temp[(t << 2) | s] = temp[(t << 2) | uSrc[s]];
+                        }
+                    }
+                }
+
+                if (ph < 4)
+                {
+                    for (size_t t = ph; t < 4; ++t)
+                    {
+                        for (size_t s = 0; s < 4; ++s)
+                        {
+                            temp[(t << 2) | s] = temp[(uSrc[t] << 2) | s];
+                        }
+                    }
+                }
+            }
+
+            ConvertScanline(temp, 16, result.format, format, cflags | srgb);
+
+            if (pfEncode)
+                pfEncode(pDest, temp, bcflags);
+            else
+                D3DXEncodeBC1(pDest, temp, threshold, bcflags);
+
+            // Report progress when a new row is reached.
+            if (x == 0 && statusCallback)
+            {
+#pragma omp atomic
+                progress += 4;
+
+                if (!statusCallback(progress, progressTotal))
+                {
+                    abort = true;
+#pragma omp flush (abort)
+                }
+            }
+        }
+
+        if (abort)
+        {
+            return E_ABORT;
+        }
+        else
+        {
+            return (fail) ? E_FAIL : S_OK;
+        }
+    }
+#endif // _OPENMP
+
+
+    //-------------------------------------------------------------------------------------
+    DXGI_FORMAT DefaultDecompress(_In_ DXGI_FORMAT format) noexcept
+    {
+        switch (format)
+        {
+        case DXGI_FORMAT_BC1_TYPELESS:
+        case DXGI_FORMAT_BC1_UNORM:
+        case DXGI_FORMAT_BC2_TYPELESS:
+        case DXGI_FORMAT_BC2_UNORM:
+        case DXGI_FORMAT_BC3_TYPELESS:
+        case DXGI_FORMAT_BC3_UNORM:
+        case DXGI_FORMAT_BC7_TYPELESS:
+        case DXGI_FORMAT_BC7_UNORM:
+            return DXGI_FORMAT_R8G8B8A8_UNORM;
+
+        case DXGI_FORMAT_BC1_UNORM_SRGB:
+        case DXGI_FORMAT_BC2_UNORM_SRGB:
+        case DXGI_FORMAT_BC3_UNORM_SRGB:
+        case DXGI_FORMAT_BC7_UNORM_SRGB:
+            return DXGI_FORMAT_R8G8B8A8_UNORM_SRGB;
+
+        case DXGI_FORMAT_BC4_TYPELESS:
+        case DXGI_FORMAT_BC4_UNORM:
+            return DXGI_FORMAT_R8_UNORM;
+
+        case DXGI_FORMAT_BC4_SNORM:
+            return DXGI_FORMAT_R8_SNORM;
+
+        case DXGI_FORMAT_BC5_TYPELESS:
+        case DXGI_FORMAT_BC5_UNORM:
+            return DXGI_FORMAT_R8G8_UNORM;
+
+        case DXGI_FORMAT_BC5_SNORM:
+            return DXGI_FORMAT_R8G8_SNORM;
+
+        case DXGI_FORMAT_BC6H_TYPELESS:
+        case DXGI_FORMAT_BC6H_UF16:
+        case DXGI_FORMAT_BC6H_SF16:
+            // We could use DXGI_FORMAT_R32G32B32_FLOAT here since BC6H is always Alpha 1.0,
+            // but this format is more supported by viewers
+            return DXGI_FORMAT_R32G32B32A32_FLOAT;
+
+        default:
+            return DXGI_FORMAT_UNKNOWN;
+        }
+    }
+
+
+    //-------------------------------------------------------------------------------------
+    HRESULT DecompressBC(_In_ const Image& cImage, _In_ const Image& result) noexcept
+    {
+        if (!cImage.pixels || !result.pixels)
+            return E_POINTER;
+
+        assert(cImage.width == result.width);
+        assert(cImage.height == result.height);
+
+        const DXGI_FORMAT format = result.format;
+        size_t dbpp = BitsPerPixel(format);
+        if (!dbpp)
+            return E_FAIL;
+
+        if (dbpp < 8)
+        {
+            // We don't support decompressing to monochrome (DXGI_FORMAT_R1_UNORM)
+            return HRESULT_E_NOT_SUPPORTED;
+        }
+
+        // Round to bytes
+        dbpp = (dbpp + 7) / 8;
+
+        uint8_t *pDest = result.pixels;
+        if (!pDest)
+            return E_POINTER;
+
+        // Promote "typeless" BC formats
+        DXGI_FORMAT cformat;
+        switch (cImage.format)
+        {
+        case DXGI_FORMAT_BC1_TYPELESS:  cformat = DXGI_FORMAT_BC1_UNORM; break;
+        case DXGI_FORMAT_BC2_TYPELESS:  cformat = DXGI_FORMAT_BC2_UNORM; break;
+        case DXGI_FORMAT_BC3_TYPELESS:  cformat = DXGI_FORMAT_BC3_UNORM; break;
+        case DXGI_FORMAT_BC4_TYPELESS:  cformat = DXGI_FORMAT_BC4_UNORM; break;
+        case DXGI_FORMAT_BC5_TYPELESS:  cformat = DXGI_FORMAT_BC5_UNORM; break;
+        case DXGI_FORMAT_BC6H_TYPELESS: cformat = DXGI_FORMAT_BC6H_UF16; break;
+        case DXGI_FORMAT_BC7_TYPELESS:  cformat = DXGI_FORMAT_BC7_UNORM; break;
+        default:                        cformat = cImage.format;         break;
+        }
+
+        // Determine BC format decoder
+        BC_DECODE pfDecode;
+        size_t sbpp;
+        switch (cformat)
+        {
+        case DXGI_FORMAT_BC1_UNORM:
+        case DXGI_FORMAT_BC1_UNORM_SRGB:    pfDecode = D3DXDecodeBC1;   sbpp = 8;   break;
+        case DXGI_FORMAT_BC2_UNORM:
+        case DXGI_FORMAT_BC2_UNORM_SRGB:    pfDecode = D3DXDecodeBC2;   sbpp = 16;  break;
+        case DXGI_FORMAT_BC3_UNORM:
+        case DXGI_FORMAT_BC3_UNORM_SRGB:    pfDecode = D3DXDecodeBC3;   sbpp = 16;  break;
+        case DXGI_FORMAT_BC4_UNORM:         pfDecode = D3DXDecodeBC4U;  sbpp = 8;   break;
+        case DXGI_FORMAT_BC4_SNORM:         pfDecode = D3DXDecodeBC4S;  sbpp = 8;   break;
+        case DXGI_FORMAT_BC5_UNORM:         pfDecode = D3DXDecodeBC5U;  sbpp = 16;  break;
+        case DXGI_FORMAT_BC5_SNORM:         pfDecode = D3DXDecodeBC5S;  sbpp = 16;  break;
+        case DXGI_FORMAT_BC6H_UF16:         pfDecode = D3DXDecodeBC6HU; sbpp = 16;  break;
+        case DXGI_FORMAT_BC6H_SF16:         pfDecode = D3DXDecodeBC6HS; sbpp = 16;  break;
+        case DXGI_FORMAT_BC7_UNORM:
+        case DXGI_FORMAT_BC7_UNORM_SRGB:    pfDecode = D3DXDecodeBC7;   sbpp = 16;  break;
+        default:
+            return HRESULT_E_NOT_SUPPORTED;
+        }
+
+        XM_ALIGNED_DATA(16) XMVECTOR temp[16];
+        const uint8_t *pSrc = cImage.pixels;
+        const size_t rowPitch = result.rowPitch;
+        for (size_t h = 0; h < cImage.height; h += 4)
+        {
+            const uint8_t *sptr = pSrc;
+            uint8_t* dptr = pDest;
+            const size_t ph = std::min<size_t>(4, cImage.height - h);
+            size_t w = 0;
+            for (size_t count = 0; (count < cImage.rowPitch) && (w < cImage.width); count += sbpp, w += 4)
+            {
+                pfDecode(temp, sptr);
+                ConvertScanline(temp, 16, format, cformat, TEX_FILTER_DEFAULT);
+
+                const size_t pw = std::min<size_t>(4, cImage.width - w);
+                assert(pw > 0 && ph > 0);
+
+                if (!StoreScanline(dptr, rowPitch, format, &temp[0], pw))
+                    return E_FAIL;
+
+                if (ph > 1)
+                {
+                    if (!StoreScanline(dptr + rowPitch, rowPitch, format, &temp[4], pw))
+                        return E_FAIL;
+
+                    if (ph > 2)
+                    {
+                        if (!StoreScanline(dptr + rowPitch * 2, rowPitch, format, &temp[8], pw))
+                            return E_FAIL;
+
+                        if (ph > 3)
+                        {
+                            if (!StoreScanline(dptr + rowPitch * 3, rowPitch, format, &temp[12], pw))
+                                return E_FAIL;
+                        }
+                    }
+                }
+
+                sptr += sbpp;
+                dptr += dbpp * 4;
+            }
+
+            pSrc += cImage.rowPitch;
+            pDest += rowPitch * 4;
+        }
+
+        return S_OK;
+    }
+}
+
+//-------------------------------------------------------------------------------------
+bool DirectX::Internal::IsAlphaAllOpaqueBC(_In_ const Image& cImage) noexcept
+{
+    if (!cImage.pixels)
+        return false;
+
+    // Promote "typeless" BC formats
+    DXGI_FORMAT cformat;
+    switch (cImage.format)
+    {
+    case DXGI_FORMAT_BC1_TYPELESS:  cformat = DXGI_FORMAT_BC1_UNORM; break;
+    case DXGI_FORMAT_BC2_TYPELESS:  cformat = DXGI_FORMAT_BC2_UNORM; break;
+    case DXGI_FORMAT_BC3_TYPELESS:  cformat = DXGI_FORMAT_BC3_UNORM; break;
+    case DXGI_FORMAT_BC7_TYPELESS:  cformat = DXGI_FORMAT_BC7_UNORM; break;
+    default:                        cformat = cImage.format;         break;
+    }
+
+    // Determine BC format decoder
+    BC_DECODE pfDecode;
+    size_t sbpp;
+    switch (cformat)
+    {
+    case DXGI_FORMAT_BC1_UNORM:
+    case DXGI_FORMAT_BC1_UNORM_SRGB:    pfDecode = D3DXDecodeBC1;   sbpp = 8;   break;
+    case DXGI_FORMAT_BC2_UNORM:
+    case DXGI_FORMAT_BC2_UNORM_SRGB:    pfDecode = D3DXDecodeBC2;   sbpp = 16;  break;
+    case DXGI_FORMAT_BC3_UNORM:
+    case DXGI_FORMAT_BC3_UNORM_SRGB:    pfDecode = D3DXDecodeBC3;   sbpp = 16;  break;
+    case DXGI_FORMAT_BC7_UNORM:
+    case DXGI_FORMAT_BC7_UNORM_SRGB:    pfDecode = D3DXDecodeBC7;   sbpp = 16;  break;
+    default:
+        // BC4, BC5, and BC6 don't have alpha channels
+        return false;
+    }
+
+    // Scan blocks for non-opaque alpha
+    static const XMVECTORF32 threshold = { { { 0.99f, 0.99f, 0.99f, 0.99f } } };
+
+    XM_ALIGNED_DATA(16) XMVECTOR temp[16];
+    const uint8_t* pPixels = cImage.pixels;
+    for (size_t h = 0; h < cImage.height; h += 4)
+    {
+        const uint8_t* ptr = pPixels;
+        const size_t ph = std::min<size_t>(4, cImage.height - h);
+        size_t w = 0;
+        for (size_t count = 0; (count < cImage.rowPitch) && (w < cImage.width); count += sbpp, w += 4)
+        {
+            pfDecode(temp, ptr);
+
+            const size_t pw = std::min<size_t>(4, cImage.width - w);
+            assert(pw > 0 && ph > 0);
+
+            if (pw == 4 && ph == 4)
+            {
+                // Full blocks
+                for (size_t j = 0; j < 16; ++j)
+                {
+                    const XMVECTOR alpha = XMVectorSplatW(temp[j]);
+                    if (XMVector4Less(alpha, threshold))
+                        return false;
+                }
+            }
+            else
+            {
+                // Handle partial blocks
+                for (size_t y = 0; y < ph; ++y)
+                {
+                    for (size_t x = 0; x < pw; ++x)
+                    {
+                        const XMVECTOR alpha = XMVectorSplatW(temp[y * 4 + x]);
+                        if (XMVector4Less(alpha, threshold))
+                            return false;
+                    }
+                }
+            }
+
+            ptr += sbpp;
+        }
+
+        pPixels += cImage.rowPitch;
+    }
+
+    return true;
+}
+
+
+//=====================================================================================
+// Entry-points
+//=====================================================================================
+
+//-------------------------------------------------------------------------------------
+// Compression
+//-------------------------------------------------------------------------------------
+_Use_decl_annotations_
+HRESULT DirectX::Compress(
+    const Image& srcImage,
+    DXGI_FORMAT format,
+    TEX_COMPRESS_FLAGS compress,
+    float threshold,
+    ScratchImage& image) noexcept
+{
+    CompressOptions options = {};
+    options.flags = compress;
+    options.threshold = threshold;
+
+    return CompressEx(srcImage, format, options, image, nullptr);
+}
+
+_Use_decl_annotations_
+HRESULT DirectX::Compress(
+    const Image* srcImages,
+    size_t nimages,
+    const TexMetadata& metadata,
+    DXGI_FORMAT format,
+    TEX_COMPRESS_FLAGS compress,
+    float threshold,
+    ScratchImage& cImages) noexcept
+{
+    CompressOptions options = {};
+    options.flags = compress;
+    options.threshold = threshold;
+
+    return CompressEx(srcImages, nimages, metadata, format, options, cImages, nullptr);
+}
+
+_Use_decl_annotations_
+HRESULT DirectX::CompressEx(
+    const Image& srcImage,
+    DXGI_FORMAT format,
+    const CompressOptions& options,
+    ScratchImage& image,
+    std::function<bool __cdecl(size_t, size_t)> statusCallback)
+{
+    if (IsCompressed(srcImage.format) || !IsCompressed(format))
+        return E_INVALIDARG;
+
+    if (IsTypeless(format)
+        || IsTypeless(srcImage.format) || IsPlanar(srcImage.format) || IsPalettized(srcImage.format))
+        return HRESULT_E_NOT_SUPPORTED;
+
+    // Create compressed image
+    HRESULT hr = image.Initialize2D(format, srcImage.width, srcImage.height, 1, 1);
+    if (FAILED(hr))
+        return hr;
+
+    const Image *img = image.GetImage(0, 0, 0);
+    if (!img)
+    {
+        image.Release();
+        return E_POINTER;
+    }
+
+    if (statusCallback)
+    {
+        if (!statusCallback(0, img->height))
+        {
+            image.Release();
+            return E_ABORT;
+        }
+    }
+
+    // Compress single image
+    if (options.flags & TEX_COMPRESS_PARALLEL)
+    {
+    #ifndef _OPENMP
+        hr = E_NOTIMPL;
+    #else
+        hr = CompressBC_Parallel(srcImage, *img, GetBCFlags(options.flags), GetSRGBFlags(options.flags), options.threshold, statusCallback);
+    #endif // _OPENMP
+    }
+    else
+    {
+        hr = CompressBC(srcImage, *img, GetBCFlags(options.flags), GetSRGBFlags(options.flags), options.threshold, statusCallback);
+    }
+
+    if (FAILED(hr))
+    {
+        image.Release();
+        return hr;
+    }
+
+    if (statusCallback)
+    {
+        if (!statusCallback(img->height, img->height))
+        {
+            image.Release();
+            return E_ABORT;
+        }
+    }
+
+    return S_OK;
+}
+
+_Use_decl_annotations_
+HRESULT DirectX::CompressEx(
+    const Image* srcImages,
+    size_t nimages,
+    const TexMetadata& metadata,
+    DXGI_FORMAT format,
+    const CompressOptions& options,
+    ScratchImage& cImages,
+    std::function<bool __cdecl(size_t, size_t)> statusCallback)
+{
+    if (!srcImages || !nimages)
+        return E_INVALIDARG;
+
+    if (IsCompressed(metadata.format) || !IsCompressed(format))
+        return E_INVALIDARG;
+
+    if (IsTypeless(format)
+        || IsTypeless(metadata.format) || IsPlanar(metadata.format) || IsPalettized(metadata.format))
+        return HRESULT_E_NOT_SUPPORTED;
+
+    cImages.Release();
+
+    if (statusCallback
+        && nimages == 1
+        && !metadata.IsVolumemap()
+        && metadata.mipLevels == 1
+        && metadata.arraySize == 1)
+    {
+        // If progress reporting is requested when compressing a single 1D or 2D image, call
+        // the CompressEx overload that takes a single image.
+        // This provides a better user experience as progress will be reported as the image
+        // is being processed, instead of after processing has been completed.
+        return CompressEx(srcImages[0], format, options, cImages, statusCallback);
+    }
+
+    TexMetadata mdata2 = metadata;
+    mdata2.format = format;
+    HRESULT hr = cImages.Initialize(mdata2);
+    if (FAILED(hr))
+        return hr;
+
+    if (nimages != cImages.GetImageCount())
+    {
+        cImages.Release();
+        return E_FAIL;
+    }
+
+    const Image* dest = cImages.GetImages();
+    if (!dest)
+    {
+        cImages.Release();
+        return E_POINTER;
+    }
+
+    if (statusCallback)
+    {
+        if (!statusCallback(0, nimages))
+        {
+            cImages.Release();
+            return E_ABORT;
+        }
+    }
+
+    for (size_t index = 0; index < nimages; ++index)
+    {
+        assert(dest[index].format == format);
+
+        const Image& src = srcImages[index];
+
+        if (src.width != dest[index].width || src.height != dest[index].height)
+        {
+            cImages.Release();
+            return E_FAIL;
+        }
+
+        if (options.flags & TEX_COMPRESS_PARALLEL)
+        {
+        #ifndef _OPENMP
+            hr = E_NOTIMPL;
+        #else
+            hr = CompressBC_Parallel(src, dest[index], GetBCFlags(options.flags), GetSRGBFlags(options.flags), options.threshold, nullptr);
+        #endif // _OPENMP
+        }
+        else
+        {
+            hr = CompressBC(src, dest[index], GetBCFlags(options.flags), GetSRGBFlags(options.flags), options.threshold, nullptr);
+        }
+
+        if (FAILED(hr))
+        {
+            cImages.Release();
+            return hr;
+        }
+
+        if (statusCallback)
+        {
+            if (!statusCallback(index, nimages))
+            {
+                cImages.Release();
+                return E_ABORT;
+            }
+        }
+    }
+
+    if (statusCallback)
+    {
+        if (!statusCallback(nimages, nimages))
+        {
+            cImages.Release();
+            return E_ABORT;
+        }
+    }
+
+    return S_OK;
+}
+
+
+//-------------------------------------------------------------------------------------
+// Decompression
+//-------------------------------------------------------------------------------------
+_Use_decl_annotations_
+HRESULT DirectX::Decompress(
+    const Image& cImage,
+    DXGI_FORMAT format,
+    ScratchImage& image) noexcept
+{
+    if (!IsCompressed(cImage.format) || IsCompressed(format))
+        return E_INVALIDARG;
+
+    if (format == DXGI_FORMAT_UNKNOWN)
+    {
+        // Pick a default decompressed format based on BC input format
+        format = DefaultDecompress(cImage.format);
+        if (format == DXGI_FORMAT_UNKNOWN)
+        {
+            // Input is not a compressed format
+            return E_INVALIDARG;
+        }
+    }
+    else
+    {
+        if (!IsValid(format))
+            return E_INVALIDARG;
+
+        if (IsTypeless(format) || IsPlanar(format) || IsPalettized(format))
+            return HRESULT_E_NOT_SUPPORTED;
+    }
+
+    // Create decompressed image
+    HRESULT hr = image.Initialize2D(format, cImage.width, cImage.height, 1, 1);
+    if (FAILED(hr))
+        return hr;
+
+    const Image *img = image.GetImage(0, 0, 0);
+    if (!img)
+    {
+        image.Release();
+        return E_POINTER;
+    }
+
+    // Decompress single image
+    hr = DecompressBC(cImage, *img);
+    if (FAILED(hr))
+        image.Release();
+
+    return hr;
+}
+
+_Use_decl_annotations_
+HRESULT DirectX::Decompress(
+    const Image* cImages,
+    size_t nimages,
+    const TexMetadata& metadata,
+    DXGI_FORMAT format,
+    ScratchImage& images) noexcept
+{
+    if (!cImages || !nimages)
+        return E_INVALIDARG;
+
+    if (!IsCompressed(metadata.format) || IsCompressed(format))
+        return E_INVALIDARG;
+
+    if (format == DXGI_FORMAT_UNKNOWN)
+    {
+        // Pick a default decompressed format based on BC input format
+        format = DefaultDecompress(cImages[0].format);
+        if (format == DXGI_FORMAT_UNKNOWN)
+        {
+            // Input is not a compressed format
+            return E_FAIL;
+        }
+    }
+    else
+    {
+        if (!IsValid(format))
+            return E_INVALIDARG;
+
+        if (IsTypeless(format) || IsPlanar(format) || IsPalettized(format))
+            return HRESULT_E_NOT_SUPPORTED;
+    }
+
+    images.Release();
+
+    TexMetadata mdata2 = metadata;
+    mdata2.format = format;
+    HRESULT hr = images.Initialize(mdata2);
+    if (FAILED(hr))
+        return hr;
+
+    if (nimages != images.GetImageCount())
+    {
+        images.Release();
+        return E_FAIL;
+    }
+
+    const Image* dest = images.GetImages();
+    if (!dest)
+    {
+        images.Release();
+        return E_POINTER;
+    }
+
+    for (size_t index = 0; index < nimages; ++index)
+    {
+        assert(dest[index].format == format);
+
+        const Image& src = cImages[index];
+        if (!IsCompressed(src.format))
+        {
+            images.Release();
+            return E_FAIL;
+        }
+
+        if (src.width != dest[index].width || src.height != dest[index].height)
+        {
+            images.Release();
+            return E_FAIL;
+        }
+
+        hr = DecompressBC(src, dest[index]);
+        if (FAILED(hr))
+        {
+            images.Release();
+            return hr;
+        }
+    }
+
+    return S_OK;
+}

--- a/DirectXTex/DirectXTex/DirectXTexConvert.cpp
+++ b/DirectXTex/DirectXTex/DirectXTexConvert.cpp
@@ -1,0 +1,5546 @@
+//-------------------------------------------------------------------------------------
+// DirectXTexConvert.cpp
+//
+// DirectX Texture Library - Image pixel format conversion
+//
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+//
+// http://go.microsoft.com/fwlink/?LinkId=248926
+//-------------------------------------------------------------------------------------
+
+#include "DirectXTexP.h"
+
+using namespace DirectX;
+using namespace DirectX::Internal;
+using namespace DirectX::PackedVector;
+using Microsoft::WRL::ComPtr;
+
+namespace
+{
+    inline uint32_t FloatTo7e3(float Value) noexcept
+    {
+        uint32_t IValue = reinterpret_cast<uint32_t *>(&Value)[0];
+
+        if (IValue & 0x80000000U)
+        {
+            // Positive only
+            return 0;
+        }
+        else if (IValue > 0x41FF73FFU)
+        {
+            // The number is too large to be represented as a 7e3. Saturate.
+            return 0x3FFU;
+        }
+        else
+        {
+            if (IValue < 0x3E800000U)
+            {
+                // The number is too small to be represented as a normalized 7e3.
+                // Convert it to a denormalized value.
+                const uint32_t Shift = std::min<uint32_t>(125U - (IValue >> 23U), 24U);
+                IValue = (0x800000U | (IValue & 0x7FFFFFU)) >> Shift;
+            }
+            else
+            {
+                // Rebias the exponent to represent the value as a normalized 7e3.
+                IValue += 0xC2000000U;
+            }
+
+            return ((IValue + 0x7FFFU + ((IValue >> 16U) & 1U)) >> 16U) & 0x3FFU;
+        }
+    }
+
+    inline float FloatFrom7e3(uint32_t Value) noexcept
+    {
+        auto Mantissa = static_cast<uint32_t>(Value & 0x7F);
+
+        uint32_t Exponent = (Value & 0x380);
+        if (Exponent != 0)  // The value is normalized
+        {
+            Exponent = static_cast<uint32_t>((Value >> 7) & 0x7);
+        }
+        else if (Mantissa != 0)     // The value is denormalized
+        {
+            // Normalize the value in the resulting float
+            Exponent = 1;
+
+            do
+            {
+                Exponent--;
+                Mantissa <<= 1;
+            }
+            while ((Mantissa & 0x80) == 0);
+
+            Mantissa &= 0x7F;
+        }
+        else                        // The value is zero
+        {
+            Exponent = uint32_t(-124);
+        }
+
+        const uint32_t Result = ((Exponent + 124) << 23) | // Exponent
+            (Mantissa << 16);          // Mantissa
+
+        return reinterpret_cast<const float*>(&Result)[0];
+    }
+
+    inline uint32_t FloatTo6e4(float Value) noexcept
+    {
+        uint32_t IValue = reinterpret_cast<uint32_t *>(&Value)[0];
+
+        if (IValue & 0x80000000U)
+        {
+            // Positive only
+            return 0;
+        }
+        else if (IValue > 0x43FEFFFFU)
+        {
+            // The number is too large to be represented as a 6e4. Saturate.
+            return 0x3FFU;
+        }
+        else
+        {
+            if (IValue < 0x3C800000U)
+            {
+                // The number is too small to be represented as a normalized 6e4.
+                // Convert it to a denormalized value.
+                const uint32_t Shift = std::min<uint32_t>(121U - (IValue >> 23U), 24U);
+                IValue = (0x800000U | (IValue & 0x7FFFFFU)) >> Shift;
+            }
+            else
+            {
+                // Rebias the exponent to represent the value as a normalized 6e4.
+                IValue += 0xC4000000U;
+            }
+
+            return ((IValue + 0xFFFFU + ((IValue >> 17U) & 1U)) >> 17U) & 0x3FFU;
+        }
+    }
+
+    inline float FloatFrom6e4(uint32_t Value) noexcept
+    {
+        uint32_t Mantissa = static_cast<uint32_t>(Value & 0x3F);
+
+        uint32_t Exponent = (Value & 0x3C0);
+        if (Exponent != 0)  // The value is normalized
+        {
+            Exponent = static_cast<uint32_t>((Value >> 6) & 0xF);
+        }
+        else if (Mantissa != 0)     // The value is denormalized
+        {
+            // Normalize the value in the resulting float
+            Exponent = 1;
+
+            do
+            {
+                Exponent--;
+                Mantissa <<= 1;
+            }
+            while ((Mantissa & 0x40) == 0);
+
+            Mantissa &= 0x3F;
+        }
+        else                        // The value is zero
+        {
+            Exponent = uint32_t(-120);
+        }
+
+        const uint32_t Result = ((Exponent + 120) << 23) | // Exponent
+            (Mantissa << 17);          // Mantissa
+
+        return reinterpret_cast<const float*>(&Result)[0];
+    }
+
+#if DIRECTX_MATH_VERSION >= 310
+#define StoreFloat3SE XMStoreFloat3SE
+#else
+    inline void XM_CALLCONV StoreFloat3SE(_Out_ XMFLOAT3SE* pDestination, DirectX::FXMVECTOR V)
+    {
+        assert(pDestination);
+
+        DirectX::XMFLOAT3A tmp;
+        DirectX::XMStoreFloat3A(&tmp, V);
+
+        constexpr float maxf9 = float(0x1FF << 7);
+        constexpr float minf9 = float(1.f / (1 << 16));
+
+        float x = (tmp.x >= 0.f) ? ((tmp.x > maxf9) ? maxf9 : tmp.x) : 0.f;
+        float y = (tmp.y >= 0.f) ? ((tmp.y > maxf9) ? maxf9 : tmp.y) : 0.f;
+        float z = (tmp.z >= 0.f) ? ((tmp.z > maxf9) ? maxf9 : tmp.z) : 0.f;
+
+        const float max_xy = (x > y) ? x : y;
+        const float max_xyz = (max_xy > z) ? max_xy : z;
+
+        const float maxColor = (max_xyz > minf9) ? max_xyz : minf9;
+
+        union { float f; int32_t i; } fi;
+        fi.f = maxColor;
+        fi.i += 0x00004000; // round up leaving 9 bits in fraction (including assumed 1)
+
+        // Fix applied from DirectXMath 3.10
+        uint32_t exp = fi.i >> 23;
+        pDestination->e = exp - 0x6f;
+
+        fi.i = 0x83000000 - (exp << 23);
+        float ScaleR = fi.f;
+
+        pDestination->xm = static_cast<uint32_t>(lroundf(x * ScaleR));
+        pDestination->ym = static_cast<uint32_t>(lroundf(y * ScaleR));
+        pDestination->zm = static_cast<uint32_t>(lroundf(z * ScaleR));
+    }
+#endif
+
+    const XMVECTORF32 g_Grayscale = { { { 0.2125f, 0.7154f, 0.0721f, 0.0f } } };
+    const XMVECTORF32 g_HalfMin = { { { -65504.f, -65504.f, -65504.f, -65504.f } } };
+    const XMVECTORF32 g_HalfMax = { { { 65504.f, 65504.f, 65504.f, 65504.f } } };
+    const XMVECTORF32 g_8BitBias = { { { 0.5f / 255.f, 0.5f / 255.f, 0.5f / 255.f, 0.5f / 255.f } } };
+}
+
+//-------------------------------------------------------------------------------------
+// Copies an image row with optional clearing of alpha value to 1.0
+// (can be used in place as well) otherwise copies the image row unmodified.
+//-------------------------------------------------------------------------------------
+_Use_decl_annotations_
+void DirectX::Internal::CopyScanline(
+    void* pDestination,
+    size_t outSize,
+    const void* pSource,
+    size_t inSize,
+    DXGI_FORMAT format,
+    uint32_t tflags) noexcept
+{
+    assert(pDestination && outSize > 0);
+    assert(pSource && inSize > 0);
+    assert(IsValid(format) && !IsPalettized(format));
+
+    if (tflags & TEXP_SCANLINE_SETALPHA)
+    {
+        switch (static_cast<int>(format))
+        {
+            //-----------------------------------------------------------------------------
+        case DXGI_FORMAT_R32G32B32A32_TYPELESS:
+        case DXGI_FORMAT_R32G32B32A32_FLOAT:
+        case DXGI_FORMAT_R32G32B32A32_UINT:
+        case DXGI_FORMAT_R32G32B32A32_SINT:
+            if (inSize >= 16 && outSize >= 16)
+            {
+                uint32_t alpha;
+                if (format == DXGI_FORMAT_R32G32B32A32_FLOAT)
+                    alpha = 0x3f800000;
+                else if (format == DXGI_FORMAT_R32G32B32A32_SINT)
+                    alpha = 0x7fffffff;
+                else
+                    alpha = 0xffffffff;
+
+                if (pDestination == pSource)
+                {
+                    auto dPtr = static_cast<uint32_t*>(pDestination);
+                    for (size_t count = 0; count < (outSize - 15); count += 16)
+                    {
+                        dPtr += 3;
+                        *(dPtr++) = alpha;
+                    }
+                }
+                else
+                {
+                    const uint32_t * __restrict sPtr = static_cast<const uint32_t*>(pSource);
+                    uint32_t * __restrict dPtr = static_cast<uint32_t*>(pDestination);
+                    const size_t size = std::min<size_t>(outSize, inSize);
+                    for (size_t count = 0; count < (size - 15); count += 16)
+                    {
+                        *(dPtr++) = *(sPtr++);
+                        *(dPtr++) = *(sPtr++);
+                        *(dPtr++) = *(sPtr++);
+                        *(dPtr++) = alpha;
+                        ++sPtr;
+                    }
+                }
+            }
+            return;
+
+            //-----------------------------------------------------------------------------
+        case DXGI_FORMAT_R16G16B16A16_TYPELESS:
+        case DXGI_FORMAT_R16G16B16A16_FLOAT:
+        case DXGI_FORMAT_R16G16B16A16_UNORM:
+        case DXGI_FORMAT_R16G16B16A16_UINT:
+        case DXGI_FORMAT_R16G16B16A16_SNORM:
+        case DXGI_FORMAT_R16G16B16A16_SINT:
+        case DXGI_FORMAT_Y416:
+            if (inSize >= 8 && outSize >= 8)
+            {
+                uint16_t alpha;
+                if (format == DXGI_FORMAT_R16G16B16A16_FLOAT)
+                    alpha = 0x3c00;
+                else if (format == DXGI_FORMAT_R16G16B16A16_SNORM || format == DXGI_FORMAT_R16G16B16A16_SINT)
+                    alpha = 0x7fff;
+                else
+                    alpha = 0xffff;
+
+                if (pDestination == pSource)
+                {
+                    auto dPtr = static_cast<uint16_t*>(pDestination);
+                    for (size_t count = 0; count < (outSize - 7); count += 8)
+                    {
+                        dPtr += 3;
+                        *(dPtr++) = alpha;
+                    }
+                }
+                else
+                {
+                    const uint16_t * __restrict sPtr = static_cast<const uint16_t*>(pSource);
+                    uint16_t * __restrict dPtr = static_cast<uint16_t*>(pDestination);
+                    const size_t size = std::min<size_t>(outSize, inSize);
+                    for (size_t count = 0; count < (size - 7); count += 8)
+                    {
+                        *(dPtr++) = *(sPtr++);
+                        *(dPtr++) = *(sPtr++);
+                        *(dPtr++) = *(sPtr++);
+                        *(dPtr++) = alpha;
+                        ++sPtr;
+                    }
+                }
+            }
+            return;
+
+            //-----------------------------------------------------------------------------
+        case DXGI_FORMAT_R10G10B10A2_TYPELESS:
+        case DXGI_FORMAT_R10G10B10A2_UNORM:
+        case DXGI_FORMAT_R10G10B10A2_UINT:
+        case DXGI_FORMAT_R10G10B10_XR_BIAS_A2_UNORM:
+        case DXGI_FORMAT_Y410:
+        case XBOX_DXGI_FORMAT_R10G10B10_7E3_A2_FLOAT:
+        case XBOX_DXGI_FORMAT_R10G10B10_6E4_A2_FLOAT:
+        case XBOX_DXGI_FORMAT_R10G10B10_SNORM_A2_UNORM:
+            if (inSize >= 4 && outSize >= 4)
+            {
+                if (pDestination == pSource)
+                {
+                    auto dPtr = static_cast<uint32_t*>(pDestination);
+                    for (size_t count = 0; count < (outSize - 3); count += 4)
+                    {
+                        *dPtr |= 0xC0000000;
+                        ++dPtr;
+                    }
+                }
+                else
+                {
+                    const uint32_t * __restrict sPtr = static_cast<const uint32_t*>(pSource);
+                    uint32_t * __restrict dPtr = static_cast<uint32_t*>(pDestination);
+                    const size_t size = std::min<size_t>(outSize, inSize);
+                    for (size_t count = 0; count < (size - 3); count += 4)
+                    {
+                        *(dPtr++) = *(sPtr++) | 0xC0000000;
+                    }
+                }
+            }
+            return;
+
+            //-----------------------------------------------------------------------------
+        case DXGI_FORMAT_R8G8B8A8_TYPELESS:
+        case DXGI_FORMAT_R8G8B8A8_UNORM:
+        case DXGI_FORMAT_R8G8B8A8_UNORM_SRGB:
+        case DXGI_FORMAT_R8G8B8A8_UINT:
+        case DXGI_FORMAT_R8G8B8A8_SNORM:
+        case DXGI_FORMAT_R8G8B8A8_SINT:
+        case DXGI_FORMAT_B8G8R8A8_UNORM:
+        case DXGI_FORMAT_B8G8R8A8_TYPELESS:
+        case DXGI_FORMAT_B8G8R8A8_UNORM_SRGB:
+        case DXGI_FORMAT_AYUV:
+            if (inSize >= 4 && outSize >= 4)
+            {
+                const uint32_t alpha = (format == DXGI_FORMAT_R8G8B8A8_SNORM || format == DXGI_FORMAT_R8G8B8A8_SINT) ? 0x7f000000 : 0xff000000;
+
+                if (pDestination == pSource)
+                {
+                    auto dPtr = static_cast<uint32_t*>(pDestination);
+                    for (size_t count = 0; count < (outSize - 3); count += 4)
+                    {
+                        uint32_t t = *dPtr & 0xFFFFFF;
+                        t |= alpha;
+                        *(dPtr++) = t;
+                    }
+                }
+                else
+                {
+                    const uint32_t * __restrict sPtr = static_cast<const uint32_t*>(pSource);
+                    uint32_t * __restrict dPtr = static_cast<uint32_t*>(pDestination);
+                    const size_t size = std::min<size_t>(outSize, inSize);
+                    for (size_t count = 0; count < (size - 3); count += 4)
+                    {
+                        uint32_t t = *(sPtr++) & 0xFFFFFF;
+                        t |= alpha;
+                        *(dPtr++) = t;
+                    }
+                }
+            }
+            return;
+
+            //-----------------------------------------------------------------------------
+        case DXGI_FORMAT_B5G5R5A1_UNORM:
+        case DXGI_FORMAT_B4G4R4A4_UNORM:
+        case WIN11_DXGI_FORMAT_A4B4G4R4_UNORM:
+            if (inSize >= 2 && outSize >= 2)
+            {
+                uint16_t alpha;
+                if (format == DXGI_FORMAT_B4G4R4A4_UNORM)
+                    alpha = 0xF000;
+                else if (format == WIN11_DXGI_FORMAT_A4B4G4R4_UNORM)
+                    alpha = 0x000F;
+                else
+                    alpha = 0x8000;
+
+                if (pDestination == pSource)
+                {
+                    auto dPtr = static_cast<uint16_t*>(pDestination);
+                    for (size_t count = 0; count < (outSize - 1); count += 2)
+                    {
+                        *(dPtr++) |= alpha;
+                    }
+                }
+                else
+                {
+                    const uint16_t * __restrict sPtr = static_cast<const uint16_t*>(pSource);
+                    uint16_t * __restrict dPtr = static_cast<uint16_t*>(pDestination);
+                    const size_t size = std::min<size_t>(outSize, inSize);
+                    for (size_t count = 0; count < (size - 1); count += 2)
+                    {
+                        *(dPtr++) = uint16_t(*(sPtr++) | alpha);
+                    }
+                }
+            }
+            return;
+
+            //-----------------------------------------------------------------------------
+        case DXGI_FORMAT_A8_UNORM:
+            memset(pDestination, 0xff, outSize);
+            return;
+
+        default:
+            break;
+        }
+    }
+
+    // Fall-through case is to just use memcpy (assuming this is not an in-place operation)
+    if (pDestination == pSource)
+        return;
+
+    const size_t size = std::min<size_t>(outSize, inSize);
+    memcpy(pDestination, pSource, size);
+}
+
+
+//-------------------------------------------------------------------------------------
+// Swizzles (RGB <-> BGR) an image row with optional clearing of alpha value to 1.0
+// (can be used in place as well) otherwise copies the image row unmodified.
+//-------------------------------------------------------------------------------------
+_Use_decl_annotations_
+void DirectX::Internal::SwizzleScanline(
+    void* pDestination,
+    size_t outSize,
+    const void* pSource,
+    size_t inSize,
+    DXGI_FORMAT format,
+    uint32_t tflags) noexcept
+{
+    assert(pDestination && outSize > 0);
+    assert(pSource && inSize > 0);
+    assert(IsValid(format) && !IsPlanar(format) && !IsPalettized(format));
+
+    switch (static_cast<int>(format))
+    {
+        //---------------------------------------------------------------------------------
+    case DXGI_FORMAT_R10G10B10A2_TYPELESS:
+    case DXGI_FORMAT_R10G10B10A2_UNORM:
+    case DXGI_FORMAT_R10G10B10A2_UINT:
+    case DXGI_FORMAT_R10G10B10_XR_BIAS_A2_UNORM:
+    case XBOX_DXGI_FORMAT_R10G10B10_SNORM_A2_UNORM:
+        if (inSize >= 4 && outSize >= 4)
+        {
+            if (tflags & TEXP_SCANLINE_LEGACY)
+            {
+                // Swap Red (R) and Blue (B) channel (used for D3DFMT_A2R10G10B10 legacy sources)
+                if (pDestination == pSource)
+                {
+                    auto dPtr = static_cast<uint32_t*>(pDestination);
+                    for (size_t count = 0; count < (outSize - 3); count += 4)
+                    {
+                        const uint32_t t = *dPtr;
+
+                        uint32_t t1 = (t & 0x3ff00000) >> 20;
+                        uint32_t t2 = (t & 0x000003ff) << 20;
+                        uint32_t t3 = (t & 0x000ffc00);
+                        uint32_t ta = (tflags & TEXP_SCANLINE_SETALPHA) ? 0xC0000000 : (t & 0xC0000000);
+
+                        *(dPtr++) = t1 | t2 | t3 | ta;
+                    }
+                }
+                else
+                {
+                    const uint32_t * __restrict sPtr = static_cast<const uint32_t*>(pSource);
+                    uint32_t * __restrict dPtr = static_cast<uint32_t*>(pDestination);
+                    const size_t size = std::min<size_t>(outSize, inSize);
+                    for (size_t count = 0; count < (size - 3); count += 4)
+                    {
+                        const uint32_t t = *(sPtr++);
+
+                        uint32_t t1 = (t & 0x3ff00000) >> 20;
+                        uint32_t t2 = (t & 0x000003ff) << 20;
+                        uint32_t t3 = (t & 0x000ffc00);
+                        uint32_t ta = (tflags & TEXP_SCANLINE_SETALPHA) ? 0xC0000000 : (t & 0xC0000000);
+
+                        *(dPtr++) = t1 | t2 | t3 | ta;
+                    }
+                }
+                return;
+            }
+        }
+        break;
+
+        //---------------------------------------------------------------------------------
+    case DXGI_FORMAT_R8G8B8A8_TYPELESS:
+    case DXGI_FORMAT_R8G8B8A8_UNORM:
+    case DXGI_FORMAT_R8G8B8A8_UNORM_SRGB:
+    case DXGI_FORMAT_B8G8R8A8_UNORM:
+    case DXGI_FORMAT_B8G8R8X8_UNORM:
+    case DXGI_FORMAT_B8G8R8A8_TYPELESS:
+    case DXGI_FORMAT_B8G8R8A8_UNORM_SRGB:
+    case DXGI_FORMAT_B8G8R8X8_TYPELESS:
+    case DXGI_FORMAT_B8G8R8X8_UNORM_SRGB:
+        if (inSize >= 4 && outSize >= 4)
+        {
+            // Swap Red (R) and Blue (B) channels (used to convert from DXGI 1.1 BGR formats to DXGI 1.0 RGB)
+            if (pDestination == pSource)
+            {
+                auto dPtr = static_cast<uint32_t*>(pDestination);
+                for (size_t count = 0; count < (outSize - 3); count += 4)
+                {
+                    const uint32_t t = *dPtr;
+
+                    uint32_t t1 = (t & 0x00ff0000) >> 16;
+                    uint32_t t2 = (t & 0x000000ff) << 16;
+                    uint32_t t3 = (t & 0x0000ff00);
+                    uint32_t ta = (tflags & TEXP_SCANLINE_SETALPHA) ? 0xff000000 : (t & 0xFF000000);
+
+                    *(dPtr++) = t1 | t2 | t3 | ta;
+                }
+            }
+            else
+            {
+                const uint32_t * __restrict sPtr = static_cast<const uint32_t*>(pSource);
+                uint32_t * __restrict dPtr = static_cast<uint32_t*>(pDestination);
+                const size_t size = std::min<size_t>(outSize, inSize);
+                for (size_t count = 0; count < (size - 3); count += 4)
+                {
+                    const uint32_t t = *(sPtr++);
+
+                    uint32_t t1 = (t & 0x00ff0000) >> 16;
+                    uint32_t t2 = (t & 0x000000ff) << 16;
+                    uint32_t t3 = (t & 0x0000ff00);
+                    uint32_t ta = (tflags & TEXP_SCANLINE_SETALPHA) ? 0xff000000 : (t & 0xFF000000);
+
+                    *(dPtr++) = t1 | t2 | t3 | ta;
+                }
+            }
+            return;
+        }
+        break;
+
+        //---------------------------------------------------------------------------------
+    case DXGI_FORMAT_YUY2:
+        if (inSize >= 4 && outSize >= 4)
+        {
+            if (tflags & TEXP_SCANLINE_LEGACY)
+            {
+                // Reorder YUV components (used to convert legacy UYVY -> YUY2)
+                if (pDestination == pSource)
+                {
+                    auto dPtr = static_cast<uint32_t*>(pDestination);
+                    for (size_t count = 0; count < (outSize - 3); count += 4)
+                    {
+                        const uint32_t t = *dPtr;
+
+                        uint32_t t1 = (t & 0x000000ff) << 8;
+                        uint32_t t2 = (t & 0x0000ff00) >> 8;
+                        uint32_t t3 = (t & 0x00ff0000) << 8;
+                        uint32_t t4 = (t & 0xff000000) >> 8;
+
+                        *(dPtr++) = t1 | t2 | t3 | t4;
+                    }
+                }
+                else
+                {
+                    const uint32_t * __restrict sPtr = static_cast<const uint32_t*>(pSource);
+                    uint32_t * __restrict dPtr = static_cast<uint32_t*>(pDestination);
+                    const size_t size = std::min<size_t>(outSize, inSize);
+                    for (size_t count = 0; count < (size - 3); count += 4)
+                    {
+                        const uint32_t t = *(sPtr++);
+
+                        uint32_t t1 = (t & 0x000000ff) << 8;
+                        uint32_t t2 = (t & 0x0000ff00) >> 8;
+                        uint32_t t3 = (t & 0x00ff0000) << 8;
+                        uint32_t t4 = (t & 0xff000000) >> 8;
+
+                        *(dPtr++) = t1 | t2 | t3 | t4;
+                    }
+                }
+                return;
+            }
+        }
+        break;
+
+    default:
+        break;
+    }
+
+    // Fall-through case is to just use memcpy (assuming this is not an in-place operation)
+    if (pDestination == pSource)
+        return;
+
+    const size_t size = std::min<size_t>(outSize, inSize);
+    memcpy(pDestination, pSource, size);
+}
+
+
+//-------------------------------------------------------------------------------------
+// Converts an image row with optional clearing of alpha value to 1.0
+// Returns true if supported, false if expansion case not supported
+//-------------------------------------------------------------------------------------
+_Use_decl_annotations_
+bool DirectX::Internal::ExpandScanline(
+    void* pDestination,
+    size_t outSize,
+    DXGI_FORMAT outFormat,
+    const void* pSource,
+    size_t inSize,
+    DXGI_FORMAT inFormat,
+    uint32_t tflags) noexcept
+{
+    assert(pDestination && outSize > 0);
+    assert(pSource && inSize > 0);
+    assert(IsValid(outFormat) && !IsPlanar(outFormat) && !IsPalettized(outFormat));
+    assert(IsValid(inFormat) && !IsPlanar(inFormat) && !IsPalettized(inFormat));
+
+    switch (static_cast<int>(inFormat))
+    {
+    case DXGI_FORMAT_B5G6R5_UNORM:
+        if (outFormat != DXGI_FORMAT_R8G8B8A8_UNORM)
+            return false;
+
+        // DXGI_FORMAT_B5G6R5_UNORM -> DXGI_FORMAT_R8G8B8A8_UNORM
+        if (inSize >= 2 && outSize >= 4)
+        {
+            const uint16_t * __restrict sPtr = static_cast<const uint16_t*>(pSource);
+            uint32_t * __restrict dPtr = static_cast<uint32_t*>(pDestination);
+
+            for (size_t ocount = 0, icount = 0; ((icount < (inSize - 1)) && (ocount < (outSize - 3))); icount += 2, ocount += 4)
+            {
+                const uint16_t t = *(sPtr++);
+
+                uint32_t t1 = uint32_t(((t & 0xf800) >> 8) | ((t & 0xe000) >> 13));
+                uint32_t t2 = uint32_t(((t & 0x07e0) << 5) | ((t & 0x0600) >> 5));
+                uint32_t t3 = uint32_t(((t & 0x001f) << 19) | ((t & 0x001c) << 14));
+
+                *(dPtr++) = t1 | t2 | t3 | 0xff000000;
+            }
+            return true;
+        }
+        return false;
+
+    case DXGI_FORMAT_B5G5R5A1_UNORM:
+        if (outFormat != DXGI_FORMAT_R8G8B8A8_UNORM)
+            return false;
+
+        // DXGI_FORMAT_B5G5R5A1_UNORM -> DXGI_FORMAT_R8G8B8A8_UNORM
+        if (inSize >= 2 && outSize >= 4)
+        {
+            const uint16_t * __restrict sPtr = static_cast<const uint16_t*>(pSource);
+            uint32_t * __restrict dPtr = static_cast<uint32_t*>(pDestination);
+
+            for (size_t ocount = 0, icount = 0; ((icount < (inSize - 1)) && (ocount < (outSize - 3))); icount += 2, ocount += 4)
+            {
+                const uint16_t t = *(sPtr++);
+
+                uint32_t t1 = uint32_t(((t & 0x7c00) >> 7) | ((t & 0x7000) >> 12));
+                uint32_t t2 = uint32_t(((t & 0x03e0) << 6) | ((t & 0x0380) << 1));
+                uint32_t t3 = uint32_t(((t & 0x001f) << 19) | ((t & 0x001c) << 14));
+                uint32_t ta = (tflags & TEXP_SCANLINE_SETALPHA) ? 0xff000000 : ((t & 0x8000) ? 0xff000000 : 0);
+
+                *(dPtr++) = t1 | t2 | t3 | ta;
+            }
+            return true;
+        }
+        return false;
+
+    case DXGI_FORMAT_B4G4R4A4_UNORM:
+        if (outFormat != DXGI_FORMAT_R8G8B8A8_UNORM)
+            return false;
+
+        // DXGI_FORMAT_B4G4R4A4_UNORM -> DXGI_FORMAT_R8G8B8A8_UNORM
+        if (inSize >= 2 && outSize >= 4)
+        {
+            const uint16_t * __restrict sPtr = static_cast<const uint16_t*>(pSource);
+            uint32_t * __restrict dPtr = static_cast<uint32_t*>(pDestination);
+
+            for (size_t ocount = 0, icount = 0; ((icount < (inSize - 1)) && (ocount < (outSize - 3))); icount += 2, ocount += 4)
+            {
+                const uint16_t t = *(sPtr++);
+
+                uint32_t t1 = uint32_t(((t & 0x0f00) >> 4) | ((t & 0x0f00) >> 8));
+                uint32_t t2 = uint32_t(((t & 0x00f0) << 8) | ((t & 0x00f0) << 4));
+                uint32_t t3 = uint32_t(((t & 0x000f) << 20) | ((t & 0x000f) << 16));
+                uint32_t ta = (tflags & TEXP_SCANLINE_SETALPHA) ? 0xff000000 : uint32_t(((t & 0xf000) << 16) | ((t & 0xf000) << 12));
+
+                *(dPtr++) = t1 | t2 | t3 | ta;
+            }
+            return true;
+        }
+        return false;
+
+    case WIN11_DXGI_FORMAT_A4B4G4R4_UNORM:
+        if (outFormat != DXGI_FORMAT_R8G8B8A8_UNORM)
+            return false;
+
+        // DXGI_FORMAT_A4B4G4R4_UNORM -> DXGI_FORMAT_R8G8B8A8_UNORM
+        if (inSize >= 2 && outSize >= 4)
+        {
+            const uint16_t * __restrict sPtr = static_cast<const uint16_t*>(pSource);
+            uint32_t * __restrict dPtr = static_cast<uint32_t*>(pDestination);
+
+            for (size_t ocount = 0, icount = 0; ((icount < (inSize - 1)) && (ocount < (outSize - 3))); icount += 2, ocount += 4)
+            {
+                const uint16_t t = *(sPtr++);
+
+                uint32_t t1 = uint32_t(((t & 0xf000) >> 8) | ((t & 0xf000) >> 12));
+                uint32_t t2 = uint32_t((t & 0x0f00) | ((t & 0x0f00) << 4));
+                uint32_t t3 = uint32_t(((t & 0x00f0) << 16) | ((t & 0x00f0) << 12));
+                uint32_t ta = (tflags & TEXP_SCANLINE_SETALPHA) ? 0xff000000 : uint32_t(((t & 0x000f) << 28) | ((t & 0x000f) << 24));
+
+                *(dPtr++) = t1 | t2 | t3 | ta;
+            }
+            return true;
+        }
+        return false;
+
+    default:
+        return false;
+    }
+}
+
+
+//-------------------------------------------------------------------------------------
+// Loads an image row into standard RGBA XMVECTOR (aligned) array
+//-------------------------------------------------------------------------------------
+#define LOAD_SCANLINE( type, func )\
+        if (size >= sizeof(type))\
+        {\
+            const type * __restrict sPtr = reinterpret_cast<const type*>(pSource);\
+            for(size_t icount = 0; icount < (size - sizeof(type) + 1); icount += sizeof(type))\
+            {\
+                if (dPtr >= ePtr) break;\
+                *(dPtr++) = func(sPtr++);\
+            }\
+            return true;\
+        }\
+        return false;
+
+#define LOAD_SCANLINE3( type, func, defvec )\
+        if (size >= sizeof(type))\
+        {\
+            const type * __restrict sPtr = reinterpret_cast<const type*>(pSource);\
+            for(size_t icount = 0; icount < (size - sizeof(type) + 1); icount += sizeof(type))\
+            {\
+                const XMVECTOR v = func(sPtr++);\
+                if (dPtr >= ePtr) break;\
+                *(dPtr++) = XMVectorSelect(defvec, v, g_XMSelect1110);\
+            }\
+            return true;\
+        }\
+        return false;
+
+#define LOAD_SCANLINE2( type, func, defvec )\
+        if (size >= sizeof(type))\
+        {\
+            const type * __restrict sPtr = reinterpret_cast<const type*>(pSource);\
+            for(size_t icount = 0; icount < (size - sizeof(type) + 1); icount += sizeof(type))\
+            {\
+                const XMVECTOR v = func(sPtr++);\
+                if (dPtr >= ePtr) break;\
+                *(dPtr++) = XMVectorSelect(defvec, v, g_XMSelect1100);\
+            }\
+            return true;\
+        }\
+        return false;
+
+#pragma warning(suppress: 6101)
+_Use_decl_annotations_ bool DirectX::Internal::LoadScanline(
+    XMVECTOR* pDestination,
+    size_t count,
+    const void* pSource,
+    size_t size,
+    DXGI_FORMAT format) noexcept
+{
+    assert(pDestination && count > 0 && ((reinterpret_cast<uintptr_t>(pDestination) & 0xF) == 0));
+    assert(pSource && size > 0);
+    assert(IsValid(format) && !IsTypeless(format, false) && !IsCompressed(format) && !IsPlanar(format) && !IsPalettized(format));
+
+    XMVECTOR* __restrict dPtr = pDestination;
+    if (!dPtr)
+        return false;
+
+    const XMVECTOR* ePtr = pDestination + count;
+
+    switch (static_cast<int>(format))
+    {
+    case DXGI_FORMAT_R32G32B32A32_FLOAT:
+        {
+            const size_t msize = (size > (sizeof(XMVECTOR)*count)) ? (sizeof(XMVECTOR)*count) : size;
+            memcpy(dPtr, pSource, msize);
+        }
+        return true;
+
+    case DXGI_FORMAT_R32G32B32A32_UINT:
+        LOAD_SCANLINE(XMUINT4, XMLoadUInt4)
+
+    case DXGI_FORMAT_R32G32B32A32_SINT:
+        LOAD_SCANLINE(XMINT4, XMLoadSInt4)
+
+    case DXGI_FORMAT_R32G32B32_FLOAT:
+        LOAD_SCANLINE3(XMFLOAT3, XMLoadFloat3, g_XMIdentityR3)
+
+    case DXGI_FORMAT_R32G32B32_UINT:
+        LOAD_SCANLINE3(XMUINT3, XMLoadUInt3, g_XMIdentityR3)
+
+    case DXGI_FORMAT_R32G32B32_SINT:
+        LOAD_SCANLINE3(XMINT3, XMLoadSInt3, g_XMIdentityR3)
+
+    case DXGI_FORMAT_R16G16B16A16_FLOAT:
+        LOAD_SCANLINE(XMHALF4, XMLoadHalf4)
+
+    case DXGI_FORMAT_R16G16B16A16_UNORM:
+        LOAD_SCANLINE(XMUSHORTN4, XMLoadUShortN4)
+
+    case DXGI_FORMAT_R16G16B16A16_UINT:
+        LOAD_SCANLINE(XMUSHORT4, XMLoadUShort4)
+
+    case DXGI_FORMAT_R16G16B16A16_SNORM:
+        LOAD_SCANLINE(XMSHORTN4, XMLoadShortN4)
+
+    case DXGI_FORMAT_R16G16B16A16_SINT:
+        LOAD_SCANLINE(XMSHORT4, XMLoadShort4)
+
+    case DXGI_FORMAT_R32G32_FLOAT:
+        LOAD_SCANLINE2(XMFLOAT2, XMLoadFloat2, g_XMIdentityR3)
+
+    case DXGI_FORMAT_R32G32_UINT:
+        LOAD_SCANLINE2(XMUINT2, XMLoadUInt2, g_XMIdentityR3)
+
+    case DXGI_FORMAT_R32G32_SINT:
+        LOAD_SCANLINE2(XMINT2, XMLoadSInt2, g_XMIdentityR3)
+
+    case DXGI_FORMAT_D32_FLOAT_S8X24_UINT:
+            {
+                constexpr size_t psize = sizeof(float) + sizeof(uint32_t);
+                if (size >= psize)
+                {
+                    auto sPtr = static_cast<const float*>(pSource);
+                    for (size_t icount = 0; icount < (size - psize + 1); icount += psize)
+                    {
+                        auto ps8 = reinterpret_cast<const uint8_t*>(&sPtr[1]);
+                        if (dPtr >= ePtr) break;
+                        *(dPtr++) = XMVectorSet(sPtr[0], static_cast<float>(*ps8), 0.f, 1.f);
+                        sPtr += 2;
+                    }
+                    return true;
+                }
+            }
+            return false;
+
+    case DXGI_FORMAT_R32_FLOAT_X8X24_TYPELESS:
+        {
+            constexpr size_t psize = sizeof(float) + sizeof(uint32_t);
+            if (size >= psize)
+            {
+                auto sPtr = static_cast<const float*>(pSource);
+                for (size_t icount = 0; icount < (size - psize + 1); icount += psize)
+                {
+                    if (dPtr >= ePtr) break;
+                    *(dPtr++) = XMVectorSet(sPtr[0], 0.f /* typeless component assumed zero */, 0.f, 1.f);
+                    sPtr += 2;
+                }
+                return true;
+            }
+        }
+        return false;
+
+    case DXGI_FORMAT_X32_TYPELESS_G8X24_UINT:
+        {
+            constexpr size_t psize = sizeof(float) + sizeof(uint32_t);
+            if (size >= psize)
+            {
+                auto sPtr = static_cast<const float*>(pSource);
+                for (size_t icount = 0; icount < (size - psize + 1); icount += psize)
+                {
+                    auto pg8 = reinterpret_cast<const uint8_t*>(&sPtr[1]);
+                    if (dPtr >= ePtr) break;
+                    *(dPtr++) = XMVectorSet(0.f /* typeless component assumed zero */, static_cast<float>(*pg8), 0.f, 1.f);
+                    sPtr += 2;
+                }
+                return true;
+            }
+        }
+        return false;
+
+    case DXGI_FORMAT_R10G10B10A2_UNORM:
+        LOAD_SCANLINE(XMUDECN4, XMLoadUDecN4)
+
+    case DXGI_FORMAT_R10G10B10_XR_BIAS_A2_UNORM:
+        LOAD_SCANLINE(XMUDECN4, XMLoadUDecN4_XR)
+
+    case DXGI_FORMAT_R10G10B10A2_UINT:
+        LOAD_SCANLINE(XMUDEC4, XMLoadUDec4)
+
+    case DXGI_FORMAT_R11G11B10_FLOAT:
+        LOAD_SCANLINE3(XMFLOAT3PK, XMLoadFloat3PK, g_XMIdentityR3)
+
+    case DXGI_FORMAT_R8G8B8A8_UNORM:
+    case DXGI_FORMAT_R8G8B8A8_UNORM_SRGB:
+        LOAD_SCANLINE(XMUBYTEN4, XMLoadUByteN4)
+
+    case DXGI_FORMAT_R8G8B8A8_UINT:
+        LOAD_SCANLINE(XMUBYTE4, XMLoadUByte4)
+
+    case DXGI_FORMAT_R8G8B8A8_SNORM:
+        LOAD_SCANLINE(XMBYTEN4, XMLoadByteN4)
+
+    case DXGI_FORMAT_R8G8B8A8_SINT:
+        LOAD_SCANLINE(XMBYTE4, XMLoadByte4)
+
+    case DXGI_FORMAT_R16G16_FLOAT:
+        LOAD_SCANLINE2(XMHALF2, XMLoadHalf2, g_XMIdentityR3)
+
+    case DXGI_FORMAT_R16G16_UNORM:
+        LOAD_SCANLINE2(XMUSHORTN2, XMLoadUShortN2, g_XMIdentityR3)
+
+    case DXGI_FORMAT_R16G16_UINT:
+        LOAD_SCANLINE2(XMUSHORT2, XMLoadUShort2, g_XMIdentityR3)
+
+    case DXGI_FORMAT_R16G16_SNORM:
+        LOAD_SCANLINE2(XMSHORTN2, XMLoadShortN2, g_XMIdentityR3)
+
+    case DXGI_FORMAT_R16G16_SINT:
+        LOAD_SCANLINE2(XMSHORT2, XMLoadShort2, g_XMIdentityR3)
+
+    case DXGI_FORMAT_D32_FLOAT:
+    case DXGI_FORMAT_R32_FLOAT:
+        if (size >= sizeof(float))
+        {
+            const float* __restrict sPtr = static_cast<const float*>(pSource);
+            for (size_t icount = 0; icount < (size - sizeof(float) + 1); icount += sizeof(float))
+            {
+                const XMVECTOR v = XMLoadFloat(sPtr++);
+                if (dPtr >= ePtr) break;
+                *(dPtr++) = XMVectorSelect(g_XMIdentityR3, v, g_XMSelect1000);
+            }
+            return true;
+        }
+        return false;
+
+    case DXGI_FORMAT_R32_UINT:
+        if (size >= sizeof(uint32_t))
+        {
+            const uint32_t* __restrict sPtr = static_cast<const uint32_t*>(pSource);
+            for (size_t icount = 0; icount < (size - sizeof(uint32_t) + 1); icount += sizeof(uint32_t))
+            {
+                XMVECTOR v = XMLoadInt(sPtr++);
+                v = XMConvertVectorUIntToFloat(v, 0);
+                if (dPtr >= ePtr) break;
+                *(dPtr++) = XMVectorSelect(g_XMIdentityR3, v, g_XMSelect1000);
+            }
+            return true;
+        }
+        return false;
+
+    case DXGI_FORMAT_R32_SINT:
+        if (size >= sizeof(int32_t))
+        {
+            const int32_t * __restrict sPtr = static_cast<const int32_t*>(pSource);
+            for (size_t icount = 0; icount < (size - sizeof(int32_t) + 1); icount += sizeof(int32_t))
+            {
+                XMVECTOR v = XMLoadInt(reinterpret_cast<const uint32_t*>(sPtr++));
+                v = XMConvertVectorIntToFloat(v, 0);
+                if (dPtr >= ePtr) break;
+                *(dPtr++) = XMVectorSelect(g_XMIdentityR3, v, g_XMSelect1000);
+            }
+            return true;
+        }
+        return false;
+
+    case DXGI_FORMAT_D24_UNORM_S8_UINT:
+        if (size >= sizeof(uint32_t))
+        {
+            auto sPtr = static_cast<const uint32_t*>(pSource);
+            for (size_t icount = 0; icount < (size - sizeof(uint32_t) + 1); icount += sizeof(uint32_t))
+            {
+                auto const d = static_cast<float>(*sPtr & 0xFFFFFF) / 16777215.f;
+                auto const s = static_cast<float>((*sPtr & 0xFF000000) >> 24);
+                ++sPtr;
+                if (dPtr >= ePtr) break;
+                *(dPtr++) = XMVectorSet(d, s, 0.f, 1.f);
+            }
+            return true;
+        }
+        return false;
+
+    case DXGI_FORMAT_R24_UNORM_X8_TYPELESS:
+        if (size >= sizeof(uint32_t))
+        {
+            auto sPtr = static_cast<const uint32_t*>(pSource);
+            for (size_t icount = 0; icount < (size - sizeof(uint32_t) + 1); icount += sizeof(uint32_t))
+            {
+                auto const r = static_cast<float>(*sPtr & 0xFFFFFF) / 16777215.f;
+                ++sPtr;
+                if (dPtr >= ePtr) break;
+                *(dPtr++) = XMVectorSet(r, 0.f /* typeless component assumed zero */, 0.f, 1.f);
+            }
+            return true;
+        }
+        return false;
+
+    case DXGI_FORMAT_X24_TYPELESS_G8_UINT:
+        if (size >= sizeof(uint32_t))
+        {
+            auto sPtr = static_cast<const uint32_t*>(pSource);
+            for (size_t icount = 0; icount < (size - sizeof(uint32_t) + 1); icount += sizeof(uint32_t))
+            {
+                auto const g = static_cast<float>((*sPtr & 0xFF000000) >> 24);
+                ++sPtr;
+                if (dPtr >= ePtr) break;
+                *(dPtr++) = XMVectorSet(0.f /* typeless component assumed zero */, g, 0.f, 1.f);
+            }
+            return true;
+        }
+        return false;
+
+    case DXGI_FORMAT_R8G8_UNORM:
+        LOAD_SCANLINE2(XMUBYTEN2, XMLoadUByteN2, g_XMIdentityR3)
+
+    case DXGI_FORMAT_R8G8_UINT:
+        LOAD_SCANLINE2(XMUBYTE2, XMLoadUByte2, g_XMIdentityR3)
+
+    case DXGI_FORMAT_R8G8_SNORM:
+        LOAD_SCANLINE2(XMBYTEN2, XMLoadByteN2, g_XMIdentityR3)
+
+    case DXGI_FORMAT_R8G8_SINT:
+        LOAD_SCANLINE2(XMBYTE2, XMLoadByte2, g_XMIdentityR3)
+
+    case DXGI_FORMAT_R16_FLOAT:
+        if (size >= sizeof(HALF))
+        {
+            const HALF * __restrict sPtr = static_cast<const HALF*>(pSource);
+            for (size_t icount = 0; icount < (size - sizeof(HALF) + 1); icount += sizeof(HALF))
+            {
+                if (dPtr >= ePtr) break;
+                *(dPtr++) = XMVectorSet(XMConvertHalfToFloat(*sPtr++), 0.f, 0.f, 1.f);
+            }
+            return true;
+        }
+        return false;
+
+    case DXGI_FORMAT_D16_UNORM:
+    case DXGI_FORMAT_R16_UNORM:
+        if (size >= sizeof(uint16_t))
+        {
+            const uint16_t* __restrict sPtr = static_cast<const uint16_t*>(pSource);
+            for (size_t icount = 0; icount < (size - sizeof(uint16_t) + 1); icount += sizeof(uint16_t))
+            {
+                if (dPtr >= ePtr) break;
+                *(dPtr++) = XMVectorSet(static_cast<float>(*sPtr++) / 65535.f, 0.f, 0.f, 1.f);
+            }
+            return true;
+        }
+        return false;
+
+    case DXGI_FORMAT_R16_UINT:
+        if (size >= sizeof(uint16_t))
+        {
+            const uint16_t * __restrict sPtr = static_cast<const uint16_t*>(pSource);
+            for (size_t icount = 0; icount < (size - sizeof(uint16_t) + 1); icount += sizeof(uint16_t))
+            {
+                if (dPtr >= ePtr) break;
+                *(dPtr++) = XMVectorSet(static_cast<float>(*sPtr++), 0.f, 0.f, 1.f);
+            }
+            return true;
+        }
+        return false;
+
+    case DXGI_FORMAT_R16_SNORM:
+        if (size >= sizeof(int16_t))
+        {
+            const int16_t * __restrict sPtr = static_cast<const int16_t*>(pSource);
+            for (size_t icount = 0; icount < (size - sizeof(int16_t) + 1); icount += sizeof(int16_t))
+            {
+                if (dPtr >= ePtr) break;
+                *(dPtr++) = XMVectorSet(static_cast<float>(*sPtr++) / 32767.f, 0.f, 0.f, 1.f);
+            }
+            return true;
+        }
+        return false;
+
+    case DXGI_FORMAT_R16_SINT:
+        if (size >= sizeof(int16_t))
+        {
+            const int16_t * __restrict sPtr = static_cast<const int16_t*>(pSource);
+            for (size_t icount = 0; icount < (size - sizeof(int16_t) + 1); icount += sizeof(int16_t))
+            {
+                if (dPtr >= ePtr) break;
+                *(dPtr++) = XMVectorSet(static_cast<float>(*sPtr++), 0.f, 0.f, 1.f);
+            }
+            return true;
+        }
+        return false;
+
+    case DXGI_FORMAT_R8_UNORM:
+        if (size >= sizeof(uint8_t))
+        {
+            const uint8_t * __restrict sPtr = static_cast<const uint8_t*>(pSource);
+            for (size_t icount = 0; icount < size; icount += sizeof(uint8_t))
+            {
+                if (dPtr >= ePtr) break;
+                *(dPtr++) = XMVectorSet(static_cast<float>(*sPtr++) / 255.f, 0.f, 0.f, 1.f);
+            }
+            return true;
+        }
+        return false;
+
+    case DXGI_FORMAT_R8_UINT:
+        if (size >= sizeof(uint8_t))
+        {
+            const uint8_t * __restrict sPtr = static_cast<const uint8_t*>(pSource);
+            for (size_t icount = 0; icount < size; icount += sizeof(uint8_t))
+            {
+                if (dPtr >= ePtr) break;
+                *(dPtr++) = XMVectorSet(static_cast<float>(*sPtr++), 0.f, 0.f, 1.f);
+            }
+            return true;
+        }
+        return false;
+
+    case DXGI_FORMAT_R8_SNORM:
+        if (size >= sizeof(int8_t))
+        {
+            const int8_t * __restrict sPtr = static_cast<const int8_t*>(pSource);
+            for (size_t icount = 0; icount < size; icount += sizeof(int8_t))
+            {
+                if (dPtr >= ePtr) break;
+                *(dPtr++) = XMVectorSet(static_cast<float>(*sPtr++) / 127.f, 0.f, 0.f, 1.f);
+            }
+            return true;
+        }
+        return false;
+
+    case DXGI_FORMAT_R8_SINT:
+        if (size >= sizeof(int8_t))
+        {
+            const int8_t * __restrict sPtr = static_cast<const int8_t*>(pSource);
+            for (size_t icount = 0; icount < size; icount += sizeof(int8_t))
+            {
+                if (dPtr >= ePtr) break;
+                *(dPtr++) = XMVectorSet(static_cast<float>(*sPtr++), 0.f, 0.f, 1.f);
+            }
+            return true;
+        }
+        return false;
+
+    case DXGI_FORMAT_A8_UNORM:
+        if (size >= sizeof(uint8_t))
+        {
+            const uint8_t * __restrict sPtr = static_cast<const uint8_t*>(pSource);
+            for (size_t icount = 0; icount < size; icount += sizeof(uint8_t))
+            {
+                if (dPtr >= ePtr) break;
+                *(dPtr++) = XMVectorSet(0.f, 0.f, 0.f, static_cast<float>(*sPtr++) / 255.f);
+            }
+            return true;
+        }
+        return false;
+
+    case DXGI_FORMAT_R1_UNORM:
+        if (size >= sizeof(uint8_t))
+        {
+            const uint8_t * __restrict sPtr = static_cast<const uint8_t*>(pSource);
+            for (size_t icount = 0; icount < size; icount += sizeof(uint8_t))
+            {
+                for (size_t bcount = 8; bcount > 0; --bcount)
+                {
+                    if (dPtr >= ePtr) break;
+                    *(dPtr++) = XMVectorSet((((*sPtr >> (bcount - 1)) & 0x1) ? 1.f : 0.f), 0.f, 0.f, 1.f);
+                }
+
+                ++sPtr;
+            }
+            return true;
+        }
+        return false;
+
+    case DXGI_FORMAT_R9G9B9E5_SHAREDEXP:
+        LOAD_SCANLINE3(XMFLOAT3SE, XMLoadFloat3SE, g_XMIdentityR3)
+
+    case DXGI_FORMAT_R8G8_B8G8_UNORM:
+        if (size >= sizeof(XMUBYTEN4))
+        {
+            const XMUBYTEN4 * __restrict sPtr = static_cast<const XMUBYTEN4*>(pSource);
+            for (size_t icount = 0; icount < (size - sizeof(XMUBYTEN4) + 1); icount += sizeof(XMUBYTEN4))
+            {
+                const XMVECTOR v = XMLoadUByteN4(sPtr++);
+                const XMVECTOR v1 = XMVectorSwizzle<0, 3, 2, 1>(v);
+                if (dPtr >= ePtr) break;
+                *(dPtr++) = XMVectorSelect(g_XMIdentityR3, v, g_XMSelect1110);
+                if (dPtr >= ePtr) break;
+                *(dPtr++) = XMVectorSelect(g_XMIdentityR3, v1, g_XMSelect1110);
+            }
+            return true;
+        }
+        return false;
+
+    case DXGI_FORMAT_G8R8_G8B8_UNORM:
+        if (size >= sizeof(XMUBYTEN4))
+        {
+            const XMUBYTEN4 * __restrict sPtr = static_cast<const XMUBYTEN4*>(pSource);
+            for (size_t icount = 0; icount < (size - sizeof(XMUBYTEN4) + 1); icount += sizeof(XMUBYTEN4))
+            {
+                const XMVECTOR v = XMLoadUByteN4(sPtr++);
+                const XMVECTOR v0 = XMVectorSwizzle<1, 0, 3, 2>(v);
+                const XMVECTOR v1 = XMVectorSwizzle<1, 2, 3, 0>(v);
+                if (dPtr >= ePtr) break;
+                *(dPtr++) = XMVectorSelect(g_XMIdentityR3, v0, g_XMSelect1110);
+                if (dPtr >= ePtr) break;
+                *(dPtr++) = XMVectorSelect(g_XMIdentityR3, v1, g_XMSelect1110);
+            }
+            return true;
+        }
+        return false;
+
+    case DXGI_FORMAT_B5G6R5_UNORM:
+        if (size >= sizeof(XMU565))
+        {
+            static const XMVECTORF32 s_Scale = { { { 1.f / 31.f, 1.f / 63.f, 1.f / 31.f, 1.f } } };
+            const XMU565 * __restrict sPtr = static_cast<const XMU565*>(pSource);
+            for (size_t icount = 0; icount < (size - sizeof(XMU565) + 1); icount += sizeof(XMU565))
+            {
+                XMVECTOR v = XMLoadU565(sPtr++);
+                v = XMVectorMultiply(v, s_Scale);
+                v = XMVectorSwizzle<2, 1, 0, 3>(v);
+                if (dPtr >= ePtr) break;
+                *(dPtr++) = XMVectorSelect(g_XMIdentityR3, v, g_XMSelect1110);
+            }
+            return true;
+        }
+        return false;
+
+    case DXGI_FORMAT_B5G5R5A1_UNORM:
+        if (size >= sizeof(XMU555))
+        {
+            static const XMVECTORF32 s_Scale = { { { 1.f / 31.f, 1.f / 31.f, 1.f / 31.f, 1.f } } };
+            const XMU555 * __restrict sPtr = static_cast<const XMU555*>(pSource);
+            for (size_t icount = 0; icount < (size - sizeof(XMU555) + 1); icount += sizeof(XMU555))
+            {
+                XMVECTOR v = XMLoadU555(sPtr++);
+                v = XMVectorMultiply(v, s_Scale);
+                if (dPtr >= ePtr) break;
+                *(dPtr++) = XMVectorSwizzle<2, 1, 0, 3>(v);
+            }
+            return true;
+        }
+        return false;
+
+    case DXGI_FORMAT_B8G8R8A8_UNORM:
+    case DXGI_FORMAT_B8G8R8A8_UNORM_SRGB:
+        if (size >= sizeof(XMUBYTEN4))
+        {
+            const XMUBYTEN4 * __restrict sPtr = static_cast<const XMUBYTEN4*>(pSource);
+            for (size_t icount = 0; icount < (size - sizeof(XMUBYTEN4) + 1); icount += sizeof(XMUBYTEN4))
+            {
+                const XMVECTOR v = XMLoadUByteN4(sPtr++);
+                if (dPtr >= ePtr) break;
+                *(dPtr++) = XMVectorSwizzle<2, 1, 0, 3>(v);
+            }
+            return true;
+        }
+        return false;
+
+    case DXGI_FORMAT_B8G8R8X8_UNORM:
+    case DXGI_FORMAT_B8G8R8X8_UNORM_SRGB:
+        if (size >= sizeof(XMUBYTEN4))
+        {
+            const XMUBYTEN4 * __restrict sPtr = static_cast<const XMUBYTEN4*>(pSource);
+            for (size_t icount = 0; icount < (size - sizeof(XMUBYTEN4) + 1); icount += sizeof(XMUBYTEN4))
+            {
+                XMVECTOR v = XMLoadUByteN4(sPtr++);
+                v = XMVectorSwizzle<2, 1, 0, 3>(v);
+                if (dPtr >= ePtr) break;
+                *(dPtr++) = XMVectorSelect(g_XMIdentityR3, v, g_XMSelect1110);
+            }
+            return true;
+        }
+        return false;
+
+    case DXGI_FORMAT_AYUV:
+        if (size >= sizeof(XMUBYTEN4))
+        {
+            const XMUBYTEN4 * __restrict sPtr = static_cast<const XMUBYTEN4*>(pSource);
+            for (size_t icount = 0; icount < (size - sizeof(XMUBYTEN4) + 1); icount += sizeof(XMUBYTEN4))
+            {
+                const int v = int(sPtr->x) - 128;
+                const int u = int(sPtr->y) - 128;
+                const int y = int(sPtr->z) - 16;
+                const unsigned int a = sPtr->w;
+                ++sPtr;
+
+                // http://msdn.microsoft.com/en-us/library/windows/desktop/dd206750.aspx
+
+                // Y'  = Y - 16
+                // Cb' = Cb - 128
+                // Cr' = Cr - 128
+
+                // R = 1.1644Y' + 1.5960Cr'
+                // G = 1.1644Y' - 0.3917Cb' - 0.8128Cr'
+                // B = 1.1644Y' + 2.0172Cb'
+
+                const int r = (298 * y + 409 * v + 128) >> 8;
+                const int g = (298 * y - 100 * u - 208 * v + 128) >> 8;
+                const int b = (298 * y + 516 * u + 128) >> 8;
+
+                if (dPtr >= ePtr) break;
+                *(dPtr++) = XMVectorSet(float(std::min<int>(std::max<int>(r, 0), 255)) / 255.f,
+                    float(std::min<int>(std::max<int>(g, 0), 255)) / 255.f,
+                    float(std::min<int>(std::max<int>(b, 0), 255)) / 255.f,
+                    float(a) / 255.f);
+            }
+            return true;
+        }
+        return false;
+
+    case DXGI_FORMAT_Y410:
+        if (size >= sizeof(XMUDECN4))
+        {
+            const XMUDECN4 * __restrict sPtr = static_cast<const XMUDECN4*>(pSource);
+            for (size_t icount = 0; icount < (size - sizeof(XMUDECN4) + 1); icount += sizeof(XMUDECN4))
+            {
+                const int64_t u = int(sPtr->x) - 512;
+                const int64_t y = int(sPtr->y) - 64;
+                const int64_t v = int(sPtr->z) - 512;
+                const unsigned int a = sPtr->w;
+                ++sPtr;
+
+                // http://msdn.microsoft.com/en-us/library/windows/desktop/bb970578.aspx
+
+                // Y'  = Y - 64
+                // Cb' = Cb - 512
+                // Cr' = Cr - 512
+
+                // R = 1.1678Y' + 1.6007Cr'
+                // G = 1.1678Y' - 0.3929Cb' - 0.8152Cr'
+                // B = 1.1678Y' + 2.0232Cb'
+
+                auto const r = static_cast<int>((76533 * y + 104905 * v + 32768) >> 16);
+                auto const g = static_cast<int>((76533 * y - 25747 * u - 53425 * v + 32768) >> 16);
+                auto const b = static_cast<int>((76533 * y + 132590 * u + 32768) >> 16);
+
+                if (dPtr >= ePtr) break;
+                *(dPtr++) = XMVectorSet(float(std::min<int>(std::max<int>(r, 0), 1023)) / 1023.f,
+                    float(std::min<int>(std::max<int>(g, 0), 1023)) / 1023.f,
+                    float(std::min<int>(std::max<int>(b, 0), 1023)) / 1023.f,
+                    float(a) / 3.f);
+            }
+            return true;
+        }
+        return false;
+
+    case DXGI_FORMAT_Y416:
+        if (size >= sizeof(XMUSHORTN4))
+        {
+            const XMUSHORTN4 * __restrict sPtr = static_cast<const XMUSHORTN4*>(pSource);
+            for (size_t icount = 0; icount < (size - sizeof(XMUSHORTN4) + 1); icount += sizeof(XMUSHORTN4))
+            {
+                const int64_t u = int64_t(sPtr->x) - 32768;
+                const int64_t y = int64_t(sPtr->y) - 4096;
+                const int64_t v = int64_t(sPtr->z) - 32768;
+                auto const a = static_cast<int>(sPtr->w);
+                ++sPtr;
+
+                // http://msdn.microsoft.com/en-us/library/windows/desktop/bb970578.aspx
+
+                // Y'  = Y - 4096
+                // Cb' = Cb - 32768
+                // Cr' = Cr - 32768
+
+                // R = 1.1689Y' + 1.6023Cr'
+                // G = 1.1689Y' - 0.3933Cb' - 0.8160Cr'
+                // B = 1.1689Y'+ 2.0251Cb'
+
+                auto const r = static_cast<int>((76607 * y + 105006 * v + 32768) >> 16);
+                auto const g = static_cast<int>((76607 * y - 25772 * u - 53477 * v + 32768) >> 16);
+                auto const b = static_cast<int>((76607 * y + 132718 * u + 32768) >> 16);
+
+                if (dPtr >= ePtr) break;
+                *(dPtr++) = XMVectorSet(float(std::min<int>(std::max<int>(r, 0), 65535)) / 65535.f,
+                    float(std::min<int>(std::max<int>(g, 0), 65535)) / 65535.f,
+                    float(std::min<int>(std::max<int>(b, 0), 65535)) / 65535.f,
+                    float(std::min<int>(std::max<int>(a, 0), 65535)) / 65535.f);
+            }
+            return true;
+        }
+        return false;
+
+    case DXGI_FORMAT_YUY2:
+        if (size >= sizeof(XMUBYTEN4))
+        {
+            const XMUBYTEN4 * __restrict sPtr = static_cast<const XMUBYTEN4*>(pSource);
+            for (size_t icount = 0; icount < (size - sizeof(XMUBYTEN4) + 1); icount += sizeof(XMUBYTEN4))
+            {
+                const int y0 = int(sPtr->x) - 16;
+                const int u = int(sPtr->y) - 128;
+                const int y1 = int(sPtr->z) - 16;
+                const int v = int(sPtr->w) - 128;
+                ++sPtr;
+
+                // See AYUV
+                int r = (298 * y0 + 409 * v + 128) >> 8;
+                int g = (298 * y0 - 100 * u - 208 * v + 128) >> 8;
+                int b = (298 * y0 + 516 * u + 128) >> 8;
+
+                if (dPtr >= ePtr) break;
+                *(dPtr++) = XMVectorSet(float(std::min<int>(std::max<int>(r, 0), 255)) / 255.f,
+                    float(std::min<int>(std::max<int>(g, 0), 255)) / 255.f,
+                    float(std::min<int>(std::max<int>(b, 0), 255)) / 255.f,
+                    1.f);
+
+                r = (298 * y1 + 409 * v + 128) >> 8;
+                g = (298 * y1 - 100 * u - 208 * v + 128) >> 8;
+                b = (298 * y1 + 516 * u + 128) >> 8;
+
+                if (dPtr >= ePtr) break;
+                *(dPtr++) = XMVectorSet(float(std::min<int>(std::max<int>(r, 0), 255)) / 255.f,
+                    float(std::min<int>(std::max<int>(g, 0), 255)) / 255.f,
+                    float(std::min<int>(std::max<int>(b, 0), 255)) / 255.f,
+                    1.f);
+            }
+            return true;
+        }
+        return false;
+
+    case DXGI_FORMAT_Y210:
+        // Same as Y216 with least significant 6 bits set to zero
+        if (size >= sizeof(XMUSHORTN4))
+        {
+            const XMUSHORTN4 * __restrict sPtr = static_cast<const XMUSHORTN4*>(pSource);
+            for (size_t icount = 0; icount < (size - sizeof(XMUSHORTN4) + 1); icount += sizeof(XMUSHORTN4))
+            {
+                const int64_t y0 = int64_t(sPtr->x >> 6) - 64;
+                const int64_t u = int64_t(sPtr->y >> 6) - 512;
+                const int64_t y1 = int64_t(sPtr->z >> 6) - 64;
+                const int64_t v = int64_t(sPtr->w >> 6) - 512;
+                ++sPtr;
+
+                // See Y410
+                auto r = static_cast<int>((76533 * y0 + 104905 * v + 32768) >> 16);
+                auto g = static_cast<int>((76533 * y0 - 25747 * u - 53425 * v + 32768) >> 16);
+                auto b = static_cast<int>((76533 * y0 + 132590 * u + 32768) >> 16);
+
+                if (dPtr >= ePtr) break;
+                *(dPtr++) = XMVectorSet(float(std::min<int>(std::max<int>(r, 0), 1023)) / 1023.f,
+                    float(std::min<int>(std::max<int>(g, 0), 1023)) / 1023.f,
+                    float(std::min<int>(std::max<int>(b, 0), 1023)) / 1023.f,
+                    1.f);
+
+                r = static_cast<int>((76533 * y1 + 104905 * v + 32768) >> 16);
+                g = static_cast<int>((76533 * y1 - 25747 * u - 53425 * v + 32768) >> 16);
+                b = static_cast<int>((76533 * y1 + 132590 * u + 32768) >> 16);
+
+                if (dPtr >= ePtr) break;
+                *(dPtr++) = XMVectorSet(float(std::min<int>(std::max<int>(r, 0), 1023)) / 1023.f,
+                    float(std::min<int>(std::max<int>(g, 0), 1023)) / 1023.f,
+                    float(std::min<int>(std::max<int>(b, 0), 1023)) / 1023.f,
+                    1.f);
+            }
+            return true;
+        }
+        return false;
+
+    case DXGI_FORMAT_Y216:
+        if (size >= sizeof(XMUSHORTN4))
+        {
+            const XMUSHORTN4 * __restrict sPtr = static_cast<const XMUSHORTN4*>(pSource);
+            for (size_t icount = 0; icount < (size - sizeof(XMUSHORTN4) + 1); icount += sizeof(XMUSHORTN4))
+            {
+                const int64_t y0 = int64_t(sPtr->x) - 4096;
+                const int64_t u = int64_t(sPtr->y) - 32768;
+                const int64_t y1 = int64_t(sPtr->z) - 4096;
+                const int64_t v = int64_t(sPtr->w) - 32768;
+                ++sPtr;
+
+                // See Y416
+                auto r = static_cast<int>((76607 * y0 + 105006 * v + 32768) >> 16);
+                auto g = static_cast<int>((76607 * y0 - 25772 * u - 53477 * v + 32768) >> 16);
+                auto b = static_cast<int>((76607 * y0 + 132718 * u + 32768) >> 16);
+
+                if (dPtr >= ePtr) break;
+                *(dPtr++) = XMVectorSet(float(std::min<int>(std::max<int>(r, 0), 65535)) / 65535.f,
+                    float(std::min<int>(std::max<int>(g, 0), 65535)) / 65535.f,
+                    float(std::min<int>(std::max<int>(b, 0), 65535)) / 65535.f,
+                    1.f);
+
+                r = static_cast<int>((76607 * y1 + 105006 * v + 32768) >> 16);
+                g = static_cast<int>((76607 * y1 - 25772 * u - 53477 * v + 32768) >> 16);
+                b = static_cast<int>((76607 * y1 + 132718 * u + 32768) >> 16);
+
+                if (dPtr >= ePtr) break;
+                *(dPtr++) = XMVectorSet(float(std::min<int>(std::max<int>(r, 0), 65535)) / 65535.f,
+                    float(std::min<int>(std::max<int>(g, 0), 65535)) / 65535.f,
+                    float(std::min<int>(std::max<int>(b, 0), 65535)) / 65535.f,
+                    1.f);
+            }
+            return true;
+        }
+        return false;
+
+    case DXGI_FORMAT_B4G4R4A4_UNORM:
+        if (size >= sizeof(XMUNIBBLE4))
+        {
+            static const XMVECTORF32 s_Scale = { { { 1.f / 15.f, 1.f / 15.f, 1.f / 15.f, 1.f / 15.f } } };
+            const XMUNIBBLE4 * __restrict sPtr = static_cast<const XMUNIBBLE4*>(pSource);
+            for (size_t icount = 0; icount < (size - sizeof(XMUNIBBLE4) + 1); icount += sizeof(XMUNIBBLE4))
+            {
+                XMVECTOR v = XMLoadUNibble4(sPtr++);
+                v = XMVectorMultiply(v, s_Scale);
+                if (dPtr >= ePtr) break;
+                *(dPtr++) = XMVectorSwizzle<2, 1, 0, 3>(v);
+            }
+            return true;
+        }
+        return false;
+
+    case WIN11_DXGI_FORMAT_A4B4G4R4_UNORM:
+        if (size >= sizeof(XMUNIBBLE4))
+        {
+            static const XMVECTORF32 s_Scale = { { { 1.f / 15.f, 1.f / 15.f, 1.f / 15.f, 1.f / 15.f } } };
+            const XMUNIBBLE4 * __restrict sPtr = static_cast<const XMUNIBBLE4*>(pSource);
+            for (size_t icount = 0; icount < (size - sizeof(XMUNIBBLE4) + 1); icount += sizeof(XMUNIBBLE4))
+            {
+                XMVECTOR v = XMLoadUNibble4(sPtr++);
+                v = XMVectorMultiply(v, s_Scale);
+                if (dPtr >= ePtr) break;
+                *(dPtr++) = XMVectorSwizzle<3, 2, 1, 0>(v);
+            }
+            return true;
+        }
+        return false;
+
+    case XBOX_DXGI_FORMAT_R10G10B10_7E3_A2_FLOAT:
+        // Xbox One specific 7e3 format
+        if (size >= sizeof(XMUDECN4))
+        {
+            const XMUDECN4 * __restrict sPtr = static_cast<const XMUDECN4*>(pSource);
+            for (size_t icount = 0; icount < (size - sizeof(XMUDECN4) + 1); icount += sizeof(XMUDECN4))
+            {
+                if (dPtr >= ePtr) break;
+
+                XMVECTORF32 vResult = { { {
+                    FloatFrom7e3(sPtr->x),
+                    FloatFrom7e3(sPtr->y),
+                    FloatFrom7e3(sPtr->z),
+                    static_cast<float>(sPtr->v >> 30) / 3.0f
+                } } };
+
+                ++sPtr;
+
+                *(dPtr++) = vResult.v;
+            }
+            return true;
+        }
+        return false;
+
+    case XBOX_DXGI_FORMAT_R10G10B10_6E4_A2_FLOAT:
+        // Xbox One specific 6e4 format
+        if (size >= sizeof(XMUDECN4))
+        {
+            const XMUDECN4 * __restrict sPtr = static_cast<const XMUDECN4*>(pSource);
+            for (size_t icount = 0; icount < (size - sizeof(XMUDECN4) + 1); icount += sizeof(XMUDECN4))
+            {
+                if (dPtr >= ePtr) break;
+
+                XMVECTORF32 vResult = { { {
+                    FloatFrom6e4(sPtr->x),
+                    FloatFrom6e4(sPtr->y),
+                    FloatFrom6e4(sPtr->z),
+                    static_cast<float>(sPtr->v >> 30) / 3.0f
+                } } };
+
+                ++sPtr;
+
+                *(dPtr++) = vResult.v;
+            }
+            return true;
+        }
+        return false;
+
+    case XBOX_DXGI_FORMAT_R10G10B10_SNORM_A2_UNORM:
+        // Xbox One specific format
+        LOAD_SCANLINE(XMXDECN4, XMLoadXDecN4)
+
+    case XBOX_DXGI_FORMAT_R4G4_UNORM:
+        // Xbox One specific format
+        if (size >= sizeof(uint8_t))
+        {
+            static const XMVECTORF32 s_Scale = { { { 1.f / 15.f, 1.f / 15.f, 0.f, 0.f } } };
+            const uint8_t * __restrict sPtr = static_cast<const uint8_t*>(pSource);
+            for (size_t icount = 0; icount < (size - sizeof(uint8_t) + 1); icount += sizeof(uint8_t))
+            {
+                XMUNIBBLE4 nibble;
+                nibble.v = static_cast<uint16_t>(*sPtr++);
+                XMVECTOR v = XMLoadUNibble4(&nibble);
+                v = XMVectorMultiply(v, s_Scale);
+                if (dPtr >= ePtr) break;
+                *(dPtr++) = XMVectorSelect(g_XMIdentityR3, v, g_XMSelect1100);
+            }
+            return true;
+        }
+        return false;
+
+        // We don't support the planar or palettized formats
+
+    default:
+        return false;
+    }
+}
+
+#undef LOAD_SCANLINE
+#undef LOAD_SCANLINE3
+#undef LOAD_SCANLINE2
+
+
+//-------------------------------------------------------------------------------------
+// Stores an image row from standard RGBA XMVECTOR (aligned) array
+//-------------------------------------------------------------------------------------
+#define STORE_SCANLINE( type, func )\
+        if (size >= sizeof(type))\
+        {\
+            type * __restrict dPtr = reinterpret_cast<type*>(pDestination);\
+            for(size_t icount = 0; icount < (size - sizeof(type) + 1); icount += sizeof(type))\
+            {\
+                if (sPtr >= ePtr) break;\
+                func(dPtr++, *sPtr++);\
+            }\
+            return true; \
+        }\
+        return false;
+
+_Use_decl_annotations_
+bool DirectX::Internal::StoreScanline(
+    void* pDestination,
+    size_t size,
+    DXGI_FORMAT format,
+    const XMVECTOR* pSource,
+    size_t count,
+    float threshold) noexcept
+{
+    assert(pDestination != nullptr);
+    assert(IsValid(format) && !IsTypeless(format) && !IsCompressed(format) && !IsPlanar(format) && !IsPalettized(format));
+
+    if (!size || !count)
+        return false;
+
+    const XMVECTOR* __restrict sPtr = pSource;
+    if (!sPtr)
+        return false;
+
+    assert((reinterpret_cast<uintptr_t>(pSource) & 0xF) == 0);
+
+    const XMVECTOR* ePtr = sPtr + count;
+
+#ifdef _PREFAST_
+    *reinterpret_cast<uint8_t*>(pDestination) = 0;
+#endif
+
+    switch (static_cast<int>(format))
+    {
+    case DXGI_FORMAT_R32G32B32A32_FLOAT:
+        STORE_SCANLINE(XMFLOAT4, XMStoreFloat4)
+
+    case DXGI_FORMAT_R32G32B32A32_UINT:
+        STORE_SCANLINE(XMUINT4, XMStoreUInt4)
+
+    case DXGI_FORMAT_R32G32B32A32_SINT:
+        STORE_SCANLINE(XMINT4, XMStoreSInt4)
+
+    case DXGI_FORMAT_R32G32B32_FLOAT:
+        STORE_SCANLINE(XMFLOAT3, XMStoreFloat3)
+
+    case DXGI_FORMAT_R32G32B32_UINT:
+        STORE_SCANLINE(XMUINT3, XMStoreUInt3)
+
+    case DXGI_FORMAT_R32G32B32_SINT:
+        STORE_SCANLINE(XMINT3, XMStoreSInt3)
+
+    case DXGI_FORMAT_R16G16B16A16_FLOAT:
+        if (size >= sizeof(XMHALF4))
+        {
+            XMHALF4* __restrict dPtr = static_cast<XMHALF4*>(pDestination);
+            for (size_t icount = 0; icount < (size - sizeof(XMHALF4) + 1); icount += sizeof(XMHALF4))
+            {
+                if (sPtr >= ePtr) break;
+                XMVECTOR v = *sPtr++;
+                v = XMVectorClamp(v, g_HalfMin, g_HalfMax);
+                XMStoreHalf4(dPtr++, v);
+            }
+            return true;
+        }
+        return false;
+
+    case DXGI_FORMAT_R16G16B16A16_UNORM:
+        STORE_SCANLINE(XMUSHORTN4, XMStoreUShortN4)
+
+    case DXGI_FORMAT_R16G16B16A16_UINT:
+        STORE_SCANLINE(XMUSHORT4, XMStoreUShort4)
+
+    case DXGI_FORMAT_R16G16B16A16_SNORM:
+        STORE_SCANLINE(XMSHORTN4, XMStoreShortN4)
+
+    case DXGI_FORMAT_R16G16B16A16_SINT:
+        STORE_SCANLINE(XMSHORT4, XMStoreShort4)
+
+    case DXGI_FORMAT_R32G32_FLOAT:
+        STORE_SCANLINE(XMFLOAT2, XMStoreFloat2)
+
+    case DXGI_FORMAT_R32G32_UINT:
+        STORE_SCANLINE(XMUINT2, XMStoreUInt2)
+
+    case DXGI_FORMAT_R32G32_SINT:
+        STORE_SCANLINE(XMINT2, XMStoreSInt2)
+
+    case DXGI_FORMAT_D32_FLOAT_S8X24_UINT:
+            {
+                constexpr size_t psize = sizeof(float) + sizeof(uint32_t);
+                if (size >= psize)
+                {
+                    auto dPtr = static_cast<float*>(pDestination);
+                    for (size_t icount = 0; icount < (size - psize + 1); icount += psize)
+                    {
+                        if (sPtr >= ePtr) break;
+                        XMFLOAT4 f;
+                        XMStoreFloat4(&f, *sPtr++);
+                        dPtr[0] = f.x;
+                        auto ps8 = reinterpret_cast<uint8_t*>(&dPtr[1]);
+                        ps8[0] = static_cast<uint8_t>(std::min<float>(255.f, std::max<float>(0.f, f.y)));
+                        ps8[1] = ps8[2] = ps8[3] = 0;
+                        dPtr += 2;
+                    }
+                    return true;
+                }
+            }
+            return false;
+
+    case DXGI_FORMAT_R10G10B10A2_UNORM:
+        STORE_SCANLINE(XMUDECN4, XMStoreUDecN4)
+
+    case DXGI_FORMAT_R10G10B10_XR_BIAS_A2_UNORM:
+        STORE_SCANLINE(XMUDECN4, XMStoreUDecN4_XR)
+
+    case DXGI_FORMAT_R10G10B10A2_UINT:
+        STORE_SCANLINE(XMUDEC4, XMStoreUDec4)
+
+    case DXGI_FORMAT_R11G11B10_FLOAT:
+        STORE_SCANLINE(XMFLOAT3PK, XMStoreFloat3PK)
+
+    case DXGI_FORMAT_R8G8B8A8_UNORM:
+    case DXGI_FORMAT_R8G8B8A8_UNORM_SRGB:
+        if (size >= sizeof(XMUBYTEN4))
+        {
+            XMUBYTEN4 * __restrict dPtr = static_cast<XMUBYTEN4*>(pDestination);
+            for (size_t icount = 0; icount < (size - sizeof(XMUBYTEN4) + 1); icount += sizeof(XMUBYTEN4))
+            {
+                if (sPtr >= ePtr) break;
+                const XMVECTOR v = XMVectorAdd(*sPtr++, g_8BitBias);
+                XMStoreUByteN4(dPtr++, v);
+            }
+            return true;
+        }
+        return false;
+
+    case DXGI_FORMAT_R8G8B8A8_UINT:
+        STORE_SCANLINE(XMUBYTE4, XMStoreUByte4)
+
+    case DXGI_FORMAT_R8G8B8A8_SNORM:
+        STORE_SCANLINE(XMBYTEN4, XMStoreByteN4)
+
+    case DXGI_FORMAT_R8G8B8A8_SINT:
+        STORE_SCANLINE(XMBYTE4, XMStoreByte4)
+
+    case DXGI_FORMAT_R16G16_FLOAT:
+        if (size >= sizeof(XMHALF2))
+        {
+            XMHALF2* __restrict dPtr = static_cast<XMHALF2*>(pDestination);
+            for (size_t icount = 0; icount < (size - sizeof(XMHALF2) + 1); icount += sizeof(XMHALF2))
+            {
+                if (sPtr >= ePtr) break;
+                XMVECTOR v = *sPtr++;
+                v = XMVectorClamp(v, g_HalfMin, g_HalfMax);
+                XMStoreHalf2(dPtr++, v);
+            }
+            return true;
+        }
+        return false;
+
+    case DXGI_FORMAT_R16G16_UNORM:
+        STORE_SCANLINE(XMUSHORTN2, XMStoreUShortN2)
+
+    case DXGI_FORMAT_R16G16_UINT:
+        STORE_SCANLINE(XMUSHORT2, XMStoreUShort2)
+
+    case DXGI_FORMAT_R16G16_SNORM:
+        STORE_SCANLINE(XMSHORTN2, XMStoreShortN2)
+
+    case DXGI_FORMAT_R16G16_SINT:
+        STORE_SCANLINE(XMSHORT2, XMStoreShort2)
+
+    case DXGI_FORMAT_D32_FLOAT:
+    case DXGI_FORMAT_R32_FLOAT:
+        if (size >= sizeof(float))
+        {
+            float * __restrict dPtr = static_cast<float*>(pDestination);
+            for (size_t icount = 0; icount < (size - sizeof(float) + 1); icount += sizeof(float))
+            {
+                if (sPtr >= ePtr) break;
+                XMStoreFloat(dPtr++, *(sPtr++));
+            }
+            return true;
+        }
+        return false;
+
+    case DXGI_FORMAT_R32_UINT:
+        if (size >= sizeof(uint32_t))
+        {
+            uint32_t * __restrict dPtr = static_cast<uint32_t*>(pDestination);
+            for (size_t icount = 0; icount < (size - sizeof(uint32_t) + 1); icount += sizeof(uint32_t))
+            {
+                if (sPtr >= ePtr) break;
+                const XMVECTOR v = XMConvertVectorFloatToUInt(*(sPtr++), 0);
+                XMStoreInt(dPtr++, v);
+            }
+            return true;
+        }
+        return false;
+
+    case DXGI_FORMAT_R32_SINT:
+        if (size >= sizeof(int32_t))
+        {
+            uint32_t * __restrict dPtr = static_cast<uint32_t*>(pDestination);
+            for (size_t icount = 0; icount < (size - sizeof(int32_t) + 1); icount += sizeof(int32_t))
+            {
+                if (sPtr >= ePtr) break;
+                const XMVECTOR v = XMConvertVectorFloatToInt(*(sPtr++), 0);
+                XMStoreInt(dPtr++, v);
+            }
+            return true;
+        }
+        return false;
+
+    case DXGI_FORMAT_D24_UNORM_S8_UINT:
+        if (size >= sizeof(uint32_t))
+        {
+            static const XMVECTORF32 clamp = { { { 1.f, 255.f, 0.f, 0.f } } };
+            const XMVECTOR zero = XMVectorZero();
+            auto dPtr = static_cast<uint32_t*>(pDestination);
+            for (size_t icount = 0; icount < (size - sizeof(uint32_t) + 1); icount += sizeof(uint32_t))
+            {
+                if (sPtr >= ePtr) break;
+                XMFLOAT4 f;
+                XMStoreFloat4(&f, XMVectorClamp(*sPtr++, zero, clamp));
+                *dPtr++ = (static_cast<uint32_t>(f.x * 16777215.f) & 0xFFFFFF)
+                    | ((static_cast<uint32_t>(f.y) & 0xFF) << 24);
+            }
+            return true;
+        }
+        return false;
+
+    case DXGI_FORMAT_R8G8_UNORM:
+        STORE_SCANLINE(XMUBYTEN2, XMStoreUByteN2)
+
+    case DXGI_FORMAT_R8G8_UINT:
+        STORE_SCANLINE(XMUBYTE2, XMStoreUByte2)
+
+    case DXGI_FORMAT_R8G8_SNORM:
+        STORE_SCANLINE(XMBYTEN2, XMStoreByteN2)
+
+    case DXGI_FORMAT_R8G8_SINT:
+        STORE_SCANLINE(XMBYTE2, XMStoreByte2)
+
+    case DXGI_FORMAT_R16_FLOAT:
+        if (size >= sizeof(HALF))
+        {
+            HALF * __restrict dPtr = static_cast<HALF*>(pDestination);
+            for (size_t icount = 0; icount < (size - sizeof(HALF) + 1); icount += sizeof(HALF))
+            {
+                if (sPtr >= ePtr) break;
+                float v = XMVectorGetX(*sPtr++);
+                v = std::max<float>(std::min<float>(v, 65504.f), -65504.f);
+                *(dPtr++) = XMConvertFloatToHalf(v);
+            }
+            return true;
+        }
+        return false;
+
+    case DXGI_FORMAT_D16_UNORM:
+    case DXGI_FORMAT_R16_UNORM:
+        if (size >= sizeof(uint16_t))
+        {
+            uint16_t * __restrict dPtr = static_cast<uint16_t*>(pDestination);
+            for (size_t icount = 0; icount < (size - sizeof(uint16_t) + 1); icount += sizeof(uint16_t))
+            {
+                if (sPtr >= ePtr) break;
+                float v = XMVectorGetX(*sPtr++);
+                v = std::max<float>(std::min<float>(v, 1.f), 0.f);
+                *(dPtr++) = static_cast<uint16_t>(v*65535.f + 0.5f);
+            }
+            return true;
+        }
+        return false;
+
+    case DXGI_FORMAT_R16_UINT:
+        if (size >= sizeof(uint16_t))
+        {
+            uint16_t * __restrict dPtr = static_cast<uint16_t*>(pDestination);
+            for (size_t icount = 0; icount < (size - sizeof(uint16_t) + 1); icount += sizeof(uint16_t))
+            {
+                if (sPtr >= ePtr) break;
+                float v = XMVectorGetX(*sPtr++);
+                v = std::max<float>(std::min<float>(v, 65535.f), 0.f);
+                *(dPtr++) = static_cast<uint16_t>(v);
+            }
+            return true;
+        }
+        return false;
+
+    case DXGI_FORMAT_R16_SNORM:
+        if (size >= sizeof(int16_t))
+        {
+            int16_t * __restrict dPtr = static_cast<int16_t*>(pDestination);
+            for (size_t icount = 0; icount < (size - sizeof(int16_t) + 1); icount += sizeof(int16_t))
+            {
+                if (sPtr >= ePtr) break;
+                float v = XMVectorGetX(*sPtr++);
+                v = std::max<float>(std::min<float>(v, 1.f), -1.f);
+                *(dPtr++) = static_cast<int16_t>(lroundf(v * 32767.f));
+            }
+            return true;
+        }
+        return false;
+
+    case DXGI_FORMAT_R16_SINT:
+        if (size >= sizeof(int16_t))
+        {
+            int16_t * __restrict dPtr = static_cast<int16_t*>(pDestination);
+            for (size_t icount = 0; icount < (size - sizeof(int16_t) + 1); icount += sizeof(int16_t))
+            {
+                if (sPtr >= ePtr) break;
+                float v = XMVectorGetX(*sPtr++);
+                v = std::max<float>(std::min<float>(v, 32767.f), -32767.f);
+                *(dPtr++) = static_cast<int16_t>(v);
+            }
+            return true;
+        }
+        return false;
+
+    case DXGI_FORMAT_R8_UNORM:
+        if (size >= sizeof(uint8_t))
+        {
+            uint8_t * __restrict dPtr = static_cast<uint8_t*>(pDestination);
+            for (size_t icount = 0; icount < size; icount += sizeof(uint8_t))
+            {
+                if (sPtr >= ePtr) break;
+                float v = XMVectorGetX(*sPtr++);
+                v = std::max<float>(std::min<float>(v, 1.f), 0.f);
+                *(dPtr++) = static_cast<uint8_t>(v * 255.f);
+            }
+            return true;
+        }
+        return false;
+
+    case DXGI_FORMAT_R8_UINT:
+        if (size >= sizeof(uint8_t))
+        {
+            uint8_t * __restrict dPtr = static_cast<uint8_t*>(pDestination);
+            for (size_t icount = 0; icount < size; icount += sizeof(uint8_t))
+            {
+                if (sPtr >= ePtr) break;
+                float v = XMVectorGetX(*sPtr++);
+                v = std::max<float>(std::min<float>(v, 255.f), 0.f);
+                *(dPtr++) = static_cast<uint8_t>(v);
+            }
+            return true;
+        }
+        return false;
+
+    case DXGI_FORMAT_R8_SNORM:
+        if (size >= sizeof(int8_t))
+        {
+            int8_t * __restrict dPtr = static_cast<int8_t*>(pDestination);
+            for (size_t icount = 0; icount < size; icount += sizeof(int8_t))
+            {
+                if (sPtr >= ePtr) break;
+                float v = XMVectorGetX(*sPtr++);
+                v = std::max<float>(std::min<float>(v, 1.f), -1.f);
+                *(dPtr++) = static_cast<int8_t>(lroundf(v * 127.f));
+            }
+            return true;
+        }
+        return false;
+
+    case DXGI_FORMAT_R8_SINT:
+        if (size >= sizeof(int8_t))
+        {
+            int8_t * __restrict dPtr = static_cast<int8_t*>(pDestination);
+            for (size_t icount = 0; icount < size; icount += sizeof(int8_t))
+            {
+                if (sPtr >= ePtr) break;
+                float v = XMVectorGetX(*sPtr++);
+                v = std::max<float>(std::min<float>(v, 127.f), -127.f);
+                *(dPtr++) = static_cast<int8_t>(v);
+            }
+            return true;
+        }
+        return false;
+
+    case DXGI_FORMAT_A8_UNORM:
+        if (size >= sizeof(uint8_t))
+        {
+            uint8_t * __restrict dPtr = static_cast<uint8_t*>(pDestination);
+            for (size_t icount = 0; icount < size; icount += sizeof(uint8_t))
+            {
+                if (sPtr >= ePtr) break;
+                float v = XMVectorGetW(*sPtr++);
+                v = std::max<float>(std::min<float>(v, 1.f), 0.f);
+                *(dPtr++) = static_cast<uint8_t>(v * 255.f);
+            }
+            return true;
+        }
+        return false;
+
+    case DXGI_FORMAT_R1_UNORM:
+        if (size >= sizeof(uint8_t))
+        {
+            uint8_t * __restrict dPtr = static_cast<uint8_t*>(pDestination);
+            for (size_t icount = 0; icount < size; icount += sizeof(uint8_t))
+            {
+                uint8_t pixels = 0;
+                for (size_t bcount = 8; bcount > 0; --bcount)
+                {
+                    if (sPtr >= ePtr) break;
+                    const float v = XMVectorGetX(*sPtr++);
+
+                    // Absolute thresholding generally doesn't give good results for all images
+                    // Picking the 'right' threshold automatically requires whole-image analysis
+
+                    if (v > 0.25f)
+                        pixels |= 1 << (bcount - 1);
+                }
+                *(dPtr++) = pixels;
+            }
+            return true;
+        }
+        return false;
+
+    case DXGI_FORMAT_R9G9B9E5_SHAREDEXP:
+        STORE_SCANLINE(XMFLOAT3SE, StoreFloat3SE)
+
+    case DXGI_FORMAT_R8G8_B8G8_UNORM:
+        if (size >= sizeof(XMUBYTEN4))
+        {
+            XMUBYTEN4 * __restrict dPtr = static_cast<XMUBYTEN4*>(pDestination);
+            for (size_t icount = 0; icount < (size - sizeof(XMUBYTEN4) + 1); icount += sizeof(XMUBYTEN4))
+            {
+                if (sPtr >= ePtr) break;
+                const XMVECTOR v0 = *sPtr++;
+                const XMVECTOR v1 = (sPtr < ePtr) ? XMVectorSplatY(*sPtr++) : XMVectorZero();
+                XMVECTOR v = XMVectorSelect(v1, v0, g_XMSelect1110);
+                v = XMVectorAdd(v, g_8BitBias);
+                XMStoreUByteN4(dPtr++, v);
+            }
+            return true;
+        }
+        return false;
+
+    case DXGI_FORMAT_G8R8_G8B8_UNORM:
+        if (size >= sizeof(XMUBYTEN4))
+        {
+            static XMVECTORU32 select1101 = { { { XM_SELECT_1, XM_SELECT_1, XM_SELECT_0, XM_SELECT_1 } } };
+
+            XMUBYTEN4 * __restrict dPtr = static_cast<XMUBYTEN4*>(pDestination);
+            for (size_t icount = 0; icount < (size - sizeof(XMUBYTEN4) + 1); icount += sizeof(XMUBYTEN4))
+            {
+                if (sPtr >= ePtr) break;
+                const XMVECTOR v0 = XMVectorSwizzle<1, 0, 3, 2>(*sPtr++);
+                const XMVECTOR v1 = (sPtr < ePtr) ? XMVectorSplatY(*sPtr++) : XMVectorZero();
+                XMVECTOR v = XMVectorSelect(v1, v0, select1101);
+                v = XMVectorAdd(v, g_8BitBias);
+                XMStoreUByteN4(dPtr++, v);
+            }
+            return true;
+        }
+        return false;
+
+    case DXGI_FORMAT_B5G6R5_UNORM:
+        if (size >= sizeof(XMU565))
+        {
+            static const XMVECTORF32 s_Scale = { { { 31.f, 63.f, 31.f, 1.f } } };
+            XMU565 * __restrict dPtr = static_cast<XMU565*>(pDestination);
+            for (size_t icount = 0; icount < (size - sizeof(XMU565) + 1); icount += sizeof(XMU565))
+            {
+                if (sPtr >= ePtr) break;
+                XMVECTOR v = XMVectorSwizzle<2, 1, 0, 3>(*sPtr++);
+#if defined(_M_ARM) || defined(_M_ARM64) || defined(_M_HYBRID_X86_ARM64) || defined(_M_ARM64EC) || __arm__ || __aarch64__
+                v = XMVectorMultiplyAdd(v, s_Scale, g_XMOneHalf);
+#else
+                v = XMVectorMultiply(v, s_Scale);
+#endif
+                XMStoreU565(dPtr++, v);
+            }
+            return true;
+        }
+        return false;
+
+    case DXGI_FORMAT_B5G5R5A1_UNORM:
+        if (size >= sizeof(XMU555))
+        {
+            static const XMVECTORF32 s_Scale = { { { 31.f, 31.f, 31.f, 1.f } } };
+#if defined(_M_ARM) || defined(_M_ARM64) || defined(_M_HYBRID_X86_ARM64) || defined(_M_ARM64EC) || __arm__ || __aarch64__
+            static const XMVECTORF32 s_OneHalfXYZ = { { { 0.5f, 0.5f, 0.5f, 0.f } } };
+#endif
+            XMU555 * __restrict dPtr = static_cast<XMU555*>(pDestination);
+            for (size_t icount = 0; icount < (size - sizeof(XMU555) + 1); icount += sizeof(XMU555))
+            {
+                if (sPtr >= ePtr) break;
+                XMVECTOR v = XMVectorSwizzle<2, 1, 0, 3>(*sPtr++);
+#if defined(_M_ARM) || defined(_M_ARM64) || defined(_M_HYBRID_X86_ARM64) || defined(_M_ARM64EC) || __arm__ || __aarch64__
+                v = XMVectorMultiplyAdd(v, s_Scale, s_OneHalfXYZ);
+#else
+                v = XMVectorMultiply(v, s_Scale);
+#endif
+                XMStoreU555(dPtr, v);
+                dPtr->w = (XMVectorGetW(v) > threshold) ? 1u : 0u;
+                ++dPtr;
+            }
+            return true;
+        }
+        return false;
+
+    case DXGI_FORMAT_B8G8R8A8_UNORM:
+    case DXGI_FORMAT_B8G8R8A8_UNORM_SRGB:
+        if (size >= sizeof(XMUBYTEN4))
+        {
+            XMUBYTEN4 * __restrict dPtr = static_cast<XMUBYTEN4*>(pDestination);
+            for (size_t icount = 0; icount < (size - sizeof(XMUBYTEN4) + 1); icount += sizeof(XMUBYTEN4))
+            {
+                if (sPtr >= ePtr) break;
+                XMVECTOR v = XMVectorSwizzle<2, 1, 0, 3>(*sPtr++);
+                v = XMVectorAdd(v, g_8BitBias);
+                XMStoreUByteN4(dPtr++, v);
+            }
+            return true;
+        }
+        return false;
+
+    case DXGI_FORMAT_B8G8R8X8_UNORM:
+    case DXGI_FORMAT_B8G8R8X8_UNORM_SRGB:
+        if (size >= sizeof(XMUBYTEN4))
+        {
+            XMUBYTEN4 * __restrict dPtr = static_cast<XMUBYTEN4*>(pDestination);
+            for (size_t icount = 0; icount < (size - sizeof(XMUBYTEN4) + 1); icount += sizeof(XMUBYTEN4))
+            {
+                if (sPtr >= ePtr) break;
+                XMVECTOR v = XMVectorPermute<2, 1, 0, 7>(*sPtr++, g_XMIdentityR3);
+                v = XMVectorAdd(v, g_8BitBias);
+                XMStoreUByteN4(dPtr++, v);
+            }
+            return true;
+        }
+        return false;
+
+    case DXGI_FORMAT_AYUV:
+        if (size >= sizeof(XMUBYTEN4))
+        {
+            XMUBYTEN4 * __restrict dPtr = static_cast<XMUBYTEN4*>(pDestination);
+            for (size_t icount = 0; icount < (size - sizeof(XMUBYTEN4) + 1); icount += sizeof(XMUBYTEN4))
+            {
+                if (sPtr >= ePtr) break;
+
+                XMUBYTEN4 rgba;
+                XMStoreUByteN4(&rgba, *sPtr++);
+
+                // http://msdn.microsoft.com/en-us/library/windows/desktop/dd206750.aspx
+
+                // Y  =  0.2568R + 0.5041G + 0.1001B + 16
+                // Cb = -0.1482R - 0.2910G + 0.4392B + 128
+                // Cr =  0.4392R - 0.3678G - 0.0714B + 128
+
+                const int y = ((66 * rgba.x + 129 * rgba.y + 25 * rgba.z + 128) >> 8) + 16;
+                const int u = ((-38 * rgba.x - 74 * rgba.y + 112 * rgba.z + 128) >> 8) + 128;
+                const int v = ((112 * rgba.x - 94 * rgba.y - 18 * rgba.z + 128) >> 8) + 128;
+
+                dPtr->x = static_cast<uint8_t>(std::min<int>(std::max<int>(v, 0), 255));
+                dPtr->y = static_cast<uint8_t>(std::min<int>(std::max<int>(u, 0), 255));
+                dPtr->z = static_cast<uint8_t>(std::min<int>(std::max<int>(y, 0), 255));
+                dPtr->w = rgba.w;
+                ++dPtr;
+            }
+            return true;
+        }
+        return false;
+
+    case DXGI_FORMAT_Y410:
+        if (size >= sizeof(XMUDECN4))
+        {
+            XMUDECN4 * __restrict dPtr = static_cast<XMUDECN4*>(pDestination);
+            for (size_t icount = 0; icount < (size - sizeof(XMUDECN4) + 1); icount += sizeof(XMUDECN4))
+            {
+                if (sPtr >= ePtr) break;
+
+                XMUDECN4 rgba;
+                XMStoreUDecN4(&rgba, *sPtr++);
+
+                // http://msdn.microsoft.com/en-us/library/windows/desktop/bb970578.aspx
+
+                // Y  =  0.2560R + 0.5027G + 0.0998B + 64
+                // Cb = -0.1478R - 0.2902G + 0.4379B + 512
+                // Cr =  0.4379R - 0.3667G - 0.0712B + 512
+
+                const int64_t r = rgba.x;
+                const int64_t g = rgba.y;
+                const int64_t b = rgba.z;
+
+                const int y = static_cast<int>((16780 * r + 32942 * g + 6544 * b + 32768) >> 16) + 64;
+                const int u = static_cast<int>((-9683 * r - 19017 * g + 28700 * b + 32768) >> 16) + 512;
+                const int v = static_cast<int>((28700 * r - 24033 * g - 4667 * b + 32768) >> 16) + 512;
+
+                dPtr->x = static_cast<uint32_t>(std::min<int>(std::max<int>(u, 0), 1023));
+                dPtr->y = static_cast<uint32_t>(std::min<int>(std::max<int>(y, 0), 1023));
+                dPtr->z = static_cast<uint32_t>(std::min<int>(std::max<int>(v, 0), 1023));
+                dPtr->w = rgba.w;
+                ++dPtr;
+            }
+            return true;
+        }
+        return false;
+
+    case DXGI_FORMAT_Y416:
+        if (size >= sizeof(XMUSHORTN4))
+        {
+            XMUSHORTN4 * __restrict dPtr = static_cast<XMUSHORTN4*>(pDestination);
+            for (size_t icount = 0; icount < (size - sizeof(XMUSHORTN4) + 1); icount += sizeof(XMUSHORTN4))
+            {
+                if (sPtr >= ePtr) break;
+
+                XMUSHORTN4 rgba;
+                XMStoreUShortN4(&rgba, *sPtr++);
+
+                // http://msdn.microsoft.com/en-us/library/windows/desktop/bb970578.aspx
+
+                // Y  =  0.2558R + 0.5022G + 0.0998B + 4096
+                // Cb = -0.1476R - 0.2899G + 0.4375B + 32768
+                // Cr =  0.4375R - 0.3664G - 0.0711B + 32768
+
+                const int64_t r = int64_t(rgba.x);
+                const int64_t g = int64_t(rgba.y);
+                const int64_t b = int64_t(rgba.z);
+
+                const int y = static_cast<int>((16763 * r + 32910 * g + 6537 * b + 32768) >> 16) + 4096;
+                const int u = static_cast<int>((-9674 * r - 18998 * g + 28672 * b + 32768) >> 16) + 32768;
+                const int v = static_cast<int>((28672 * r - 24010 * g - 4662 * b + 32768) >> 16) + 32768;
+
+                dPtr->x = static_cast<uint16_t>(std::min<int>(std::max<int>(u, 0), 65535));
+                dPtr->y = static_cast<uint16_t>(std::min<int>(std::max<int>(y, 0), 65535));
+                dPtr->z = static_cast<uint16_t>(std::min<int>(std::max<int>(v, 0), 65535));
+                dPtr->w = rgba.w;
+                ++dPtr;
+            }
+            return true;
+        }
+        return false;
+
+    case DXGI_FORMAT_YUY2:
+        if (size >= sizeof(XMUBYTEN4))
+        {
+            XMUBYTEN4 * __restrict dPtr = static_cast<XMUBYTEN4*>(pDestination);
+            for (size_t icount = 0; icount < (size - sizeof(XMUBYTEN4) + 1); icount += sizeof(XMUBYTEN4))
+            {
+                if (sPtr >= ePtr) break;
+
+                XMUBYTEN4 rgb1;
+                XMStoreUByteN4(&rgb1, *sPtr++);
+
+                // See AYUV
+                const int y0 = ((66 * rgb1.x + 129 * rgb1.y + 25 * rgb1.z + 128) >> 8) + 16;
+                const int u0 = ((-38 * rgb1.x - 74 * rgb1.y + 112 * rgb1.z + 128) >> 8) + 128;
+                const int v0 = ((112 * rgb1.x - 94 * rgb1.y - 18 * rgb1.z + 128) >> 8) + 128;
+
+                XMUBYTEN4 rgb2 = {};
+                if (sPtr < ePtr)
+                {
+                    XMStoreUByteN4(&rgb2, *sPtr++);
+                }
+
+                const int y1 = ((66 * rgb2.x + 129 * rgb2.y + 25 * rgb2.z + 128) >> 8) + 16;
+                const int u1 = ((-38 * rgb2.x - 74 * rgb2.y + 112 * rgb2.z + 128) >> 8) + 128;
+                const int v1 = ((112 * rgb2.x - 94 * rgb2.y - 18 * rgb2.z + 128) >> 8) + 128;
+
+                dPtr->x = static_cast<uint8_t>(std::min<int>(std::max<int>(y0, 0), 255));
+                dPtr->y = static_cast<uint8_t>(std::min<int>(std::max<int>((u0 + u1) >> 1, 0), 255));
+                dPtr->z = static_cast<uint8_t>(std::min<int>(std::max<int>(y1, 0), 255));
+                dPtr->w = static_cast<uint8_t>(std::min<int>(std::max<int>((v0 + v1) >> 1, 0), 255));
+                ++dPtr;
+            }
+            return true;
+        }
+        return false;
+
+    case DXGI_FORMAT_Y210:
+        // Same as Y216 with least significant 6 bits set to zero
+        if (size >= sizeof(XMUSHORTN4))
+        {
+            XMUSHORTN4 * __restrict dPtr = static_cast<XMUSHORTN4*>(pDestination);
+            for (size_t icount = 0; icount < (size - sizeof(XMUSHORTN4) + 1); icount += sizeof(XMUSHORTN4))
+            {
+                if (sPtr >= ePtr) break;
+
+                XMUDECN4 rgb1;
+                XMStoreUDecN4(&rgb1, *sPtr++);
+
+                // See Y410
+                int64_t r = rgb1.x;
+                int64_t g = rgb1.y;
+                int64_t b = rgb1.z;
+
+                const int y0 = static_cast<int>((16780 * r + 32942 * g + 6544 * b + 32768) >> 16) + 64;
+                const int u0 = static_cast<int>((-9683 * r - 19017 * g + 28700 * b + 32768) >> 16) + 512;
+                const int v0 = static_cast<int>((28700 * r - 24033 * g - 4667 * b + 32768) >> 16) + 512;
+
+                XMUDECN4 rgb2 = {};
+                if (sPtr < ePtr)
+                {
+                    XMStoreUDecN4(&rgb2, *sPtr++);
+                }
+
+                r = rgb2.x;
+                g = rgb2.y;
+                b = rgb2.z;
+
+                const int y1 = static_cast<int>((16780 * r + 32942 * g + 6544 * b + 32768) >> 16) + 64;
+                const int u1 = static_cast<int>((-9683 * r - 19017 * g + 28700 * b + 32768) >> 16) + 512;
+                const int v1 = static_cast<int>((28700 * r - 24033 * g - 4667 * b + 32768) >> 16) + 512;
+
+                dPtr->x = static_cast<uint16_t>(std::min<int>(std::max<int>(y0, 0), 1023) << 6);
+                dPtr->y = static_cast<uint16_t>(std::min<int>(std::max<int>((u0 + u1) >> 1, 0), 1023) << 6);
+                dPtr->z = static_cast<uint16_t>(std::min<int>(std::max<int>(y1, 0), 1023) << 6);
+                dPtr->w = static_cast<uint16_t>(std::min<int>(std::max<int>((v0 + v1) >> 1, 0), 1023) << 6);
+                ++dPtr;
+            }
+            return true;
+        }
+        return false;
+
+    case DXGI_FORMAT_Y216:
+        if (size >= sizeof(XMUSHORTN4))
+        {
+            XMUSHORTN4 * __restrict dPtr = static_cast<XMUSHORTN4*>(pDestination);
+            for (size_t icount = 0; icount < (size - sizeof(XMUSHORTN4) + 1); icount += sizeof(XMUSHORTN4))
+            {
+                if (sPtr >= ePtr) break;
+
+                XMUSHORTN4 rgb1;
+                XMStoreUShortN4(&rgb1, *sPtr++);
+
+                // See Y416
+                int64_t r = int64_t(rgb1.x);
+                int64_t g = int64_t(rgb1.y);
+                int64_t b = int64_t(rgb1.z);
+
+                const int y0 = static_cast<int>((16763 * r + 32910 * g + 6537 * b + 32768) >> 16) + 4096;
+                const int u0 = static_cast<int>((-9674 * r - 18998 * g + 28672 * b + 32768) >> 16) + 32768;
+                const int v0 = static_cast<int>((28672 * r - 24010 * g - 4662 * b + 32768) >> 16) + 32768;
+
+                XMUSHORTN4 rgb2 = {};
+                if (sPtr < ePtr)
+                {
+                    XMStoreUShortN4(&rgb2, *sPtr++);
+                }
+
+                r = int64_t(rgb2.x);
+                g = int64_t(rgb2.y);
+                b = int64_t(rgb2.z);
+
+                const int y1 = static_cast<int>((16763 * r + 32910 * g + 6537 * b + 32768) >> 16) + 4096;
+                const int u1 = static_cast<int>((-9674 * r - 18998 * g + 28672 * b + 32768) >> 16) + 32768;
+                const int v1 = static_cast<int>((28672 * r - 24010 * g - 4662 * b + 32768) >> 16) + 32768;
+
+                dPtr->x = static_cast<uint16_t>(std::min<int>(std::max<int>(y0, 0), 65535));
+                dPtr->y = static_cast<uint16_t>(std::min<int>(std::max<int>((u0 + u1) >> 1, 0), 65535));
+                dPtr->z = static_cast<uint16_t>(std::min<int>(std::max<int>(y1, 0), 65535));
+                dPtr->w = static_cast<uint16_t>(std::min<int>(std::max<int>((v0 + v1) >> 1, 0), 65535));
+                ++dPtr;
+            }
+            return true;
+        }
+        return false;
+
+    case DXGI_FORMAT_B4G4R4A4_UNORM:
+        if (size >= sizeof(XMUNIBBLE4))
+        {
+            static const XMVECTORF32 s_Scale = { { { 15.f, 15.f, 15.f, 15.f } } };
+            XMUNIBBLE4 * __restrict dPtr = static_cast<XMUNIBBLE4*>(pDestination);
+            for (size_t icount = 0; icount < (size - sizeof(XMUNIBBLE4) + 1); icount += sizeof(XMUNIBBLE4))
+            {
+                if (sPtr >= ePtr) break;
+                XMVECTOR v = XMVectorSwizzle<2, 1, 0, 3>(*sPtr++);
+#if defined(_M_ARM) || defined(_M_ARM64) || defined(_M_HYBRID_X86_ARM64) || defined(_M_ARM64EC) || __arm__ || __aarch64__
+                v = XMVectorMultiplyAdd(v, s_Scale, g_XMOneHalf);
+#else
+                v = XMVectorMultiply(v, s_Scale);
+#endif
+                XMStoreUNibble4(dPtr++, v);
+            }
+            return true;
+        }
+        return false;
+
+    case WIN11_DXGI_FORMAT_A4B4G4R4_UNORM:
+        if (size >= sizeof(XMUNIBBLE4))
+        {
+            static const XMVECTORF32 s_Scale = { { { 15.f, 15.f, 15.f, 15.f } } };
+            XMUNIBBLE4 * __restrict dPtr = static_cast<XMUNIBBLE4*>(pDestination);
+            for (size_t icount = 0; icount < (size - sizeof(XMUNIBBLE4) + 1); icount += sizeof(XMUNIBBLE4))
+            {
+                if (sPtr >= ePtr) break;
+                XMVECTOR v = XMVectorSwizzle<3, 2, 1, 0>(*sPtr++);
+#if defined(_M_ARM) || defined(_M_ARM64) || defined(_M_HYBRID_X86_ARM64) || defined(_M_ARM64EC) || __arm__ || __aarch64__
+                v = XMVectorMultiplyAdd(v, s_Scale, g_XMOneHalf);
+#else
+                v = XMVectorMultiply(v, s_Scale);
+#endif
+                XMStoreUNibble4(dPtr++, v);
+            }
+            return true;
+        }
+        return false;
+
+    case XBOX_DXGI_FORMAT_R10G10B10_7E3_A2_FLOAT:
+        // Xbox One specific 7e3 format with alpha
+        if (size >= sizeof(XMUDECN4))
+        {
+            static const XMVECTORF32  Scale = { { { 1.0f, 1.0f, 1.0f, 3.0f } } };
+            static const XMVECTORF32  C = { { { 31.875f, 31.875f, 31.875f, 3.f } } };
+
+            XMUDECN4 * __restrict dPtr = static_cast<XMUDECN4*>(pDestination);
+            for (size_t icount = 0; icount < (size - sizeof(XMUDECN4) + 1); icount += sizeof(XMUDECN4))
+            {
+                if (sPtr >= ePtr) break;
+
+                XMVECTOR V = XMVectorMultiply(*sPtr++, Scale);
+                V = XMVectorClamp(V, g_XMZero, C);
+
+                XMFLOAT4A tmp;
+                XMStoreFloat4A(&tmp, V);
+
+                dPtr->x = FloatTo7e3(tmp.x);
+                dPtr->y = FloatTo7e3(tmp.y);
+                dPtr->z = FloatTo7e3(tmp.z);
+                dPtr->w = static_cast<uint32_t>(tmp.w);
+                ++dPtr;
+            }
+            return true;
+        }
+        return false;
+
+    case XBOX_DXGI_FORMAT_R10G10B10_6E4_A2_FLOAT:
+        // Xbox One specific 6e4 format with alpha
+        if (size >= sizeof(XMUDECN4))
+        {
+            static const XMVECTORF32  Scale = { { { 1.0f, 1.0f, 1.0f, 3.0f } } };
+            static const XMVECTORF32  C = { { { 508.f, 508.f, 508.f, 3.f } } };
+
+            XMUDECN4 * __restrict dPtr = static_cast<XMUDECN4*>(pDestination);
+            for (size_t icount = 0; icount < (size - sizeof(XMUDECN4) + 1); icount += sizeof(XMUDECN4))
+            {
+                if (sPtr >= ePtr) break;
+
+                XMVECTOR V = XMVectorMultiply(*sPtr++, Scale);
+                V = XMVectorClamp(V, g_XMZero, C);
+
+                XMFLOAT4A tmp;
+                XMStoreFloat4A(&tmp, V);
+
+                dPtr->x = FloatTo6e4(tmp.x);
+                dPtr->y = FloatTo6e4(tmp.y);
+                dPtr->z = FloatTo6e4(tmp.z);
+                dPtr->w = static_cast<uint32_t>(tmp.w);
+                ++dPtr;
+            }
+            return true;
+        }
+        return false;
+
+    case XBOX_DXGI_FORMAT_R10G10B10_SNORM_A2_UNORM:
+        // Xbox One specific format
+        STORE_SCANLINE(XMXDECN4, XMStoreXDecN4)
+
+    case XBOX_DXGI_FORMAT_R4G4_UNORM:
+        // Xbox One specific format
+        if (size >= sizeof(uint8_t))
+        {
+            static const XMVECTORF32 s_Scale = { { { 15.f, 15.f, 0.f, 0.f } } };
+            uint8_t * __restrict dPtr = static_cast<uint8_t*>(pDestination);
+            for (size_t icount = 0; icount < (size - sizeof(uint8_t) + 1); icount += sizeof(uint8_t))
+            {
+                if (sPtr >= ePtr) break;
+#if defined(_M_ARM) || defined(_M_ARM64) || defined(_M_HYBRID_X86_ARM64) || defined(_M_ARM64EC) || __arm__ || __aarch64__
+                const XMVECTOR v = XMVectorMultiplyAdd(*sPtr++, s_Scale, g_XMOneHalf);
+#else
+                const XMVECTOR v = XMVectorMultiply(*sPtr++, s_Scale);
+#endif
+                XMUNIBBLE4 nibble;
+                XMStoreUNibble4(&nibble, v);
+                *dPtr = static_cast<uint8_t>(nibble.v);
+                ++dPtr;
+            }
+            return true;
+        }
+        return false;
+
+        // We don't support the planar or palettized formats
+
+    default:
+        return false;
+    }
+}
+
+#undef STORE_SCANLINE
+
+
+//-------------------------------------------------------------------------------------
+// Convert DXGI image to/from GUID_WICPixelFormat128bppRGBAFloat (no range conversions)
+//-------------------------------------------------------------------------------------
+_Use_decl_annotations_
+HRESULT DirectX::Internal::ConvertToR32G32B32A32(const Image& srcImage, ScratchImage& image) noexcept
+{
+    if (!srcImage.pixels)
+        return E_POINTER;
+
+    HRESULT hr = image.Initialize2D(DXGI_FORMAT_R32G32B32A32_FLOAT, srcImage.width, srcImage.height, 1, 1);
+    if (FAILED(hr))
+        return hr;
+
+    const Image *img = image.GetImage(0, 0, 0);
+    if (!img)
+    {
+        image.Release();
+        return E_POINTER;
+    }
+
+    uint8_t* pDest = img->pixels;
+    if (!pDest)
+    {
+        image.Release();
+        return E_POINTER;
+    }
+
+    const uint8_t *pSrc = srcImage.pixels;
+    for (size_t h = 0; h < srcImage.height; ++h)
+    {
+        if (!LoadScanline(reinterpret_cast<XMVECTOR*>(pDest), srcImage.width, pSrc, srcImage.rowPitch, srcImage.format))
+        {
+            image.Release();
+            return E_FAIL;
+        }
+
+        pSrc += srcImage.rowPitch;
+        pDest += img->rowPitch;
+    }
+
+    return S_OK;
+}
+
+_Use_decl_annotations_
+HRESULT DirectX::Internal::ConvertFromR32G32B32A32(const Image& srcImage, const Image& destImage) noexcept
+{
+    assert(srcImage.format == DXGI_FORMAT_R32G32B32A32_FLOAT);
+
+    if (!srcImage.pixels || !destImage.pixels)
+        return E_POINTER;
+
+    if (srcImage.width != destImage.width || srcImage.height != destImage.height)
+        return E_FAIL;
+
+    const uint8_t *pSrc = srcImage.pixels;
+    uint8_t* pDest = destImage.pixels;
+
+    for (size_t h = 0; h < srcImage.height; ++h)
+    {
+        if (!StoreScanline(pDest, destImage.rowPitch, destImage.format, reinterpret_cast<const XMVECTOR*>(pSrc), srcImage.width))
+            return E_FAIL;
+
+        pSrc += srcImage.rowPitch;
+        pDest += destImage.rowPitch;
+    }
+
+    return S_OK;
+}
+
+_Use_decl_annotations_
+HRESULT DirectX::Internal::ConvertFromR32G32B32A32(
+    const Image& srcImage,
+    DXGI_FORMAT format,
+    ScratchImage& image) noexcept
+{
+    if (!srcImage.pixels)
+        return E_POINTER;
+
+    HRESULT hr = image.Initialize2D(format, srcImage.width, srcImage.height, 1, 1);
+    if (FAILED(hr))
+        return hr;
+
+    const Image *img = image.GetImage(0, 0, 0);
+    if (!img)
+    {
+        image.Release();
+        return E_POINTER;
+    }
+
+    hr = ConvertFromR32G32B32A32(srcImage, *img);
+    if (FAILED(hr))
+    {
+        image.Release();
+        return hr;
+    }
+
+    return S_OK;
+}
+
+_Use_decl_annotations_
+HRESULT DirectX::Internal::ConvertFromR32G32B32A32(
+    const Image* srcImages,
+    size_t nimages,
+    const TexMetadata& metadata,
+    DXGI_FORMAT format,
+    ScratchImage& result) noexcept
+{
+    if (!srcImages)
+        return E_POINTER;
+
+    result.Release();
+
+    assert(metadata.format == DXGI_FORMAT_R32G32B32A32_FLOAT);
+
+    TexMetadata mdata2 = metadata;
+    mdata2.format = format;
+    HRESULT hr = result.Initialize(mdata2);
+    if (FAILED(hr))
+        return hr;
+
+    if (nimages != result.GetImageCount())
+    {
+        result.Release();
+        return E_FAIL;
+    }
+
+    const Image* dest = result.GetImages();
+    if (!dest)
+    {
+        result.Release();
+        return E_POINTER;
+    }
+
+    for (size_t index = 0; index < nimages; ++index)
+    {
+        const Image& src = srcImages[index];
+        const Image& dst = dest[index];
+
+        assert(src.format == DXGI_FORMAT_R32G32B32A32_FLOAT);
+        assert(dst.format == format);
+
+        if (src.width != dst.width || src.height != dst.height)
+        {
+            result.Release();
+            return E_FAIL;
+        }
+
+        const uint8_t* pSrc = src.pixels;
+        uint8_t* pDest = dst.pixels;
+        if (!pSrc || !pDest)
+        {
+            result.Release();
+            return E_POINTER;
+        }
+
+        for (size_t h = 0; h < src.height; ++h)
+        {
+            if (!StoreScanline(pDest, dst.rowPitch, format, reinterpret_cast<const XMVECTOR*>(pSrc), src.width))
+            {
+                result.Release();
+                return E_FAIL;
+            }
+
+            pSrc += src.rowPitch;
+            pDest += dst.rowPitch;
+        }
+    }
+
+    return S_OK;
+}
+
+
+//-------------------------------------------------------------------------------------
+// Convert DXGI image to/from GUID_WICPixelFormat64bppRGBAHalf (no range conversions)
+//-------------------------------------------------------------------------------------
+_Use_decl_annotations_
+HRESULT DirectX::Internal::ConvertToR16G16B16A16(const Image& srcImage, ScratchImage& image) noexcept
+{
+    if (!srcImage.pixels)
+        return E_POINTER;
+
+    HRESULT hr = image.Initialize2D(DXGI_FORMAT_R16G16B16A16_FLOAT, srcImage.width, srcImage.height, 1, 1);
+    if (FAILED(hr))
+        return hr;
+
+    auto scanline = make_AlignedArrayXMVECTOR(srcImage.width);
+    if (!scanline)
+    {
+        image.Release();
+        return E_OUTOFMEMORY;
+    }
+
+    const Image *img = image.GetImage(0, 0, 0);
+    if (!img)
+    {
+        image.Release();
+        return E_POINTER;
+    }
+
+    uint8_t* pDest = img->pixels;
+    if (!pDest)
+    {
+        image.Release();
+        return E_POINTER;
+    }
+
+    const uint8_t *pSrc = srcImage.pixels;
+    for (size_t h = 0; h < srcImage.height; ++h)
+    {
+        if (!LoadScanline(scanline.get(), srcImage.width, pSrc, srcImage.rowPitch, srcImage.format))
+        {
+            image.Release();
+            return E_FAIL;
+        }
+
+        XMConvertFloatToHalfStream(
+            reinterpret_cast<HALF*>(pDest), sizeof(HALF),
+            reinterpret_cast<float*>(scanline.get()), sizeof(float),
+            srcImage.width * 4);
+
+        pSrc += srcImage.rowPitch;
+        pDest += img->rowPitch;
+    }
+
+    return S_OK;
+}
+
+_Use_decl_annotations_
+HRESULT DirectX::Internal::ConvertFromR16G16B16A16(const Image& srcImage, const Image& destImage) noexcept
+{
+    assert(srcImage.format == DXGI_FORMAT_R16G16B16A16_FLOAT);
+
+    if (!srcImage.pixels || !destImage.pixels)
+        return E_POINTER;
+
+    if (srcImage.width != destImage.width || srcImage.height != destImage.height)
+        return E_FAIL;
+
+    auto scanline = make_AlignedArrayXMVECTOR(srcImage.width);
+    if (!scanline)
+        return E_OUTOFMEMORY;
+
+    const uint8_t *pSrc = srcImage.pixels;
+    uint8_t* pDest = destImage.pixels;
+
+    for (size_t h = 0; h < srcImage.height; ++h)
+    {
+        XMConvertHalfToFloatStream(
+            reinterpret_cast<float*>(scanline.get()), sizeof(float),
+            reinterpret_cast<const HALF*>(pSrc), sizeof(HALF),
+            srcImage.width * 4);
+
+        if (!StoreScanline(pDest, destImage.rowPitch, destImage.format, scanline.get(), srcImage.width))
+            return E_FAIL;
+
+        pSrc += srcImage.rowPitch;
+        pDest += destImage.rowPitch;
+    }
+
+    return S_OK;
+}
+
+
+//-------------------------------------------------------------------------------------
+// Convert from Linear RGB to sRGB
+//
+// if C_linear <= 0.0031308 -> C_srgb = 12.92 * C_linear
+// if C_linear >  0.0031308 -> C_srgb = ( 1 + a ) * pow( C_Linear, 1 / 2.4 ) - a
+//                             where a = 0.055
+//-------------------------------------------------------------------------------------
+_Use_decl_annotations_
+bool DirectX::Internal::StoreScanlineLinear(
+    void* pDestination,
+    size_t size,
+    DXGI_FORMAT format,
+    XMVECTOR* pSource,
+    size_t count,
+    TEX_FILTER_FLAGS flags,
+    float threshold) noexcept
+{
+    if (!pSource || !count)
+        return false;
+
+    assert((reinterpret_cast<uintptr_t>(pSource) & 0xF) == 0);
+
+    switch (static_cast<int>(format))
+    {
+    case DXGI_FORMAT_R8G8B8A8_UNORM_SRGB:
+    case DXGI_FORMAT_B8G8R8A8_UNORM_SRGB:
+    case DXGI_FORMAT_B8G8R8X8_UNORM_SRGB:
+        flags |= TEX_FILTER_SRGB;
+        break;
+
+    case DXGI_FORMAT_R32G32B32A32_FLOAT:
+    case DXGI_FORMAT_R32G32B32_FLOAT:
+    case DXGI_FORMAT_R16G16B16A16_FLOAT:
+    case DXGI_FORMAT_R16G16B16A16_UNORM:
+    case DXGI_FORMAT_R32G32_FLOAT:
+    case DXGI_FORMAT_R10G10B10A2_UNORM:
+    case DXGI_FORMAT_R11G11B10_FLOAT:
+    case DXGI_FORMAT_R8G8B8A8_UNORM:
+    case DXGI_FORMAT_R16G16_FLOAT:
+    case DXGI_FORMAT_R16G16_UNORM:
+    case DXGI_FORMAT_R32_FLOAT:
+    case DXGI_FORMAT_R8G8_UNORM:
+    case DXGI_FORMAT_R16_FLOAT:
+    case DXGI_FORMAT_R16_UNORM:
+    case DXGI_FORMAT_R8_UNORM:
+    case DXGI_FORMAT_R9G9B9E5_SHAREDEXP:
+    case DXGI_FORMAT_R8G8_B8G8_UNORM:
+    case DXGI_FORMAT_G8R8_G8B8_UNORM:
+    case DXGI_FORMAT_B5G6R5_UNORM:
+    case DXGI_FORMAT_B5G5R5A1_UNORM:
+    case DXGI_FORMAT_B8G8R8A8_UNORM:
+    case DXGI_FORMAT_B8G8R8X8_UNORM:
+    case DXGI_FORMAT_B4G4R4A4_UNORM:
+    case WIN11_DXGI_FORMAT_A4B4G4R4_UNORM:
+        break;
+
+    default:
+        // can't treat A8, XR, Depth, SNORM, UINT, or SINT as sRGB
+        flags &= ~TEX_FILTER_SRGB;
+        break;
+    }
+
+    // sRGB output processing (Linear RGB -> sRGB)
+    if (flags & TEX_FILTER_SRGB_OUT)
+    {
+        // To avoid the need for another temporary scanline buffer, we allow this function to overwrite the source buffer in-place
+        // Given the intended usage in the filtering routines, this is not a problem.
+        XMVECTOR* ptr = pSource;
+        for (size_t i = 0; i < count; ++i, ++ptr)
+        {
+            *ptr = XMColorRGBToSRGB(*ptr);
+        }
+    }
+
+    return StoreScanline(pDestination, size, format, pSource, count, threshold);
+}
+
+
+//-------------------------------------------------------------------------------------
+// Convert from sRGB to Linear RGB
+//
+// if C_srgb <= 0.04045 -> C_linear = C_srgb / 12.92
+// if C_srgb >  0.04045 -> C_linear = pow( ( C_srgb + a ) / ( 1 + a ), 2.4 )
+//                         where a = 0.055
+//-------------------------------------------------------------------------------------
+_Use_decl_annotations_
+bool DirectX::Internal::LoadScanlineLinear(
+    XMVECTOR* pDestination,
+    size_t count,
+    const void* pSource,
+    size_t size,
+    DXGI_FORMAT format,
+    TEX_FILTER_FLAGS flags) noexcept
+{
+    switch (static_cast<int>(format))
+    {
+    case DXGI_FORMAT_R8G8B8A8_UNORM_SRGB:
+    case DXGI_FORMAT_B8G8R8A8_UNORM_SRGB:
+    case DXGI_FORMAT_B8G8R8X8_UNORM_SRGB:
+        flags |= TEX_FILTER_SRGB;
+        break;
+
+    case DXGI_FORMAT_R32G32B32A32_FLOAT:
+    case DXGI_FORMAT_R32G32B32_FLOAT:
+    case DXGI_FORMAT_R16G16B16A16_FLOAT:
+    case DXGI_FORMAT_R16G16B16A16_UNORM:
+    case DXGI_FORMAT_R32G32_FLOAT:
+    case DXGI_FORMAT_R10G10B10A2_UNORM:
+    case DXGI_FORMAT_R11G11B10_FLOAT:
+    case DXGI_FORMAT_R8G8B8A8_UNORM:
+    case DXGI_FORMAT_R16G16_FLOAT:
+    case DXGI_FORMAT_R16G16_UNORM:
+    case DXGI_FORMAT_R32_FLOAT:
+    case DXGI_FORMAT_R8G8_UNORM:
+    case DXGI_FORMAT_R16_FLOAT:
+    case DXGI_FORMAT_R16_UNORM:
+    case DXGI_FORMAT_R8_UNORM:
+    case DXGI_FORMAT_R9G9B9E5_SHAREDEXP:
+    case DXGI_FORMAT_R8G8_B8G8_UNORM:
+    case DXGI_FORMAT_G8R8_G8B8_UNORM:
+    case DXGI_FORMAT_B5G6R5_UNORM:
+    case DXGI_FORMAT_B5G5R5A1_UNORM:
+    case DXGI_FORMAT_B8G8R8A8_UNORM:
+    case DXGI_FORMAT_B8G8R8X8_UNORM:
+    case DXGI_FORMAT_B4G4R4A4_UNORM:
+    case WIN11_DXGI_FORMAT_A4B4G4R4_UNORM:
+        break;
+
+    default:
+        // can't treat A8, XR, Depth, SNORM, UINT, or SINT as sRGB
+        flags &= ~TEX_FILTER_SRGB;
+        break;
+    }
+
+    if (LoadScanline(pDestination, count, pSource, size, format))
+    {
+        // sRGB input processing (sRGB -> Linear RGB)
+        if (flags & TEX_FILTER_SRGB_IN)
+        {
+            XMVECTOR* ptr = pDestination;
+            for (size_t i = 0; i < count; ++i, ++ptr)
+            {
+                *ptr = XMColorSRGBToRGB(*ptr);
+            }
+        }
+
+        return true;
+    }
+
+    return false;
+}
+
+
+//-------------------------------------------------------------------------------------
+// Convert scanline based on source/target formats
+//-------------------------------------------------------------------------------------
+namespace
+{
+    struct ConvertData
+    {
+        DXGI_FORMAT format;
+        size_t      datasize;
+        uint32_t    flags;
+    };
+
+    const ConvertData g_ConvertTable[] =
+    {
+        { DXGI_FORMAT_R32G32B32A32_FLOAT,           32, CONVF_FLOAT | CONVF_R | CONVF_G | CONVF_B | CONVF_A },
+        { DXGI_FORMAT_R32G32B32A32_UINT,            32, CONVF_UINT | CONVF_R | CONVF_G | CONVF_B | CONVF_A },
+        { DXGI_FORMAT_R32G32B32A32_SINT,            32, CONVF_SINT | CONVF_R | CONVF_G | CONVF_B | CONVF_A },
+        { DXGI_FORMAT_R32G32B32_FLOAT,              32, CONVF_FLOAT | CONVF_R | CONVF_G | CONVF_B },
+        { DXGI_FORMAT_R32G32B32_UINT,               32, CONVF_UINT | CONVF_R | CONVF_G | CONVF_B },
+        { DXGI_FORMAT_R32G32B32_SINT,               32, CONVF_SINT | CONVF_R | CONVF_G | CONVF_B },
+        { DXGI_FORMAT_R16G16B16A16_FLOAT,           16, CONVF_FLOAT | CONVF_R | CONVF_G | CONVF_B | CONVF_A },
+        { DXGI_FORMAT_R16G16B16A16_UNORM,           16, CONVF_UNORM | CONVF_R | CONVF_G | CONVF_B | CONVF_A },
+        { DXGI_FORMAT_R16G16B16A16_UINT,            16, CONVF_UINT | CONVF_R | CONVF_G | CONVF_B | CONVF_A },
+        { DXGI_FORMAT_R16G16B16A16_SNORM,           16, CONVF_SNORM | CONVF_R | CONVF_G | CONVF_B | CONVF_A },
+        { DXGI_FORMAT_R16G16B16A16_SINT,            16, CONVF_SINT | CONVF_R | CONVF_G | CONVF_B | CONVF_A },
+        { DXGI_FORMAT_R32G32_FLOAT,                 32, CONVF_FLOAT | CONVF_R | CONVF_G },
+        { DXGI_FORMAT_R32G32_UINT,                  32, CONVF_UINT | CONVF_R | CONVF_G  },
+        { DXGI_FORMAT_R32G32_SINT,                  32, CONVF_SINT | CONVF_R | CONVF_G  },
+        { DXGI_FORMAT_D32_FLOAT_S8X24_UINT,         32, CONVF_FLOAT | CONVF_DEPTH | CONVF_STENCIL },
+        { DXGI_FORMAT_R10G10B10A2_UNORM,            10, CONVF_UNORM | CONVF_R | CONVF_G | CONVF_B | CONVF_A },
+        { DXGI_FORMAT_R10G10B10A2_UINT,             10, CONVF_UINT | CONVF_R | CONVF_G | CONVF_B | CONVF_A },
+        { DXGI_FORMAT_R11G11B10_FLOAT,              10, CONVF_FLOAT | CONVF_POS_ONLY | CONVF_R | CONVF_G | CONVF_B },
+        { DXGI_FORMAT_R8G8B8A8_UNORM,                8, CONVF_UNORM | CONVF_R | CONVF_G | CONVF_B | CONVF_A },
+        { DXGI_FORMAT_R8G8B8A8_UNORM_SRGB,           8, CONVF_UNORM | CONVF_R | CONVF_G | CONVF_B | CONVF_A },
+        { DXGI_FORMAT_R8G8B8A8_UINT,                 8, CONVF_UINT | CONVF_R | CONVF_G | CONVF_B | CONVF_A },
+        { DXGI_FORMAT_R8G8B8A8_SNORM,                8, CONVF_SNORM | CONVF_R | CONVF_G | CONVF_B | CONVF_A },
+        { DXGI_FORMAT_R8G8B8A8_SINT,                 8, CONVF_SINT | CONVF_R | CONVF_G | CONVF_B | CONVF_A },
+        { DXGI_FORMAT_R16G16_FLOAT,                 16, CONVF_FLOAT | CONVF_R | CONVF_G },
+        { DXGI_FORMAT_R16G16_UNORM,                 16, CONVF_UNORM | CONVF_R | CONVF_G },
+        { DXGI_FORMAT_R16G16_UINT,                  16, CONVF_UINT | CONVF_R | CONVF_G },
+        { DXGI_FORMAT_R16G16_SNORM,                 16, CONVF_SNORM | CONVF_R | CONVF_G },
+        { DXGI_FORMAT_R16G16_SINT,                  16, CONVF_SINT | CONVF_R | CONVF_G },
+        { DXGI_FORMAT_D32_FLOAT,                    32, CONVF_FLOAT | CONVF_DEPTH },
+        { DXGI_FORMAT_R32_FLOAT,                    32, CONVF_FLOAT | CONVF_R },
+        { DXGI_FORMAT_R32_UINT,                     32, CONVF_UINT | CONVF_R },
+        { DXGI_FORMAT_R32_SINT,                     32, CONVF_SINT | CONVF_R },
+        { DXGI_FORMAT_D24_UNORM_S8_UINT,            32, CONVF_UNORM | CONVF_DEPTH | CONVF_STENCIL },
+        { DXGI_FORMAT_R8G8_UNORM,                    8, CONVF_UNORM | CONVF_R | CONVF_G },
+        { DXGI_FORMAT_R8G8_UINT,                     8, CONVF_UINT | CONVF_R | CONVF_G },
+        { DXGI_FORMAT_R8G8_SNORM,                    8, CONVF_SNORM | CONVF_R | CONVF_G },
+        { DXGI_FORMAT_R8G8_SINT,                     8, CONVF_SINT | CONVF_R | CONVF_G },
+        { DXGI_FORMAT_R16_FLOAT,                    16, CONVF_FLOAT | CONVF_R },
+        { DXGI_FORMAT_D16_UNORM,                    16, CONVF_UNORM | CONVF_DEPTH },
+        { DXGI_FORMAT_R16_UNORM,                    16, CONVF_UNORM | CONVF_R },
+        { DXGI_FORMAT_R16_UINT,                     16, CONVF_UINT | CONVF_R },
+        { DXGI_FORMAT_R16_SNORM,                    16, CONVF_SNORM | CONVF_R },
+        { DXGI_FORMAT_R16_SINT,                     16, CONVF_SINT | CONVF_R },
+        { DXGI_FORMAT_R8_UNORM,                      8, CONVF_UNORM | CONVF_R },
+        { DXGI_FORMAT_R8_UINT,                       8, CONVF_UINT | CONVF_R },
+        { DXGI_FORMAT_R8_SNORM,                      8, CONVF_SNORM | CONVF_R },
+        { DXGI_FORMAT_R8_SINT,                       8, CONVF_SINT | CONVF_R },
+        { DXGI_FORMAT_A8_UNORM,                      8, CONVF_UNORM | CONVF_A },
+        { DXGI_FORMAT_R1_UNORM,                      1, CONVF_UNORM | CONVF_R },
+        { DXGI_FORMAT_R9G9B9E5_SHAREDEXP,            9, CONVF_FLOAT | CONVF_SHAREDEXP | CONVF_POS_ONLY | CONVF_R | CONVF_G | CONVF_B },
+        { DXGI_FORMAT_R8G8_B8G8_UNORM,               8, CONVF_UNORM | CONVF_PACKED | CONVF_R | CONVF_G | CONVF_B },
+        { DXGI_FORMAT_G8R8_G8B8_UNORM,               8, CONVF_UNORM | CONVF_PACKED | CONVF_R | CONVF_G | CONVF_B },
+        { DXGI_FORMAT_BC1_UNORM,                     8, CONVF_UNORM | CONVF_BC | CONVF_R | CONVF_G | CONVF_B | CONVF_A },
+        { DXGI_FORMAT_BC1_UNORM_SRGB,                8, CONVF_UNORM | CONVF_BC | CONVF_R | CONVF_G | CONVF_B | CONVF_A },
+        { DXGI_FORMAT_BC2_UNORM,                     8, CONVF_UNORM | CONVF_BC | CONVF_R | CONVF_G | CONVF_B | CONVF_A },
+        { DXGI_FORMAT_BC2_UNORM_SRGB,                8, CONVF_UNORM | CONVF_BC | CONVF_R | CONVF_G | CONVF_B | CONVF_A },
+        { DXGI_FORMAT_BC3_UNORM,                     8, CONVF_UNORM | CONVF_BC | CONVF_R | CONVF_G | CONVF_B | CONVF_A },
+        { DXGI_FORMAT_BC3_UNORM_SRGB,                8, CONVF_UNORM | CONVF_BC | CONVF_R | CONVF_G | CONVF_B | CONVF_A },
+        { DXGI_FORMAT_BC4_UNORM,                     8, CONVF_UNORM | CONVF_BC | CONVF_R },
+        { DXGI_FORMAT_BC4_SNORM,                     8, CONVF_SNORM | CONVF_BC | CONVF_R },
+        { DXGI_FORMAT_BC5_UNORM,                     8, CONVF_UNORM | CONVF_BC | CONVF_R | CONVF_G },
+        { DXGI_FORMAT_BC5_SNORM,                     8, CONVF_SNORM | CONVF_BC | CONVF_R | CONVF_G },
+        { DXGI_FORMAT_B5G6R5_UNORM,                  5, CONVF_UNORM | CONVF_R | CONVF_G | CONVF_B },
+        { DXGI_FORMAT_B5G5R5A1_UNORM,                5, CONVF_UNORM | CONVF_R | CONVF_G | CONVF_B | CONVF_A },
+        { DXGI_FORMAT_B8G8R8A8_UNORM,                8, CONVF_UNORM | CONVF_BGR | CONVF_R | CONVF_G | CONVF_B | CONVF_A },
+        { DXGI_FORMAT_B8G8R8X8_UNORM,                8, CONVF_UNORM | CONVF_BGR | CONVF_R | CONVF_G | CONVF_B },
+        { DXGI_FORMAT_R10G10B10_XR_BIAS_A2_UNORM,   10, CONVF_UNORM | CONVF_XR | CONVF_R | CONVF_G | CONVF_B | CONVF_A },
+        { DXGI_FORMAT_B8G8R8A8_UNORM_SRGB,           8, CONVF_UNORM | CONVF_BGR | CONVF_R | CONVF_G | CONVF_B | CONVF_A },
+        { DXGI_FORMAT_B8G8R8X8_UNORM_SRGB,           8, CONVF_UNORM | CONVF_BGR | CONVF_R | CONVF_G | CONVF_B },
+        { DXGI_FORMAT_BC6H_UF16,                    16, CONVF_FLOAT | CONVF_BC | CONVF_R | CONVF_G | CONVF_B | CONVF_A },
+        { DXGI_FORMAT_BC6H_SF16,                    16, CONVF_FLOAT | CONVF_BC | CONVF_R | CONVF_G | CONVF_B | CONVF_A },
+        { DXGI_FORMAT_BC7_UNORM,                     8, CONVF_UNORM | CONVF_BC | CONVF_R | CONVF_G | CONVF_B | CONVF_A },
+        { DXGI_FORMAT_BC7_UNORM_SRGB,                8, CONVF_UNORM | CONVF_BC | CONVF_R | CONVF_G | CONVF_B | CONVF_A },
+        { DXGI_FORMAT_AYUV,                          8, CONVF_UNORM | CONVF_YUV | CONVF_R | CONVF_G | CONVF_B | CONVF_A },
+        { DXGI_FORMAT_Y410,                         10, CONVF_UNORM | CONVF_YUV | CONVF_R | CONVF_G | CONVF_B | CONVF_A },
+        { DXGI_FORMAT_Y416,                         16, CONVF_UNORM | CONVF_YUV | CONVF_R | CONVF_G | CONVF_B | CONVF_A },
+        { DXGI_FORMAT_YUY2,                          8, CONVF_UNORM | CONVF_YUV | CONVF_PACKED | CONVF_R | CONVF_G | CONVF_B },
+        { DXGI_FORMAT_Y210,                         10, CONVF_UNORM | CONVF_YUV | CONVF_PACKED | CONVF_R | CONVF_G | CONVF_B },
+        { DXGI_FORMAT_Y216,                         16, CONVF_UNORM | CONVF_YUV | CONVF_PACKED | CONVF_R | CONVF_G | CONVF_B },
+        { DXGI_FORMAT_B4G4R4A4_UNORM,                4, CONVF_UNORM | CONVF_BGR | CONVF_R | CONVF_G | CONVF_B | CONVF_A },
+        { XBOX_DXGI_FORMAT_R10G10B10_7E3_A2_FLOAT,  10, CONVF_FLOAT | CONVF_POS_ONLY | CONVF_R | CONVF_G | CONVF_B | CONVF_A },
+        { XBOX_DXGI_FORMAT_R10G10B10_6E4_A2_FLOAT,  10, CONVF_FLOAT | CONVF_POS_ONLY | CONVF_R | CONVF_G | CONVF_B | CONVF_A },
+        { XBOX_DXGI_FORMAT_R10G10B10_SNORM_A2_UNORM,10, CONVF_SNORM | CONVF_R | CONVF_G | CONVF_B | CONVF_A },
+        { XBOX_DXGI_FORMAT_R4G4_UNORM,               4, CONVF_UNORM | CONVF_R | CONVF_G },
+        { WIN11_DXGI_FORMAT_A4B4G4R4_UNORM,          4, CONVF_UNORM | CONVF_BGR | CONVF_R | CONVF_G | CONVF_B | CONVF_A },
+    };
+
+#pragma prefast( suppress : 25004, "Signature must match bsearch" );
+    int __cdecl ConvertCompare(const void* ptr1, const void *ptr2) noexcept
+    {
+        auto p1 = static_cast<const ConvertData*>(ptr1);
+        auto p2 = static_cast<const ConvertData*>(ptr2);
+        if (p1->format == p2->format) return 0;
+        else return (p1->format < p2->format) ? -1 : 1;
+    }
+}
+
+_Use_decl_annotations_
+uint32_t DirectX::Internal::GetConvertFlags(DXGI_FORMAT format) noexcept
+{
+#ifdef _DEBUG
+    // Ensure conversion table is in ascending order
+    assert(std::size(g_ConvertTable) > 0);
+    DXGI_FORMAT lastvalue = g_ConvertTable[0].format;
+    for (size_t index = 1; index < std::size(g_ConvertTable); ++index)
+    {
+        assert(g_ConvertTable[index].format > lastvalue);
+        lastvalue = g_ConvertTable[index].format;
+    }
+#endif
+
+    ConvertData key = { format, 0, 0 };
+    auto in = reinterpret_cast<const ConvertData*>(bsearch(&key, g_ConvertTable, std::size(g_ConvertTable), sizeof(ConvertData),
+        ConvertCompare));
+    return (in) ? in->flags : 0;
+}
+
+_Use_decl_annotations_
+void DirectX::Internal::ConvertScanline(
+    XMVECTOR* pBuffer,
+    size_t count,
+    DXGI_FORMAT outFormat,
+    DXGI_FORMAT inFormat,
+    TEX_FILTER_FLAGS flags) noexcept
+{
+    assert(pBuffer && count > 0 && ((reinterpret_cast<uintptr_t>(pBuffer) & 0xF) == 0));
+    assert(IsValid(outFormat) && !IsTypeless(outFormat) && !IsPlanar(outFormat) && !IsPalettized(outFormat));
+    assert(IsValid(inFormat) && !IsTypeless(inFormat) && !IsPlanar(inFormat) && !IsPalettized(inFormat));
+
+    if (!pBuffer)
+        return;
+
+#ifdef _DEBUG
+    // Ensure conversion table is in ascending order
+    assert(std::size(g_ConvertTable) > 0);
+    DXGI_FORMAT lastvalue = g_ConvertTable[0].format;
+    for (size_t index = 1; index < std::size(g_ConvertTable); ++index)
+    {
+        assert(g_ConvertTable[index].format > lastvalue);
+        lastvalue = g_ConvertTable[index].format;
+    }
+#endif
+
+    // Determine conversion details about source and dest formats
+    ConvertData key = { inFormat, 0, 0 };
+    auto in = reinterpret_cast<const ConvertData*>(
+        bsearch(&key, g_ConvertTable, std::size(g_ConvertTable), sizeof(ConvertData), ConvertCompare));
+    key.format = outFormat;
+    auto out = reinterpret_cast<const ConvertData*>(
+        bsearch(&key, g_ConvertTable, std::size(g_ConvertTable), sizeof(ConvertData), ConvertCompare));
+    if (!in || !out)
+    {
+        assert(false);
+        return;
+    }
+
+    assert(GetConvertFlags(inFormat) == in->flags);
+    assert(GetConvertFlags(outFormat) == out->flags);
+
+    // Handle SRGB filtering modes
+    switch (inFormat)
+    {
+    case DXGI_FORMAT_R8G8B8A8_UNORM_SRGB:
+    case DXGI_FORMAT_BC1_UNORM_SRGB:
+    case DXGI_FORMAT_BC2_UNORM_SRGB:
+    case DXGI_FORMAT_BC3_UNORM_SRGB:
+    case DXGI_FORMAT_B8G8R8A8_UNORM_SRGB:
+    case DXGI_FORMAT_B8G8R8X8_UNORM_SRGB:
+    case DXGI_FORMAT_BC7_UNORM_SRGB:
+        flags |= TEX_FILTER_SRGB_IN;
+        break;
+
+    case DXGI_FORMAT_A8_UNORM:
+    case DXGI_FORMAT_R10G10B10_XR_BIAS_A2_UNORM:
+        flags &= ~TEX_FILTER_SRGB_IN;
+        break;
+
+    default:
+        break;
+    }
+
+    switch (outFormat)
+    {
+    case DXGI_FORMAT_R8G8B8A8_UNORM_SRGB:
+    case DXGI_FORMAT_BC1_UNORM_SRGB:
+    case DXGI_FORMAT_BC2_UNORM_SRGB:
+    case DXGI_FORMAT_BC3_UNORM_SRGB:
+    case DXGI_FORMAT_B8G8R8A8_UNORM_SRGB:
+    case DXGI_FORMAT_B8G8R8X8_UNORM_SRGB:
+    case DXGI_FORMAT_BC7_UNORM_SRGB:
+        flags |= TEX_FILTER_SRGB_OUT;
+        break;
+
+    case DXGI_FORMAT_A8_UNORM:
+    case DXGI_FORMAT_R10G10B10_XR_BIAS_A2_UNORM:
+        flags &= ~TEX_FILTER_SRGB_OUT;
+        break;
+
+    default:
+        break;
+    }
+
+    if ((flags & (TEX_FILTER_SRGB_IN | TEX_FILTER_SRGB_OUT)) == (TEX_FILTER_SRGB_IN | TEX_FILTER_SRGB_OUT))
+    {
+        flags &= ~(TEX_FILTER_SRGB_IN | TEX_FILTER_SRGB_OUT);
+    }
+
+    // sRGB input processing (sRGB -> Linear RGB)
+    if (flags & TEX_FILTER_SRGB_IN)
+    {
+        if (!(in->flags & CONVF_DEPTH) && ((in->flags & CONVF_FLOAT) || (in->flags & CONVF_UNORM)))
+        {
+            XMVECTOR* ptr = pBuffer;
+            for (size_t i = 0; i < count; ++i, ++ptr)
+            {
+                *ptr = XMColorSRGBToRGB(*ptr);
+            }
+        }
+    }
+
+    // Handle conversion special cases
+    const uint32_t diffFlags = in->flags ^ out->flags;
+    if (diffFlags != 0)
+    {
+        if (diffFlags & CONVF_DEPTH)
+        {
+            //--- Depth conversions ---
+            if (in->flags & CONVF_DEPTH)
+            {
+                // CONVF_DEPTH -> !CONVF_DEPTH
+                if (in->flags & CONVF_STENCIL)
+                {
+                    // Stencil -> Alpha
+                    static const XMVECTORF32 S = { { { 1.f, 1.f, 1.f, 255.f } } };
+
+                    if (out->flags & CONVF_UNORM)
+                    {
+                        // UINT -> UNORM
+                        XMVECTOR* ptr = pBuffer;
+                        for (size_t i = 0; i < count; ++i)
+                        {
+                            const XMVECTOR v = *ptr;
+                            XMVECTOR v1 = XMVectorSplatY(v);
+                            v1 = XMVectorClamp(v1, g_XMZero, S);
+                            v1 = XMVectorDivide(v1, S);
+                            *ptr++ = XMVectorSelect(v1, v, g_XMSelect1110);
+                        }
+                    }
+                    else if (out->flags & CONVF_SNORM)
+                    {
+                        // UINT -> SNORM
+                        XMVECTOR* ptr = pBuffer;
+                        for (size_t i = 0; i < count; ++i)
+                        {
+                            const XMVECTOR v = *ptr;
+                            XMVECTOR v1 = XMVectorSplatY(v);
+                            v1 = XMVectorClamp(v1, g_XMZero, S);
+                            v1 = XMVectorDivide(v1, S);
+                            v1 = XMVectorMultiplyAdd(v1, g_XMTwo, g_XMNegativeOne);
+                            *ptr++ = XMVectorSelect(v1, v, g_XMSelect1110);
+                        }
+                    }
+                    else
+                    {
+                        XMVECTOR* ptr = pBuffer;
+                        for (size_t i = 0; i < count; ++i)
+                        {
+                            const XMVECTOR v = *ptr;
+                            const XMVECTOR v1 = XMVectorSplatY(v);
+                            *ptr++ = XMVectorSelect(v1, v, g_XMSelect1110);
+                        }
+                    }
+                }
+
+                // Depth -> RGB
+                if ((out->flags & CONVF_UNORM) && (in->flags & CONVF_FLOAT))
+                {
+                    // Depth FLOAT -> UNORM
+                    XMVECTOR* ptr = pBuffer;
+                    for (size_t i = 0; i < count; ++i)
+                    {
+                        const XMVECTOR v = *ptr;
+                        XMVECTOR v1 = XMVectorSaturate(v);
+                        v1 = XMVectorSplatX(v1);
+                        *ptr++ = XMVectorSelect(v, v1, g_XMSelect1110);
+                    }
+                }
+                else if (out->flags & CONVF_SNORM)
+                {
+                    if (in->flags & CONVF_UNORM)
+                    {
+                        // Depth UNORM -> SNORM
+                        XMVECTOR* ptr = pBuffer;
+                        for (size_t i = 0; i < count; ++i)
+                        {
+                            const XMVECTOR v = *ptr;
+                            XMVECTOR v1 = XMVectorMultiplyAdd(v, g_XMTwo, g_XMNegativeOne);
+                            v1 = XMVectorSplatX(v1);
+                            *ptr++ = XMVectorSelect(v, v1, g_XMSelect1110);
+                        }
+                    }
+                    else
+                    {
+                        // Depth FLOAT -> SNORM
+                        XMVECTOR* ptr = pBuffer;
+                        for (size_t i = 0; i < count; ++i)
+                        {
+                            const XMVECTOR v = *ptr;
+                            XMVECTOR v1 = XMVectorClamp(v, g_XMNegativeOne, g_XMOne);
+                            v1 = XMVectorSplatX(v1);
+                            *ptr++ = XMVectorSelect(v, v1, g_XMSelect1110);
+                        }
+                    }
+                }
+                else
+                {
+                    XMVECTOR* ptr = pBuffer;
+                    for (size_t i = 0; i < count; ++i)
+                    {
+                        const XMVECTOR v = *ptr;
+                        const XMVECTOR v1 = XMVectorSplatX(v);
+                        *ptr++ = XMVectorSelect(v, v1, g_XMSelect1110);
+                    }
+                }
+            }
+            else
+            {
+                // !CONVF_DEPTH -> CONVF_DEPTH
+
+                // RGB -> Depth (red channel or other specified channel)
+                switch (flags & (TEX_FILTER_RGB_COPY_RED | TEX_FILTER_RGB_COPY_GREEN | TEX_FILTER_RGB_COPY_BLUE | TEX_FILTER_RGB_COPY_ALPHA))
+                {
+                case TEX_FILTER_RGB_COPY_GREEN:
+                    {
+                        XMVECTOR* ptr = pBuffer;
+                        for (size_t i = 0; i < count; ++i)
+                        {
+                            const XMVECTOR v = *ptr;
+                            const XMVECTOR v1 = XMVectorSplatY(v);
+                            *ptr++ = XMVectorSelect(v, v1, g_XMSelect1000);
+                        }
+                    }
+                    break;
+
+                case TEX_FILTER_RGB_COPY_BLUE:
+                    {
+                        XMVECTOR* ptr = pBuffer;
+                        for (size_t i = 0; i < count; ++i)
+                        {
+                            const XMVECTOR v = *ptr;
+                            const XMVECTOR v1 = XMVectorSplatZ(v);
+                            *ptr++ = XMVectorSelect(v, v1, g_XMSelect1000);
+                        }
+                    }
+                    break;
+
+                case TEX_FILTER_RGB_COPY_ALPHA:
+                    {
+                        XMVECTOR* ptr = pBuffer;
+                        for (size_t i = 0; i < count; ++i)
+                        {
+                            const XMVECTOR v = *ptr;
+                            const XMVECTOR v1 = XMVectorSplatW(v);
+                            *ptr++ = XMVectorSelect(v, v1, g_XMSelect1000);
+                        }
+                    }
+                    break;
+
+                default:
+                    if ((in->flags & CONVF_UNORM) && ((in->flags & CONVF_RGB_MASK) == (CONVF_R | CONVF_G | CONVF_B)))
+                    {
+                        XMVECTOR* ptr = pBuffer;
+                        for (size_t i = 0; i < count; ++i)
+                        {
+                            const XMVECTOR v = *ptr;
+                            const XMVECTOR v1 = XMVector3Dot(v, g_Grayscale);
+                            *ptr++ = XMVectorSelect(v, v1, g_XMSelect1000);
+                        }
+                        break;
+                    }
+
+                #if (__cplusplus >= 201703L)
+                    [[fallthrough]];
+                #elif defined(__clang__)
+                    [[clang::fallthrough]];
+                #elif defined(_MSC_VER)
+                    __fallthrough;
+                #endif
+
+                case TEX_FILTER_RGB_COPY_RED:
+                    {
+                        XMVECTOR* ptr = pBuffer;
+                        for (size_t i = 0; i < count; ++i)
+                        {
+                            const XMVECTOR v = *ptr;
+                            const XMVECTOR v1 = XMVectorSplatX(v);
+                            *ptr++ = XMVectorSelect(v, v1, g_XMSelect1000);
+                        }
+                    }
+                    break;
+                }
+
+                // Finialize type conversion for depth (red channel)
+                if (out->flags & CONVF_UNORM)
+                {
+                    if (in->flags & CONVF_SNORM)
+                    {
+                        // SNORM -> UNORM
+                        XMVECTOR* ptr = pBuffer;
+                        for (size_t i = 0; i < count; ++i)
+                        {
+                            const XMVECTOR v = *ptr;
+                            const XMVECTOR v1 = XMVectorMultiplyAdd(v, g_XMOneHalf, g_XMOneHalf);
+                            *ptr++ = XMVectorSelect(v, v1, g_XMSelect1000);
+                        }
+                    }
+                    else if (in->flags & CONVF_FLOAT)
+                    {
+                        // FLOAT -> UNORM
+                        XMVECTOR* ptr = pBuffer;
+                        for (size_t i = 0; i < count; ++i)
+                        {
+                            const XMVECTOR v = *ptr;
+                            const XMVECTOR v1 = XMVectorSaturate(v);
+                            *ptr++ = XMVectorSelect(v, v1, g_XMSelect1000);
+                        }
+                    }
+                }
+
+                if (out->flags & CONVF_STENCIL)
+                {
+                    // Alpha -> Stencil (green channel)
+                    static const XMVECTORU32 select0100 = { { { XM_SELECT_0, XM_SELECT_1, XM_SELECT_0, XM_SELECT_0 } } };
+                    static const XMVECTORF32 S = { { { 255.f, 255.f, 255.f, 255.f } } };
+
+                    if (in->flags & CONVF_UNORM)
+                    {
+                        // UNORM -> UINT
+                        XMVECTOR* ptr = pBuffer;
+                        for (size_t i = 0; i < count; ++i)
+                        {
+                            const XMVECTOR v = *ptr;
+                            XMVECTOR v1 = XMVectorMultiply(v, S);
+                            v1 = XMVectorSplatW(v1);
+                            *ptr++ = XMVectorSelect(v, v1, select0100);
+                        }
+                    }
+                    else if (in->flags & CONVF_SNORM)
+                    {
+                        // SNORM -> UINT
+                        XMVECTOR* ptr = pBuffer;
+                        for (size_t i = 0; i < count; ++i)
+                        {
+                            const XMVECTOR v = *ptr;
+                            XMVECTOR v1 = XMVectorMultiplyAdd(v, g_XMOneHalf, g_XMOneHalf);
+                            v1 = XMVectorMultiply(v1, S);
+                            v1 = XMVectorSplatW(v1);
+                            *ptr++ = XMVectorSelect(v, v1, select0100);
+                        }
+                    }
+                    else
+                    {
+                        XMVECTOR* ptr = pBuffer;
+                        for (size_t i = 0; i < count; ++i)
+                        {
+                            const XMVECTOR v = *ptr;
+                            const XMVECTOR v1 = XMVectorSplatW(v);
+                            *ptr++ = XMVectorSelect(v, v1, select0100);
+                        }
+                    }
+                }
+            }
+        }
+        else if (out->flags & CONVF_DEPTH)
+        {
+            // CONVF_DEPTH -> CONVF_DEPTH
+            if (diffFlags & CONVF_FLOAT)
+            {
+                if (in->flags & CONVF_FLOAT)
+                {
+                    // FLOAT -> UNORM depth, preserve stencil
+                    XMVECTOR* ptr = pBuffer;
+                    for (size_t i = 0; i < count; ++i)
+                    {
+                        const XMVECTOR v = *ptr;
+                        const XMVECTOR v1 = XMVectorSaturate(v);
+                        *ptr++ = XMVectorSelect(v, v1, g_XMSelect1000);
+                    }
+                }
+            }
+        }
+        else if (out->flags & CONVF_UNORM)
+        {
+            //--- Converting to a UNORM ---
+            if (in->flags & CONVF_SNORM)
+            {
+                // SNORM -> UNORM
+                XMVECTOR* ptr = pBuffer;
+                for (size_t i = 0; i < count; ++i)
+                {
+                    const XMVECTOR v = *ptr;
+                    *ptr++ = XMVectorMultiplyAdd(v, g_XMOneHalf, g_XMOneHalf);
+                }
+            }
+            else if (in->flags & CONVF_FLOAT)
+            {
+                XMVECTOR* ptr = pBuffer;
+                if (!(in->flags & CONVF_POS_ONLY) && (flags & TEX_FILTER_FLOAT_X2BIAS))
+                {
+                    // FLOAT -> UNORM (x2 bias)
+                    for (size_t i = 0; i < count; ++i)
+                    {
+                        XMVECTOR v = *ptr;
+                        v = XMVectorClamp(v, g_XMNegativeOne, g_XMOne);
+                        *ptr++ = XMVectorMultiplyAdd(v, g_XMOneHalf, g_XMOneHalf);
+                    }
+                }
+                else
+                {
+                    // FLOAT -> UNORM
+                    for (size_t i = 0; i < count; ++i)
+                    {
+                        const XMVECTOR v = *ptr;
+                        *ptr++ = XMVectorSaturate(v);
+                    }
+                }
+            }
+        }
+        else if (out->flags & CONVF_SNORM)
+        {
+            //--- Converting to a SNORM ---
+            if (in->flags & CONVF_UNORM)
+            {
+                // UNORM -> SNORM
+                XMVECTOR* ptr = pBuffer;
+                for (size_t i = 0; i < count; ++i)
+                {
+                    const XMVECTOR v = *ptr;
+                    *ptr++ = XMVectorMultiplyAdd(v, g_XMTwo, g_XMNegativeOne);
+                }
+            }
+            else if (in->flags & CONVF_FLOAT)
+            {
+                XMVECTOR* ptr = pBuffer;
+                if ((in->flags & CONVF_POS_ONLY) && (flags & TEX_FILTER_FLOAT_X2BIAS))
+                {
+                    // FLOAT (positive only, x2 bias) -> SNORM
+                    for (size_t i = 0; i < count; ++i)
+                    {
+                        XMVECTOR v = *ptr;
+                        v = XMVectorSaturate(v);
+                        *ptr++ = XMVectorMultiplyAdd(v, g_XMTwo, g_XMNegativeOne);
+                    }
+                }
+                else
+                {
+                    // FLOAT -> SNORM
+                    for (size_t i = 0; i < count; ++i)
+                    {
+                        const XMVECTOR v = *ptr;
+                        *ptr++ = XMVectorClamp(v, g_XMNegativeOne, g_XMOne);
+                    }
+                }
+            }
+        }
+        else if (diffFlags & CONVF_UNORM)
+        {
+            //--- Converting from a UNORM ---
+            assert(in->flags & CONVF_UNORM);
+            if (out->flags & CONVF_FLOAT)
+            {
+                if (!(out->flags & CONVF_POS_ONLY) && (flags & TEX_FILTER_FLOAT_X2BIAS))
+                {
+                    // UNORM (x2 bias) -> FLOAT
+                    XMVECTOR* ptr = pBuffer;
+                    for (size_t i = 0; i < count; ++i)
+                    {
+                        const XMVECTOR v = *ptr;
+                        *ptr++ = XMVectorMultiplyAdd(v, g_XMTwo, g_XMNegativeOne);
+                    }
+                }
+            }
+        }
+        else if (diffFlags & CONVF_POS_ONLY)
+        {
+            if (flags & TEX_FILTER_FLOAT_X2BIAS)
+            {
+                if (in->flags & CONVF_POS_ONLY)
+                {
+                    if (out->flags & CONVF_FLOAT)
+                    {
+                        // FLOAT (positive only, x2 bias) -> FLOAT
+                        XMVECTOR* ptr = pBuffer;
+                        for (size_t i = 0; i < count; ++i)
+                        {
+                            XMVECTOR v = *ptr;
+                            v = XMVectorSaturate(v);
+                            *ptr++ = XMVectorMultiplyAdd(v, g_XMTwo, g_XMNegativeOne);
+                        }
+                    }
+                }
+                else if (out->flags & CONVF_POS_ONLY)
+                {
+                    if (in->flags & CONVF_FLOAT)
+                    {
+                        // FLOAT -> FLOAT (positive only, x2 bias)
+                        XMVECTOR* ptr = pBuffer;
+                        for (size_t i = 0; i < count; ++i)
+                        {
+                            XMVECTOR v = *ptr;
+                            v = XMVectorClamp(v, g_XMNegativeOne, g_XMOne);
+                            *ptr++ = XMVectorMultiplyAdd(v, g_XMOneHalf, g_XMOneHalf);
+                        }
+                    }
+                    else if (in->flags & CONVF_SNORM)
+                    {
+                        // SNORM -> FLOAT (positive only, x2 bias)
+                        XMVECTOR* ptr = pBuffer;
+                        for (size_t i = 0; i < count; ++i)
+                        {
+                            const XMVECTOR v = *ptr;
+                            *ptr++ = XMVectorMultiplyAdd(v, g_XMOneHalf, g_XMOneHalf);
+                        }
+                    }
+                }
+            }
+        }
+
+        // !CONVF_A -> CONVF_A is handled because LoadScanline ensures alpha defaults to 1.0 for no-alpha formats
+
+        // CONVF_PACKED cases are handled because LoadScanline/StoreScanline handles packing/unpacking
+
+        if (((out->flags & CONVF_RGBA_MASK) == CONVF_A) && !(in->flags & CONVF_A))
+        {
+            // !CONVF_A -> A format
+            // We ignore TEX_FILTER_RGB_COPY_ALPHA since there's no input alpha channel.
+            switch (flags & (TEX_FILTER_RGB_COPY_RED | TEX_FILTER_RGB_COPY_GREEN | TEX_FILTER_RGB_COPY_BLUE))
+            {
+            case TEX_FILTER_RGB_COPY_GREEN:
+                {
+                    XMVECTOR* ptr = pBuffer;
+                    for (size_t i = 0; i < count; ++i)
+                    {
+                        const XMVECTOR v = *ptr;
+                        *ptr++ = XMVectorSplatY(v);
+                    }
+                }
+                break;
+
+            case TEX_FILTER_RGB_COPY_BLUE:
+                {
+                    XMVECTOR* ptr = pBuffer;
+                    for (size_t i = 0; i < count; ++i)
+                    {
+                        const XMVECTOR v = *ptr;
+                        *ptr++ = XMVectorSplatZ(v);
+                    }
+                }
+                break;
+
+            default:
+                if ((in->flags & CONVF_UNORM) && ((in->flags & CONVF_RGB_MASK) == (CONVF_R | CONVF_G | CONVF_B)))
+                {
+                    XMVECTOR* ptr = pBuffer;
+                    for (size_t i = 0; i < count; ++i)
+                    {
+                        const XMVECTOR v = *ptr;
+                        *ptr++ = XMVector3Dot(v, g_Grayscale);
+                    }
+                    break;
+                }
+
+            #if (__cplusplus >= 201703L)
+                [[fallthrough]];
+            #elif defined(__clang__)
+                [[clang::fallthrough]];
+            #elif defined(_MSC_VER)
+                __fallthrough;
+            #endif
+
+            case TEX_FILTER_RGB_COPY_RED:
+                {
+                    XMVECTOR* ptr = pBuffer;
+                    for (size_t i = 0; i < count; ++i)
+                    {
+                        const XMVECTOR v = *ptr;
+                        *ptr++ = XMVectorSplatX(v);
+                    }
+                }
+                break;
+            }
+        }
+        else if (((in->flags & CONVF_RGBA_MASK) == CONVF_A) && !(out->flags & CONVF_A))
+        {
+            // A format -> !CONVF_A
+            XMVECTOR* ptr = pBuffer;
+            for (size_t i = 0; i < count; ++i)
+            {
+                const XMVECTOR v = *ptr;
+                *ptr++ = XMVectorSplatW(v);
+            }
+        }
+        else if ((in->flags & CONVF_RGB_MASK) == CONVF_R)
+        {
+            if ((out->flags & CONVF_RGB_MASK) == (CONVF_R | CONVF_G | CONVF_B))
+            {
+                // R format -> RGB format
+                XMVECTOR* ptr = pBuffer;
+                for (size_t i = 0; i < count; ++i)
+                {
+                    const XMVECTOR v = *ptr;
+                    const XMVECTOR v1 = XMVectorSplatX(v);
+                    *ptr++ = XMVectorSelect(v, v1, g_XMSelect1110);
+                }
+            }
+            else if ((out->flags & CONVF_RGB_MASK) == (CONVF_R | CONVF_G))
+            {
+                // R format -> RG format
+                XMVECTOR* ptr = pBuffer;
+                for (size_t i = 0; i < count; ++i)
+                {
+                    const XMVECTOR v = *ptr;
+                    const XMVECTOR v1 = XMVectorSplatX(v);
+                    *ptr++ = XMVectorSelect(v, v1, g_XMSelect1100);
+                }
+            }
+        }
+        else if ((in->flags & CONVF_RGB_MASK) == (CONVF_R | CONVF_G | CONVF_B))
+        {
+            if ((out->flags & CONVF_RGB_MASK) == CONVF_R)
+            {
+                // RGB(A) format -> R format
+                switch (flags & (TEX_FILTER_RGB_COPY_RED | TEX_FILTER_RGB_COPY_GREEN | TEX_FILTER_RGB_COPY_BLUE | TEX_FILTER_RGB_COPY_ALPHA))
+                {
+                case TEX_FILTER_RGB_COPY_GREEN:
+                    {
+                        XMVECTOR* ptr = pBuffer;
+                        for (size_t i = 0; i < count; ++i)
+                        {
+                            const XMVECTOR v = *ptr;
+                            const XMVECTOR v1 = XMVectorSplatY(v);
+                            *ptr++ = XMVectorSelect(v, v1, g_XMSelect1110);
+                        }
+                    }
+                    break;
+
+                case TEX_FILTER_RGB_COPY_BLUE:
+                    {
+                        XMVECTOR* ptr = pBuffer;
+                        for (size_t i = 0; i < count; ++i)
+                        {
+                            const XMVECTOR v = *ptr;
+                            const XMVECTOR v1 = XMVectorSplatZ(v);
+                            *ptr++ = XMVectorSelect(v, v1, g_XMSelect1110);
+                        }
+                    }
+                    break;
+
+                case TEX_FILTER_RGB_COPY_ALPHA:
+                    {
+                        XMVECTOR* ptr = pBuffer;
+                        for (size_t i = 0; i < count; ++i)
+                        {
+                            const XMVECTOR v = *ptr;
+                            const XMVECTOR v1 = XMVectorSplatW(v);
+                            *ptr++ = XMVectorSelect(v, v1, g_XMSelect1110);
+                        }
+                    }
+                    break;
+
+                default:
+                    if (in->flags & CONVF_UNORM)
+                    {
+                        XMVECTOR* ptr = pBuffer;
+                        for (size_t i = 0; i < count; ++i)
+                        {
+                            const XMVECTOR v = *ptr;
+                            const XMVECTOR v1 = XMVector3Dot(v, g_Grayscale);
+                            *ptr++ = XMVectorSelect(v, v1, g_XMSelect1110);
+                        }
+                        break;
+                    }
+
+                #if (__cplusplus >= 201703L)
+                    [[fallthrough]];
+                #elif defined(__clang__)
+                    [[clang::fallthrough]];
+                #elif defined(_MSC_VER)
+                    __fallthrough;
+                #endif
+
+                case TEX_FILTER_RGB_COPY_RED:
+                    // Leave data unchanged and the store will handle this...
+                    break;
+                }
+            }
+            else if ((out->flags & CONVF_RGB_MASK) == (CONVF_R | CONVF_G))
+            {
+                if ((flags & TEX_FILTER_RGB_COPY_ALPHA) && (in->flags & CONVF_A))
+                {
+                    // RGBA -> RG format
+                    switch (static_cast<int>(flags & (TEX_FILTER_RGB_COPY_RED | TEX_FILTER_RGB_COPY_GREEN | TEX_FILTER_RGB_COPY_BLUE | TEX_FILTER_RGB_COPY_ALPHA)))
+                    {
+                    case (static_cast<int>(TEX_FILTER_RGB_COPY_RED) | static_cast<int>(TEX_FILTER_RGB_COPY_ALPHA)):
+                    default:
+                        {
+                            XMVECTOR* ptr = pBuffer;
+                            for (size_t i = 0; i < count; ++i)
+                            {
+                                const XMVECTOR v = *ptr;
+                                const XMVECTOR v1 = XMVectorSwizzle<0, 3, 0, 3>(v);
+                                *ptr++ = XMVectorSelect(v, v1, g_XMSelect1100);
+                            }
+                        }
+                        break;
+
+                    case (static_cast<int>(TEX_FILTER_RGB_COPY_GREEN) | static_cast<int>(TEX_FILTER_RGB_COPY_ALPHA)):
+                        {
+                            XMVECTOR* ptr = pBuffer;
+                            for (size_t i = 0; i < count; ++i)
+                            {
+                                const XMVECTOR v = *ptr;
+                                const XMVECTOR v1 = XMVectorSwizzle<1, 3, 1, 3>(v);
+                                *ptr++ = XMVectorSelect(v, v1, g_XMSelect1100);
+                            }
+                        }
+                        break;
+
+                    case (static_cast<int>(TEX_FILTER_RGB_COPY_BLUE) | static_cast<int>(TEX_FILTER_RGB_COPY_ALPHA)):
+                        {
+                            XMVECTOR* ptr = pBuffer;
+                            for (size_t i = 0; i < count; ++i)
+                            {
+                                const XMVECTOR v = *ptr;
+                                const XMVECTOR v1 = XMVectorSwizzle<2, 3, 2, 3>(v);
+                                *ptr++ = XMVectorSelect(v, v1, g_XMSelect1100);
+                            }
+                        }
+                        break;
+                    }
+                }
+                else
+                {
+                    // RGB format -> RG format
+                    switch (static_cast<int>(flags & (TEX_FILTER_RGB_COPY_RED | TEX_FILTER_RGB_COPY_GREEN | TEX_FILTER_RGB_COPY_BLUE)))
+                    {
+                    case (static_cast<int>(TEX_FILTER_RGB_COPY_RED) | static_cast<int>(TEX_FILTER_RGB_COPY_BLUE)):
+                        {
+                            XMVECTOR* ptr = pBuffer;
+                            for (size_t i = 0; i < count; ++i)
+                            {
+                                const XMVECTOR v = *ptr;
+                                const XMVECTOR v1 = XMVectorSwizzle<0, 2, 0, 2>(v);
+                                *ptr++ = XMVectorSelect(v, v1, g_XMSelect1100);
+                            }
+                        }
+                        break;
+
+                    case (static_cast<int>(TEX_FILTER_RGB_COPY_GREEN) | static_cast<int>(TEX_FILTER_RGB_COPY_BLUE)):
+                        {
+                            XMVECTOR* ptr = pBuffer;
+                            for (size_t i = 0; i < count; ++i)
+                            {
+                                const XMVECTOR v = *ptr;
+                                const XMVECTOR v1 = XMVectorSwizzle<1, 2, 3, 0>(v);
+                                *ptr++ = XMVectorSelect(v, v1, g_XMSelect1100);
+                            }
+                        }
+                        break;
+
+                    case (static_cast<int>(TEX_FILTER_RGB_COPY_RED) | static_cast<int>(TEX_FILTER_RGB_COPY_GREEN)):
+                    default:
+                        // Leave data unchanged and the store will handle this...
+                        break;
+                    }
+                }
+            }
+        }
+    }
+
+    // sRGB output processing (Linear RGB -> sRGB)
+    if (flags & TEX_FILTER_SRGB_OUT)
+    {
+        if (!(out->flags & CONVF_DEPTH) && ((out->flags & CONVF_FLOAT) || (out->flags & CONVF_UNORM)))
+        {
+            XMVECTOR* ptr = pBuffer;
+            for (size_t i = 0; i < count; ++i, ++ptr)
+            {
+                *ptr = XMColorRGBToSRGB(*ptr);
+            }
+        }
+    }
+}
+
+
+//-------------------------------------------------------------------------------------
+// Dithering
+//-------------------------------------------------------------------------------------
+namespace
+{
+    // 4X4X4 ordered dithering matrix
+    const float g_Dither[] =
+    {
+        // (z & 3) + ( (y & 3) * 8) + (x & 3)
+        0.468750f,  -0.031250f, 0.343750f, -0.156250f, 0.468750f, -0.031250f, 0.343750f, -0.156250f,
+        -0.281250f,  0.218750f, -0.406250f, 0.093750f, -0.281250f, 0.218750f, -0.406250f, 0.093750f,
+        0.281250f,  -0.218750f, 0.406250f, -0.093750f, 0.281250f, -0.218750f, 0.406250f, -0.093750f,
+        -0.468750f,  0.031250f, -0.343750f, 0.156250f, -0.468750f, 0.031250f, -0.343750f, 0.156250f,
+    };
+
+    const XMVECTORF32 g_Scale16pc = { { { 65535.f, 65535.f, 65535.f, 65535.f } } };
+    const XMVECTORF32 g_Scale15pc = { { { 32767.f, 32767.f, 32767.f, 32767.f } } };
+    const XMVECTORF32 g_Scale10pc = { { {  1023.f,  1023.f,  1023.f,     3.f } } };
+    const XMVECTORF32 g_Scale9pc = { { {   511.f,   511.f,   511.f,     3.f } } };
+    const XMVECTORF32 g_Scale8pc = { { {   255.f,   255.f,   255.f,   255.f } } };
+    const XMVECTORF32 g_Scale7pc = { { {   127.f,   127.f,   127.f,   127.f } } };
+    const XMVECTORF32 g_Scale565pc = { { {    31.f,    63.f,    31.f,     1.f } } };
+    const XMVECTORF32 g_Scale5551pc = { { {    31.f,    31.f,    31.f,     1.f } } };
+    const XMVECTORF32 g_Scale4pc = { { {    15.f,    15.f,    15.f,    15.f } } };
+
+    const XMVECTORF32 g_ErrorWeight3 = { { { 3.f / 16.f, 3.f / 16.f, 3.f / 16.f, 3.f / 16.f } } };
+    const XMVECTORF32 g_ErrorWeight5 = { { { 5.f / 16.f, 5.f / 16.f, 5.f / 16.f, 5.f / 16.f } } };
+    const XMVECTORF32 g_ErrorWeight1 = { { { 1.f / 16.f, 1.f / 16.f, 1.f / 16.f, 1.f / 16.f } } };
+    const XMVECTORF32 g_ErrorWeight7 = { { { 7.f / 16.f, 7.f / 16.f, 7.f / 16.f, 7.f / 16.f } } };
+
+#define STORE_SCANLINE( type, scalev, clampzero, norm, itype, mask, row, bgr ) \
+        if (size >= sizeof(type)) \
+        { \
+            type * __restrict dest = reinterpret_cast<type*>(pDestination); \
+            for(size_t i = 0; i < count; ++i) \
+            { \
+                auto index = static_cast<ptrdiff_t>((row & 1) ? (count - i - 1) : i ); \
+                ptrdiff_t delta = (row & 1) ? -2 : 0; \
+                \
+                XMVECTOR v = sPtr[ index ]; \
+                if (bgr) { v = XMVectorSwizzle<2, 1, 0, 3>(v); } \
+                if (norm && clampzero) v = XMVectorSaturate(v) ; \
+                else if (clampzero) v = XMVectorClamp(v, g_XMZero, scalev); \
+                else if (norm) v = XMVectorClamp(v, g_XMNegativeOne, g_XMOne); \
+                else v = XMVectorClamp(v, XMVectorAdd(XMVectorNegate(scalev), g_XMOne), scalev); \
+                v = XMVectorAdd(v, vError); \
+                if (norm) v = XMVectorMultiply(v, scalev); \
+                \
+                XMVECTOR target; \
+                if (pDiffusionErrors) \
+                { \
+                    target = XMVectorRound(v); \
+                    vError = XMVectorSubtract(v, target); \
+                    if (norm) vError = XMVectorDivide(vError, scalev); \
+                    \
+                    /* Distribute error to next scanline and next pixel */ \
+                    pDiffusionErrors[ index-delta ]   = XMVectorMultiplyAdd(g_ErrorWeight3, vError, pDiffusionErrors[ index-delta ]); \
+                    pDiffusionErrors[ index+1 ]       = XMVectorMultiplyAdd(g_ErrorWeight5, vError, pDiffusionErrors[ index+1 ]); \
+                    pDiffusionErrors[ index+2+delta ] = XMVectorMultiplyAdd(g_ErrorWeight1, vError, pDiffusionErrors[ index+2+delta ]); \
+                    vError = XMVectorMultiply(vError, g_ErrorWeight7); \
+                } \
+                else \
+                { \
+                    /* Applied ordered dither */ \
+                    target = XMVectorAdd(v, ordered[ index & 3 ]); \
+                    target = XMVectorRound(target); \
+                } \
+                \
+                target = XMVectorMin(scalev, target); \
+                target = XMVectorMax((clampzero) ? g_XMZero : (XMVectorAdd(XMVectorNegate(scalev), g_XMOne)), target); \
+                \
+                XMFLOAT4A tmp; \
+                XMStoreFloat4A(&tmp, target); \
+                \
+                auto dPtr = &dest[ index ]; \
+                if (dPtr >= ePtr) break; \
+                dPtr->x = itype(static_cast<itype>(tmp.x) & mask); \
+                dPtr->y = itype(static_cast<itype>(tmp.y) & mask); \
+                dPtr->z = itype(static_cast<itype>(tmp.z) & mask); \
+                dPtr->w = itype(static_cast<itype>(tmp.w) & mask); \
+            } \
+            return true; \
+        } \
+        return false;
+
+#define STORE_SCANLINE2( type, scalev, clampzero, norm, itype, mask, row ) \
+        /* The 2 component cases are always bgr=false */ \
+        if (size >= sizeof(type)) \
+        { \
+            type * __restrict dest = reinterpret_cast<type*>(pDestination); \
+            for(size_t i = 0; i < count; ++i) \
+            { \
+                auto index = static_cast<ptrdiff_t>((row & 1) ? (count - i - 1) : i ); \
+                ptrdiff_t delta = (row & 1) ? -2 : 0; \
+                \
+                XMVECTOR v = sPtr[ index ]; \
+                if (norm && clampzero) v = XMVectorSaturate(v) ; \
+                else if (clampzero) v = XMVectorClamp(v, g_XMZero, scalev); \
+                else if (norm) v = XMVectorClamp(v, g_XMNegativeOne, g_XMOne); \
+                else v = XMVectorClamp(v, XMVectorAdd(XMVectorNegate(scalev), g_XMOne), scalev); \
+                v = XMVectorAdd(v, vError); \
+                if (norm) v = XMVectorMultiply(v, scalev); \
+                \
+                XMVECTOR target; \
+                if (pDiffusionErrors) \
+                { \
+                    target = XMVectorRound(v); \
+                    vError = XMVectorSubtract(v, target); \
+                    if (norm) vError = XMVectorDivide(vError, scalev); \
+                    \
+                    /* Distribute error to next scanline and next pixel */ \
+                    pDiffusionErrors[ index-delta ]   = XMVectorMultiplyAdd(g_ErrorWeight3, vError, pDiffusionErrors[ index-delta ]); \
+                    pDiffusionErrors[ index+1 ]       = XMVectorMultiplyAdd(g_ErrorWeight5, vError, pDiffusionErrors[ index+1 ]); \
+                    pDiffusionErrors[ index+2+delta ] = XMVectorMultiplyAdd(g_ErrorWeight1, vError, pDiffusionErrors[ index+2+delta ]); \
+                    vError = XMVectorMultiply(vError, g_ErrorWeight7); \
+                } \
+                else \
+                { \
+                    /* Applied ordered dither */ \
+                    target = XMVectorAdd(v, ordered[ index & 3 ]); \
+                    target = XMVectorRound(target); \
+                } \
+                \
+                target = XMVectorMin(scalev, target); \
+                target = XMVectorMax((clampzero) ? g_XMZero : (XMVectorAdd(XMVectorNegate(scalev), g_XMOne)), target); \
+                \
+                XMFLOAT4A tmp; \
+                XMStoreFloat4A(&tmp, target); \
+                \
+                auto dPtr = &dest[ index ]; \
+                if (dPtr >= ePtr) break; \
+                dPtr->x = itype(static_cast<itype>(tmp.x) & mask); \
+                dPtr->y = itype(static_cast<itype>(tmp.y) & mask); \
+            } \
+            return true; \
+        } \
+        return false;
+
+#define STORE_SCANLINE1( type, scalev, clampzero, norm, mask, row, selectw ) \
+        /* The 1 component cases are always bgr=false */ \
+        if (size >= sizeof(type)) \
+        { \
+            type * __restrict dest = reinterpret_cast<type*>(pDestination); \
+            for(size_t i = 0; i < count; ++i) \
+            { \
+                auto index = static_cast<ptrdiff_t>((row & 1) ? (count - i - 1) : i ); \
+                ptrdiff_t delta = (row & 1) ? -2 : 0; \
+                \
+                XMVECTOR v = sPtr[ index ]; \
+                if (norm && clampzero) v = XMVectorSaturate(v) ; \
+                else if (clampzero) v = XMVectorClamp(v, g_XMZero, scalev); \
+                else if (norm) v = XMVectorClamp(v, g_XMNegativeOne, g_XMOne); \
+                else v = XMVectorClamp(v, XMVectorAdd(XMVectorNegate(scalev), g_XMOne), scalev); \
+                v = XMVectorAdd(v, vError); \
+                if (norm) v = XMVectorMultiply(v, scalev); \
+                \
+                XMVECTOR target; \
+                if (pDiffusionErrors) \
+                { \
+                    target = XMVectorRound(v); \
+                    vError = XMVectorSubtract(v, target); \
+                    if (norm) vError = XMVectorDivide(vError, scalev); \
+                    \
+                    /* Distribute error to next scanline and next pixel */ \
+                    pDiffusionErrors[ index-delta ]   = XMVectorMultiplyAdd(g_ErrorWeight3, vError, pDiffusionErrors[ index-delta ]); \
+                    pDiffusionErrors[ index+1 ]       = XMVectorMultiplyAdd(g_ErrorWeight5, vError, pDiffusionErrors[ index+1 ]); \
+                    pDiffusionErrors[ index+2+delta ] = XMVectorMultiplyAdd(g_ErrorWeight1, vError, pDiffusionErrors[ index+2+delta ]); \
+                    vError = XMVectorMultiply(vError, g_ErrorWeight7); \
+                } \
+                else \
+                { \
+                    /* Applied ordered dither */ \
+                    target = XMVectorAdd(v, ordered[ index & 3 ]); \
+                    target = XMVectorRound(target); \
+                } \
+                \
+                target = XMVectorMin(scalev, target); \
+                target = XMVectorMax((clampzero) ? g_XMZero : (XMVectorAdd(XMVectorNegate(scalev), g_XMOne)), target); \
+                \
+                auto dPtr = &dest[ index ]; \
+                if (dPtr >= ePtr) break; \
+                *dPtr = type(static_cast<type>((selectw) ? XMVectorGetW(target) : XMVectorGetX(target)) & mask); \
+            } \
+            return true; \
+        } \
+        return false;
+}
+
+#pragma warning(push)
+#pragma warning( disable : 4127 )
+
+_Use_decl_annotations_
+bool DirectX::Internal::StoreScanlineDither(
+    void* pDestination,
+    size_t size,
+    DXGI_FORMAT format,
+    XMVECTOR* pSource,
+    size_t count,
+    float threshold,
+    size_t y,
+    size_t z,
+    XMVECTOR* pDiffusionErrors) noexcept
+{
+    assert(pDestination != nullptr);
+    assert(IsValid(format) && !IsTypeless(format) && !IsCompressed(format) && !IsPlanar(format) && !IsPalettized(format));
+
+    if (!size || !count)
+        return false;
+
+    const XMVECTOR* __restrict sPtr = pSource;
+    if (!sPtr)
+        return false;
+
+    assert((reinterpret_cast<uintptr_t>(pSource) & 0xF) == 0);
+
+    XMVECTOR ordered[4];
+    if (pDiffusionErrors)
+    {
+        // If pDiffusionErrors != 0, then this function performs error diffusion dithering (aka Floyd-Steinberg dithering)
+
+        // To avoid the need for another temporary scanline buffer, we allow this function to overwrite the source buffer in-place
+        // Given the intended usage in the conversion routines, this is not a problem.
+
+        XMVECTOR* ptr = pSource;
+        const XMVECTOR* err = pDiffusionErrors + 1;
+        for (size_t i = 0; i < count; ++i)
+        {
+            // Add contribution from previous scanline
+            XMVECTOR v = XMVectorAdd(*ptr, *err++);
+            *ptr++ = v;
+        }
+
+        // Reset errors for next scanline
+        memset(pDiffusionErrors, 0, sizeof(XMVECTOR)*(count + 2));
+    }
+    else
+    {
+        // If pDiffusionErrors == 0, then this function performs ordered dithering
+
+        const XMVECTOR dither = XMLoadFloat4(reinterpret_cast<const XMFLOAT4*>(g_Dither + (z & 3) + ((y & 3) * 8)));
+
+        ordered[0] = XMVectorSplatX(dither);
+        ordered[1] = XMVectorSplatY(dither);
+        ordered[2] = XMVectorSplatZ(dither);
+        ordered[3] = XMVectorSplatW(dither);
+    }
+
+    const void* ePtr = static_cast<const uint8_t*>(pDestination) + size;
+
+#ifdef _PREFAST_
+    *reinterpret_cast<uint8_t*>(pDestination) = 0;
+#endif
+
+    XMVECTOR vError = XMVectorZero();
+
+    switch (static_cast<int>(format))
+    {
+    case DXGI_FORMAT_R16G16B16A16_UNORM:
+        STORE_SCANLINE(XMUSHORTN4, g_Scale16pc, true, true, uint16_t, 0xFFFF, y, false)
+
+    case DXGI_FORMAT_R16G16B16A16_UINT:
+        STORE_SCANLINE(XMUSHORT4, g_Scale16pc, true, false, uint16_t, 0xFFFF, y, false)
+
+    case DXGI_FORMAT_R16G16B16A16_SNORM:
+        STORE_SCANLINE(XMSHORTN4, g_Scale15pc, false, true, int16_t, 0xFFFF, y, false)
+
+    case DXGI_FORMAT_R16G16B16A16_SINT:
+        STORE_SCANLINE(XMSHORT4, g_Scale15pc, false, false, int16_t, 0xFFFF, y, false)
+
+    case DXGI_FORMAT_R10G10B10A2_UNORM:
+        STORE_SCANLINE(XMUDECN4, g_Scale10pc, true, true, uint16_t, 0x3FF, y, false)
+
+    case DXGI_FORMAT_R10G10B10A2_UINT:
+        STORE_SCANLINE(XMUDEC4, g_Scale10pc, true, false, uint16_t, 0x3FF, y, false)
+
+    case DXGI_FORMAT_R10G10B10_XR_BIAS_A2_UNORM:
+        if (size >= sizeof(XMUDEC4))
+        {
+            static const XMVECTORF32  Scale = { { { 510.0f, 510.0f, 510.0f, 3.0f } } };
+            static const XMVECTORF32  Bias = { { { 384.0f, 384.0f, 384.0f, 0.0f } } };
+            static const XMVECTORF32  MinXR = { { { -0.7529f, -0.7529f, -0.7529f, 0.f } } };
+            static const XMVECTORF32  MaxXR = { { { 1.2529f, 1.2529f, 1.2529f, 1.0f } } };
+
+            XMUDEC4 * __restrict dest = static_cast<XMUDEC4*>(pDestination);
+            for (size_t i = 0; i < count; ++i)
+            {
+                auto index = static_cast<ptrdiff_t>((y & 1) ? (count - i - 1) : i);
+                ptrdiff_t delta = (y & 1) ? -2 : 0;
+
+                XMVECTOR v = XMVectorClamp(sPtr[index], MinXR, MaxXR);
+                v = XMVectorMultiplyAdd(v, Scale, vError);
+
+                XMVECTOR target;
+                if (pDiffusionErrors)
+                {
+                    target = XMVectorRound(v);
+                    vError = XMVectorSubtract(v, target);
+                    vError = XMVectorDivide(vError, Scale);
+
+                    // Distribute error to next scanline and next pixel
+                    pDiffusionErrors[index - delta] = XMVectorMultiplyAdd(g_ErrorWeight3, vError, pDiffusionErrors[index - delta]);
+                    pDiffusionErrors[index + 1] = XMVectorMultiplyAdd(g_ErrorWeight5, vError, pDiffusionErrors[index + 1]);
+                    pDiffusionErrors[index + 2 + delta] = XMVectorMultiplyAdd(g_ErrorWeight1, vError, pDiffusionErrors[index + 2 + delta]);
+                    vError = XMVectorMultiply(vError, g_ErrorWeight7);
+                }
+                else
+                {
+                    // Applied ordered dither
+                    target = XMVectorAdd(v, ordered[index & 3]);
+                    target = XMVectorRound(target);
+                }
+
+                target = XMVectorAdd(target, Bias);
+                target = XMVectorClamp(target, g_XMZero, g_Scale10pc);
+
+                XMFLOAT4A tmp;
+                XMStoreFloat4A(&tmp, target);
+
+                auto dPtr = &dest[index];
+                if (dPtr >= ePtr) break;
+                dPtr->x = uint16_t(static_cast<uint16_t>(tmp.x) & 0x3FF);
+                dPtr->y = uint16_t(static_cast<uint16_t>(tmp.y) & 0x3FF);
+                dPtr->z = uint16_t(static_cast<uint16_t>(tmp.z) & 0x3FF);
+                dPtr->w = static_cast<uint16_t>(tmp.w);
+            }
+            return true;
+        }
+        return false;
+
+    case DXGI_FORMAT_R8G8B8A8_UNORM:
+    case DXGI_FORMAT_R8G8B8A8_UNORM_SRGB:
+        STORE_SCANLINE(XMUBYTEN4, g_Scale8pc, true, true, uint8_t, 0xFF, y, false)
+
+    case DXGI_FORMAT_R8G8B8A8_UINT:
+        STORE_SCANLINE(XMUBYTE4, g_Scale8pc, true, false, uint8_t, 0xFF, y, false)
+
+    case DXGI_FORMAT_R8G8B8A8_SNORM:
+        STORE_SCANLINE(XMBYTEN4, g_Scale7pc, false, true, int8_t, 0xFF, y, false)
+
+    case DXGI_FORMAT_R8G8B8A8_SINT:
+        STORE_SCANLINE(XMBYTE4, g_Scale7pc, false, false, int8_t, 0xFF, y, false)
+
+    case DXGI_FORMAT_R16G16_UNORM:
+        STORE_SCANLINE2(XMUSHORTN2, g_Scale16pc, true, true, uint16_t, 0xFFFF, y)
+
+    case DXGI_FORMAT_R16G16_UINT:
+        STORE_SCANLINE2(XMUSHORT2, g_Scale16pc, true, false, uint16_t, 0xFFFF, y)
+
+    case DXGI_FORMAT_R16G16_SNORM:
+        STORE_SCANLINE2(XMSHORTN2, g_Scale15pc, false, true, int16_t, 0xFFFF, y)
+
+    case DXGI_FORMAT_R16G16_SINT:
+        STORE_SCANLINE2(XMSHORT2, g_Scale15pc, false, false, int16_t, 0xFFFF, y)
+
+    case DXGI_FORMAT_D24_UNORM_S8_UINT:
+        if (size >= sizeof(uint32_t))
+        {
+            static const XMVECTORF32 Clamp = { { { 1.f,  255.f, 0.f, 0.f } } };
+            static const XMVECTORF32 Scale = { { { 16777215.f,   1.f, 0.f, 0.f } } };
+            static const XMVECTORF32 Scale2 = { { { 16777215.f, 255.f, 0.f, 0.f } } };
+
+            uint32_t * __restrict dest = static_cast<uint32_t*>(pDestination);
+            for (size_t i = 0; i < count; ++i)
+            {
+                auto index = static_cast<ptrdiff_t>((y & 1) ? (count - i - 1) : i);
+                ptrdiff_t delta = (y & 1) ? -2 : 0;
+
+                XMVECTOR v = XMVectorClamp(sPtr[index], g_XMZero, Clamp);
+                v = XMVectorAdd(v, vError);
+                v = XMVectorMultiply(v, Scale);
+
+                XMVECTOR target;
+                if (pDiffusionErrors)
+                {
+                    target = XMVectorRound(v);
+                    vError = XMVectorSubtract(v, target);
+                    vError = XMVectorDivide(vError, Scale);
+
+                    // Distribute error to next scanline and next pixel
+                    pDiffusionErrors[index - delta] = XMVectorMultiplyAdd(g_ErrorWeight3, vError, pDiffusionErrors[index - delta]);
+                    pDiffusionErrors[index + 1] = XMVectorMultiplyAdd(g_ErrorWeight5, vError, pDiffusionErrors[index + 1]);
+                    pDiffusionErrors[index + 2 + delta] = XMVectorMultiplyAdd(g_ErrorWeight1, vError, pDiffusionErrors[index + 2 + delta]);
+                    vError = XMVectorMultiply(vError, g_ErrorWeight7);
+                }
+                else
+                {
+                    // Applied ordered dither
+                    target = XMVectorAdd(v, ordered[index & 3]);
+                    target = XMVectorRound(target);
+                }
+
+                target = XMVectorClamp(target, g_XMZero, Scale2);
+
+                XMFLOAT4A tmp;
+                XMStoreFloat4A(&tmp, target);
+
+                auto dPtr = &dest[index];
+                if (dPtr >= ePtr) break;
+                *dPtr = (static_cast<uint32_t>(tmp.x) & 0xFFFFFF)
+                    | ((static_cast<uint32_t>(tmp.y) & 0xFF) << 24);
+            }
+            return true;
+        }
+        return false;
+
+    case DXGI_FORMAT_R8G8_UNORM:
+        STORE_SCANLINE2(XMUBYTEN2, g_Scale8pc, true, true, uint8_t, 0xFF, y)
+
+    case DXGI_FORMAT_R8G8_UINT:
+        STORE_SCANLINE2(XMUBYTE2, g_Scale8pc, true, false, uint8_t, 0xFF, y)
+
+    case DXGI_FORMAT_R8G8_SNORM:
+        STORE_SCANLINE2(XMBYTEN2, g_Scale7pc, false, true, int8_t, 0xFF, y)
+
+    case DXGI_FORMAT_R8G8_SINT:
+        STORE_SCANLINE2(XMBYTE2, g_Scale7pc, false, false, int8_t, 0xFF, y)
+
+    case DXGI_FORMAT_D16_UNORM:
+    case DXGI_FORMAT_R16_UNORM:
+        STORE_SCANLINE1(uint16_t, g_Scale16pc, true, true, 0xFFFF, y, false)
+
+    case DXGI_FORMAT_R16_UINT:
+        STORE_SCANLINE1(uint16_t, g_Scale16pc, true, false, 0xFFFF, y, false)
+
+    case DXGI_FORMAT_R16_SNORM:
+        STORE_SCANLINE1(int16_t, g_Scale15pc, false, true, 0xFFFF, y, false)
+
+    case DXGI_FORMAT_R16_SINT:
+        STORE_SCANLINE1(int16_t, g_Scale15pc, false, false, 0xFFFF, y, false)
+
+    case DXGI_FORMAT_R8_UNORM:
+        STORE_SCANLINE1(uint8_t, g_Scale8pc, true, true, 0xFF, y, false)
+
+    case DXGI_FORMAT_R8_UINT:
+        STORE_SCANLINE1(uint8_t, g_Scale8pc, true, false, 0xFF, y, false)
+
+    case DXGI_FORMAT_R8_SNORM:
+        STORE_SCANLINE1(int8_t, g_Scale7pc, false, true, 0xFF, y, false)
+
+    case DXGI_FORMAT_R8_SINT:
+        STORE_SCANLINE1(int8_t, g_Scale7pc, false, false, 0xFF, y, false)
+
+    case DXGI_FORMAT_A8_UNORM:
+        STORE_SCANLINE1(uint8_t, g_Scale8pc, true, true, 0xFF, y, true)
+
+    case DXGI_FORMAT_B5G6R5_UNORM:
+        if (size >= sizeof(XMU565))
+        {
+            XMU565 * __restrict dest = static_cast<XMU565*>(pDestination);
+            for (size_t i = 0; i < count; ++i)
+            {
+                auto index = static_cast<ptrdiff_t>((y & 1) ? (count - i - 1) : i);
+                ptrdiff_t delta = (y & 1) ? -2 : 0;
+
+                XMVECTOR v = XMVectorSwizzle<2, 1, 0, 3>(sPtr[index]);
+                v = XMVectorSaturate(v);
+                v = XMVectorAdd(v, vError);
+                v = XMVectorMultiply(v, g_Scale565pc);
+
+                XMVECTOR target;
+                if (pDiffusionErrors)
+                {
+                    target = XMVectorRound(v);
+                    vError = XMVectorSubtract(v, target);
+                    vError = XMVectorDivide(vError, g_Scale565pc);
+
+                    // Distribute error to next scanline and next pixel
+                    pDiffusionErrors[index - delta] = XMVectorMultiplyAdd(g_ErrorWeight3, vError, pDiffusionErrors[index - delta]);
+                    pDiffusionErrors[index + 1] = XMVectorMultiplyAdd(g_ErrorWeight5, vError, pDiffusionErrors[index + 1]);
+                    pDiffusionErrors[index + 2 + delta] = XMVectorMultiplyAdd(g_ErrorWeight1, vError, pDiffusionErrors[index + 2 + delta]);
+                    vError = XMVectorMultiply(vError, g_ErrorWeight7);
+                }
+                else
+                {
+                    // Applied ordered dither
+                    target = XMVectorAdd(v, ordered[index & 3]);
+                    target = XMVectorRound(target);
+                }
+
+                target = XMVectorClamp(target, g_XMZero, g_Scale565pc);
+
+                XMFLOAT4A tmp;
+                XMStoreFloat4A(&tmp, target);
+
+                auto dPtr = &dest[index];
+                if (dPtr >= ePtr) break;
+                dPtr->x = uint16_t(static_cast<uint16_t>(tmp.x) & 0x1F);
+                dPtr->y = uint16_t(static_cast<uint16_t>(tmp.y) & 0x3F);
+                dPtr->z = uint16_t(static_cast<uint16_t>(tmp.z) & 0x1F);
+            }
+            return true;
+        }
+        return false;
+
+    case DXGI_FORMAT_B5G5R5A1_UNORM:
+        if (size >= sizeof(XMU555))
+        {
+            XMU555 * __restrict dest = static_cast<XMU555*>(pDestination);
+            for (size_t i = 0; i < count; ++i)
+            {
+                auto index = static_cast<ptrdiff_t>((y & 1) ? (count - i - 1) : i);
+                ptrdiff_t delta = (y & 1) ? -2 : 0;
+
+                XMVECTOR v = XMVectorSwizzle<2, 1, 0, 3>(sPtr[index]);
+                v = XMVectorSaturate(v);
+                v = XMVectorAdd(v, vError);
+                v = XMVectorMultiply(v, g_Scale5551pc);
+
+                XMVECTOR target;
+                if (pDiffusionErrors)
+                {
+                    target = XMVectorRound(v);
+                    vError = XMVectorSubtract(v, target);
+                    vError = XMVectorDivide(vError, g_Scale5551pc);
+
+                    // Distribute error to next scanline and next pixel
+                    pDiffusionErrors[index - delta] = XMVectorMultiplyAdd(g_ErrorWeight3, vError, pDiffusionErrors[index - delta]);
+                    pDiffusionErrors[index + 1] = XMVectorMultiplyAdd(g_ErrorWeight5, vError, pDiffusionErrors[index + 1]);
+                    pDiffusionErrors[index + 2 + delta] = XMVectorMultiplyAdd(g_ErrorWeight1, vError, pDiffusionErrors[index + 2 + delta]);
+                    vError = XMVectorMultiply(vError, g_ErrorWeight7);
+                }
+                else
+                {
+                    // Applied ordered dither
+                    target = XMVectorAdd(v, ordered[index & 3]);
+                    target = XMVectorRound(target);
+                }
+
+                target = XMVectorClamp(target, g_XMZero, g_Scale5551pc);
+
+                XMFLOAT4A tmp;
+                XMStoreFloat4A(&tmp, target);
+
+                auto dPtr = &dest[index];
+                if (dPtr >= ePtr) break;
+                dPtr->x = uint16_t(static_cast<uint16_t>(tmp.x) & 0x1F);
+                dPtr->y = uint16_t(static_cast<uint16_t>(tmp.y) & 0x1F);
+                dPtr->z = uint16_t(static_cast<uint16_t>(tmp.z) & 0x1F);
+                dPtr->w = (XMVectorGetW(target) > threshold) ? 1u : 0u;
+            }
+            return true;
+        }
+        return false;
+
+    case DXGI_FORMAT_B8G8R8A8_UNORM:
+    case DXGI_FORMAT_B8G8R8A8_UNORM_SRGB:
+        STORE_SCANLINE(XMUBYTEN4, g_Scale8pc, true, true, uint8_t, 0xFF, y, true)
+
+    case DXGI_FORMAT_B8G8R8X8_UNORM:
+    case DXGI_FORMAT_B8G8R8X8_UNORM_SRGB:
+        if (size >= sizeof(XMUBYTEN4))
+        {
+            XMUBYTEN4 * __restrict dest = static_cast<XMUBYTEN4*>(pDestination);
+            for (size_t i = 0; i < count; ++i)
+            {
+                auto index = static_cast<ptrdiff_t>((y & 1) ? (count - i - 1) : i);
+                ptrdiff_t delta = (y & 1) ? -2 : 0;
+
+                XMVECTOR v = XMVectorSwizzle<2, 1, 0, 3>(sPtr[index]);
+                v = XMVectorSaturate(v);
+                v = XMVectorAdd(v, vError);
+                v = XMVectorMultiply(v, g_Scale8pc);
+
+                XMVECTOR target;
+                if (pDiffusionErrors)
+                {
+                    target = XMVectorRound(v);
+                    vError = XMVectorSubtract(v, target);
+                    vError = XMVectorDivide(vError, g_Scale8pc);
+
+                    // Distribute error to next scanline and next pixel
+                    pDiffusionErrors[index - delta] = XMVectorMultiplyAdd(g_ErrorWeight3, vError, pDiffusionErrors[index - delta]);
+                    pDiffusionErrors[index + 1] = XMVectorMultiplyAdd(g_ErrorWeight5, vError, pDiffusionErrors[index + 1]);
+                    pDiffusionErrors[index + 2 + delta] = XMVectorMultiplyAdd(g_ErrorWeight1, vError, pDiffusionErrors[index + 2 + delta]);
+                    vError = XMVectorMultiply(vError, g_ErrorWeight7);
+                }
+                else
+                {
+                    // Applied ordered dither
+                    target = XMVectorAdd(v, ordered[index & 3]);
+                    target = XMVectorRound(target);
+                }
+
+                target = XMVectorClamp(target, g_XMZero, g_Scale8pc);
+
+                XMFLOAT4A tmp;
+                XMStoreFloat4A(&tmp, target);
+
+                auto dPtr = &dest[index];
+                if (dPtr >= ePtr) break;
+                dPtr->x = uint8_t(static_cast<uint8_t>(tmp.x) & 0xFF);
+                dPtr->y = uint8_t(static_cast<uint8_t>(tmp.y) & 0xFF);
+                dPtr->z = uint8_t(static_cast<uint8_t>(tmp.z) & 0xFF);
+                dPtr->w = 0;
+            }
+            return true;
+        }
+        return false;
+
+    case DXGI_FORMAT_B4G4R4A4_UNORM:
+        STORE_SCANLINE(XMUNIBBLE4, g_Scale4pc, true, true, uint8_t, 0xF, y, true)
+
+    case WIN11_DXGI_FORMAT_A4B4G4R4_UNORM:
+        if (size >= sizeof(XMUNIBBLE4))
+        {
+            XMUNIBBLE4 * __restrict dest = static_cast<XMUNIBBLE4*>(pDestination);
+            for (size_t i = 0; i < count; ++i)
+            {
+                auto index = static_cast<ptrdiff_t>((y & 1) ? (count - i - 1) : i);
+                ptrdiff_t delta = (y & 1) ? -2 : 0;
+
+                XMVECTOR v = XMVectorSaturate(sPtr[index]);
+                v = XMVectorSwizzle<3, 2, 1, 0>(v);
+                v = XMVectorAdd(v, vError);
+                v = XMVectorMultiply(v, g_Scale4pc);
+
+                XMVECTOR target;
+                if (pDiffusionErrors)
+                {
+                    target = XMVectorRound(v);
+                    vError = XMVectorSubtract(v, target);
+                    vError = XMVectorDivide(vError, g_Scale4pc);
+
+                    // Distribute error to next scanline and next pixel
+                    pDiffusionErrors[index - delta] = XMVectorMultiplyAdd(g_ErrorWeight3, vError, pDiffusionErrors[index - delta]);
+                    pDiffusionErrors[index + 1] = XMVectorMultiplyAdd(g_ErrorWeight5, vError, pDiffusionErrors[index + 1]);
+                    pDiffusionErrors[index + 2 + delta] = XMVectorMultiplyAdd(g_ErrorWeight1, vError, pDiffusionErrors[index + 2 + delta]);
+                    vError = XMVectorMultiply(vError, g_ErrorWeight7);
+                }
+                else
+                {
+                    // Applied ordered dither
+                    target = XMVectorAdd(v, ordered[index & 3]);
+                    target = XMVectorRound(target);
+                }
+
+                target = XMVectorClamp(target, g_XMZero, g_Scale4pc);
+
+                XMFLOAT4A tmp;
+                XMStoreFloat4A(&tmp, target);
+
+                auto dPtr = &dest[index];
+                if (dPtr >= ePtr) break;
+                dPtr->x = uint8_t(static_cast<uint8_t>(tmp.x) & 0xF);
+                dPtr->y = uint8_t(static_cast<uint8_t>(tmp.y) & 0xF);
+                dPtr->z = uint8_t(static_cast<uint8_t>(tmp.z) & 0xF);
+                dPtr->w = uint8_t(static_cast<uint8_t>(tmp.w) & 0xF);
+            }
+            return true;
+        }
+        return false;
+
+    case XBOX_DXGI_FORMAT_R10G10B10_SNORM_A2_UNORM:
+        STORE_SCANLINE(XMXDECN4, g_Scale9pc, false, true, uint16_t, 0x3FF, y, false)
+
+    case XBOX_DXGI_FORMAT_R4G4_UNORM:
+        if (size >= sizeof(uint8_t))
+        {
+            uint8_t * __restrict dest = static_cast<uint8_t*>(pDestination);
+            for (size_t i = 0; i < count; ++i)
+            {
+                auto index = static_cast<ptrdiff_t>((y & 1) ? (count - i - 1) : i);
+                ptrdiff_t delta = (y & 1) ? -2 : 0;
+
+                XMVECTOR v = XMVectorSaturate(sPtr[index]);
+                v = XMVectorAdd(v, vError);
+                v = XMVectorMultiply(v, g_Scale4pc);
+
+                XMVECTOR target;
+                if (pDiffusionErrors)
+                {
+                    target = XMVectorRound(v);
+                    vError = XMVectorSubtract(v, target);
+                    vError = XMVectorDivide(vError, g_Scale4pc);
+
+                    // Distribute error to next scanline and next pixel
+                    pDiffusionErrors[index - delta] = XMVectorMultiplyAdd(g_ErrorWeight3, vError, pDiffusionErrors[index - delta]);
+                    pDiffusionErrors[index + 1] = XMVectorMultiplyAdd(g_ErrorWeight5, vError, pDiffusionErrors[index + 1]);
+                    pDiffusionErrors[index + 2 + delta] = XMVectorMultiplyAdd(g_ErrorWeight1, vError, pDiffusionErrors[index + 2 + delta]);
+                    vError = XMVectorMultiply(vError, g_ErrorWeight7);
+                }
+                else
+                {
+                    // Applied ordered dither
+                    target = XMVectorAdd(v, ordered[index & 3]);
+                    target = XMVectorRound(target);
+                }
+
+                target = XMVectorClamp(target, g_XMZero, g_Scale4pc);
+
+                XMFLOAT4A tmp;
+                XMStoreFloat4A(&tmp, target);
+
+                auto dPtr = &dest[index];
+                if (dPtr >= ePtr) break;
+                *dPtr = static_cast<uint8_t>((unsigned(tmp.x) & 0xF) | ((unsigned(tmp.y) & 0xF) << 4));
+            }
+            return true;
+        }
+        return false;
+
+    default:
+        return StoreScanline(pDestination, size, format, pSource, count, threshold);
+    }
+}
+
+#pragma warning(pop)
+
+#undef STORE_SCANLINE
+#undef STORE_SCANLINE2
+#undef STORE_SCANLINE1
+
+namespace
+{
+    //-------------------------------------------------------------------------------------
+    // Selection logic for using WIC vs. our own routines
+    //-------------------------------------------------------------------------------------
+    inline bool UseWICConversion(
+        _In_ TEX_FILTER_FLAGS filter,
+        _In_ DXGI_FORMAT sformat,
+        _In_ DXGI_FORMAT tformat,
+        _Out_ WICPixelFormatGUID& pfGUID,
+        _Out_ WICPixelFormatGUID& targetGUID) noexcept
+    {
+    #ifndef _WIN32
+        UNREFERENCED_PARAMETER(filter);
+        UNREFERENCED_PARAMETER(sformat);
+        UNREFERENCED_PARAMETER(tformat);
+        UNREFERENCED_PARAMETER(pfGUID);
+        UNREFERENCED_PARAMETER(targetGUID);
+        return false;
+    #else
+        memset(&pfGUID, 0, sizeof(GUID));
+        memset(&targetGUID, 0, sizeof(GUID));
+
+        if (filter & TEX_FILTER_FORCE_NON_WIC)
+        {
+            // Explicit flag indicates use of non-WIC code paths
+            return false;
+        }
+
+        if (!DXGIToWIC(sformat, pfGUID) || !DXGIToWIC(tformat, targetGUID))
+        {
+            // Source or target format are not WIC supported native pixel formats
+            return false;
+        }
+
+        if (filter & TEX_FILTER_FORCE_WIC)
+        {
+            // Explicit flag to use WIC code paths, skips all the case checks below
+            return true;
+        }
+
+        if (filter & TEX_FILTER_SEPARATE_ALPHA)
+        {
+            // Alpha is not premultiplied, so use non-WIC code paths
+            return false;
+        }
+
+        if (filter & TEX_FILTER_FLOAT_X2BIAS)
+        {
+            // X2 Scale & Bias conversions not supported by WIC code paths
+            return false;
+        }
+
+        // Check for special cases
+    #if (defined(_XBOX_ONE) && defined(_TITLE)) || defined(_GAMING_XBOX)
+        if (sformat == DXGI_FORMAT_R16G16B16A16_FLOAT
+            || sformat == DXGI_FORMAT_R16_FLOAT
+            || tformat == DXGI_FORMAT_R16G16B16A16_FLOAT
+            || tformat == DXGI_FORMAT_R16_FLOAT)
+        {
+            // Use non-WIC code paths as these conversions are not supported by Xbox version of WIC
+            return false;
+        }
+    #endif
+
+        switch (sformat)
+        {
+        case DXGI_FORMAT_R32G32B32A32_FLOAT:
+        case DXGI_FORMAT_R32G32B32_FLOAT:
+        case DXGI_FORMAT_R32G32_FLOAT:
+        case DXGI_FORMAT_R32_FLOAT:
+        case DXGI_FORMAT_D32_FLOAT:
+            switch (tformat)
+            {
+            case DXGI_FORMAT_R16G16B16A16_FLOAT:
+            case DXGI_FORMAT_R16G16_FLOAT:
+            case DXGI_FORMAT_R16_FLOAT:
+                // WIC conversions for FP32->FP16 can result in NaN values instead of clamping for min/max value
+                return false;
+
+            default:
+                break;
+            }
+            break;
+
+        default:
+            break;
+        }
+
+        switch (sformat)
+        {
+        case DXGI_FORMAT_R32G32B32A32_FLOAT:
+        case DXGI_FORMAT_R32G32B32_FLOAT:
+        case DXGI_FORMAT_R16G16B16A16_FLOAT:
+            switch (tformat)
+            {
+            case DXGI_FORMAT_R16_FLOAT:
+            case DXGI_FORMAT_R32_FLOAT:
+            case DXGI_FORMAT_D32_FLOAT:
+                // WIC converts via UNORM formats and ends up converting colorspaces for these cases
+            case DXGI_FORMAT_A8_UNORM:
+                // Conversion logic for these kinds of textures is unintuitive for WIC code paths
+                return false;
+
+            default:
+                break;
+            }
+            break;
+
+        case DXGI_FORMAT_R16_FLOAT:
+            switch (tformat)
+            {
+            case DXGI_FORMAT_R32_FLOAT:
+            case DXGI_FORMAT_D32_FLOAT:
+                // WIC converts via UNORM formats and ends up converting colorspaces for these cases
+            case DXGI_FORMAT_A8_UNORM:
+                // Conversion logic for these kinds of textures is unintuitive for WIC code paths
+                return false;
+
+            default:
+                break;
+            }
+            break;
+
+        case DXGI_FORMAT_A8_UNORM:
+            // Conversion logic for these kinds of textures is unintuitive for WIC code paths
+            return false;
+
+        default:
+            switch (tformat)
+            {
+            case DXGI_FORMAT_A8_UNORM:
+                // Conversion logic for these kinds of textures is unintuitive for WIC code paths
+                return false;
+
+            default:
+                break;
+            }
+        }
+
+        // Check for implicit color space changes
+        if (IsSRGB(sformat))
+            filter |= TEX_FILTER_SRGB_IN;
+
+        if (IsSRGB(tformat))
+            filter |= TEX_FILTER_SRGB_OUT;
+
+        if ((filter & (TEX_FILTER_SRGB_IN | TEX_FILTER_SRGB_OUT)) == (TEX_FILTER_SRGB_IN | TEX_FILTER_SRGB_OUT))
+        {
+            filter &= ~(TEX_FILTER_SRGB_IN | TEX_FILTER_SRGB_OUT);
+        }
+
+        auto const wicsrgb = CheckWICColorSpace(pfGUID, targetGUID);
+
+        if (wicsrgb != (filter & (TEX_FILTER_SRGB_IN | TEX_FILTER_SRGB_OUT)))
+        {
+            // WIC will perform a colorspace conversion we didn't request
+            return false;
+        }
+
+        return true;
+    #endif // WIN32
+    }
+
+    //-------------------------------------------------------------------------------------
+    // Convert the source image using WIC
+    //-------------------------------------------------------------------------------------
+    HRESULT ConvertUsingWIC(
+        _In_ const Image& srcImage,
+        _In_ const WICPixelFormatGUID& pfGUID,
+        _In_ const WICPixelFormatGUID& targetGUID,
+        _In_ TEX_FILTER_FLAGS filter,
+        _In_ float threshold,
+        _In_ const Image& destImage)
+    {
+    #ifndef _WIN32
+        UNREFERENCED_PARAMETER(srcImage);
+        UNREFERENCED_PARAMETER(pfGUID);
+        UNREFERENCED_PARAMETER(targetGUID);
+        UNREFERENCED_PARAMETER(filter);
+        UNREFERENCED_PARAMETER(threshold);
+        UNREFERENCED_PARAMETER(destImage);
+        return E_NOTIMPL;
+    #else
+        assert(srcImage.width == destImage.width);
+        assert(srcImage.height == destImage.height);
+
+        bool iswic2 = false;
+        auto pWIC = GetWICFactory(iswic2);
+        if (!pWIC)
+            return E_NOINTERFACE;
+
+        ComPtr<IWICFormatConverter> FC;
+        HRESULT hr = pWIC->CreateFormatConverter(FC.GetAddressOf());
+        if (FAILED(hr))
+            return hr;
+
+        // Note that WIC conversion ignores the TEX_FILTER_SRGB_IN and TEX_FILTER_SRGB_OUT flags,
+        // but also always assumes UNORM <-> FLOAT conversions are changing color spaces sRGB <-> scRGB
+
+        BOOL canConvert = FALSE;
+        hr = FC->CanConvert(pfGUID, targetGUID, &canConvert);
+        if (FAILED(hr) || !canConvert)
+        {
+            // This case is not an issue for the subset of WIC formats that map directly to DXGI
+            return E_UNEXPECTED;
+        }
+
+        if (srcImage.rowPitch > UINT32_MAX || srcImage.slicePitch > UINT32_MAX
+            || destImage.rowPitch > UINT32_MAX || destImage.slicePitch > UINT32_MAX)
+            return HRESULT_E_ARITHMETIC_OVERFLOW;
+
+        ComPtr<IWICBitmap> source;
+        hr = pWIC->CreateBitmapFromMemory(static_cast<UINT>(srcImage.width), static_cast<UINT>(srcImage.height), pfGUID,
+            static_cast<UINT>(srcImage.rowPitch), static_cast<UINT>(srcImage.slicePitch),
+            srcImage.pixels, source.GetAddressOf());
+        if (FAILED(hr))
+            return hr;
+
+        hr = FC->Initialize(source.Get(), targetGUID, GetWICDither(filter), nullptr,
+            static_cast<double>(threshold) * 100.0, WICBitmapPaletteTypeMedianCut);
+        if (FAILED(hr))
+            return hr;
+
+        hr = FC->CopyPixels(nullptr, static_cast<UINT>(destImage.rowPitch), static_cast<UINT>(destImage.slicePitch), destImage.pixels);
+        if (FAILED(hr))
+            return hr;
+
+        return S_OK;
+    #endif // WIN32
+    }
+
+    //-------------------------------------------------------------------------------------
+    // Convert the source image (not using WIC)
+    //-------------------------------------------------------------------------------------
+    HRESULT ConvertCustom(
+        _In_ const Image& srcImage,
+        _In_ TEX_FILTER_FLAGS filter,
+        _In_ const Image& destImage,
+        _In_ float threshold,
+        size_t z,
+        const std::function<bool __cdecl(size_t, size_t)>& statusCallback) noexcept
+    {
+        assert(srcImage.width == destImage.width);
+        assert(srcImage.height == destImage.height);
+
+        const uint8_t *pSrc = srcImage.pixels;
+        uint8_t *pDest = destImage.pixels;
+        if (!pSrc || !pDest)
+            return E_POINTER;
+
+        size_t width = srcImage.width;
+
+        if (filter & TEX_FILTER_DITHER_DIFFUSION)
+        {
+            // Error diffusion dithering (aka Floyd-Steinberg dithering)
+            auto scanline = make_AlignedArrayXMVECTOR(uint64_t(width) * 2 + 2);
+            if (!scanline)
+                return E_OUTOFMEMORY;
+
+            XMVECTOR* pDiffusionErrors = scanline.get() + width;
+            memset(pDiffusionErrors, 0, sizeof(XMVECTOR)*(width + 2));
+
+            for (size_t h = 0; h < srcImage.height; ++h)
+            {
+                if (statusCallback)
+                {
+                    if (!statusCallback(h, srcImage.height))
+                    {
+                       return E_ABORT;
+                    }
+                }
+
+                if (!LoadScanline(scanline.get(), width, pSrc, srcImage.rowPitch, srcImage.format))
+                    return E_FAIL;
+
+                ConvertScanline(scanline.get(), width, destImage.format, srcImage.format, filter);
+
+                if (!StoreScanlineDither(pDest, destImage.rowPitch, destImage.format, scanline.get(), width, threshold, h, z, pDiffusionErrors))
+                    return E_FAIL;
+
+                pSrc += srcImage.rowPitch;
+                pDest += destImage.rowPitch;
+            }
+        }
+        else
+        {
+            auto scanline = make_AlignedArrayXMVECTOR(width);
+            if (!scanline)
+                return E_OUTOFMEMORY;
+
+            if (filter & TEX_FILTER_DITHER)
+            {
+                // Ordered dithering
+                for (size_t h = 0; h < srcImage.height; ++h)
+                {
+                    if (statusCallback)
+                    {
+                        if (!statusCallback(h, srcImage.height))
+                        {
+                            return E_ABORT;
+                        }
+                    }
+
+                    if (!LoadScanline(scanline.get(), width, pSrc, srcImage.rowPitch, srcImage.format))
+                        return E_FAIL;
+
+                    ConvertScanline(scanline.get(), width, destImage.format, srcImage.format, filter);
+
+                    if (!StoreScanlineDither(pDest, destImage.rowPitch, destImage.format, scanline.get(), width, threshold, h, z, nullptr))
+                        return E_FAIL;
+
+                    pSrc += srcImage.rowPitch;
+                    pDest += destImage.rowPitch;
+                }
+            }
+            else
+            {
+                // No dithering
+                for (size_t h = 0; h < srcImage.height; ++h)
+                {
+                    if (statusCallback)
+                    {
+                        if (!statusCallback(h, srcImage.height))
+                        {
+                            return E_ABORT;
+                        }
+                    }
+
+                    if (!LoadScanline(scanline.get(), width, pSrc, srcImage.rowPitch, srcImage.format))
+                        return E_FAIL;
+
+                    ConvertScanline(scanline.get(), width, destImage.format, srcImage.format, filter);
+
+                    if (!StoreScanline(pDest, destImage.rowPitch, destImage.format, scanline.get(), width, threshold))
+                        return E_FAIL;
+
+                    pSrc += srcImage.rowPitch;
+                    pDest += destImage.rowPitch;
+                }
+            }
+        }
+
+        return S_OK;
+    }
+
+    //-------------------------------------------------------------------------------------
+    DXGI_FORMAT PlanarToSingle(_In_ DXGI_FORMAT format) noexcept
+    {
+        switch (format)
+        {
+        case DXGI_FORMAT_NV12:
+        case DXGI_FORMAT_NV11:
+            return DXGI_FORMAT_YUY2;
+
+        case DXGI_FORMAT_P010:
+            return DXGI_FORMAT_Y210;
+
+        case DXGI_FORMAT_P016:
+            return DXGI_FORMAT_Y216;
+
+            // We currently do not support conversion for Xbox One specific 16-bit depth formats
+
+            // We can't do anything with DXGI_FORMAT_420_OPAQUE because it's an opaque blob of bits
+
+            // We don't support conversion of JPEG Hardware decode formats
+
+        default:
+            return DXGI_FORMAT_UNKNOWN;
+        }
+    }
+
+    //-------------------------------------------------------------------------------------
+    // Convert the image from a planar to non-planar image
+    //-------------------------------------------------------------------------------------
+#define CONVERT_420_TO_422( srcType, destType )\
+        {\
+            const size_t rowPitch = srcImage.rowPitch;\
+            \
+            auto const sourceE = reinterpret_cast<const srcType*>(pSrc + srcImage.slicePitch);\
+            auto pSrcUV = pSrc + (srcImage.height * rowPitch);\
+            \
+            for(size_t y = 0; y < srcImage.height; y+= 2)\
+            {\
+                auto sPtrY0 = reinterpret_cast<const srcType*>(pSrc);\
+                auto sPtrY2 = reinterpret_cast<const srcType*>(pSrc + rowPitch);\
+                auto sPtrUV = reinterpret_cast<const srcType*>(pSrcUV);\
+                \
+                destType * __restrict dPtr0 = reinterpret_cast<destType*>(pDest);\
+                destType * __restrict dPtr1 = reinterpret_cast<destType*>(pDest + destImage.rowPitch);\
+                \
+                for(size_t x = 0; x < srcImage.width; x+= 2)\
+                {\
+                    if ((sPtrUV+1) >= sourceE) break;\
+                    \
+                    const srcType u = *(sPtrUV++);\
+                    const srcType v = *(sPtrUV++);\
+                    \
+                    dPtr0->x = *(sPtrY0++);\
+                    dPtr0->y = u;\
+                    dPtr0->z = *(sPtrY0++);\
+                    dPtr0->w = v;\
+                    ++dPtr0;\
+                    \
+                    dPtr1->x = *(sPtrY2++);\
+                    dPtr1->y = u;\
+                    dPtr1->z = *(sPtrY2++);\
+                    dPtr1->w = v;\
+                    ++dPtr1;\
+                }\
+                \
+                pSrc += rowPitch * 2;\
+                pSrcUV += rowPitch;\
+                \
+                pDest += destImage.rowPitch * 2;\
+            }\
+        }
+
+#ifdef __clang__
+#pragma clang diagnostic ignored "-Wextra-semi-stmt"
+#endif
+
+    HRESULT ConvertToSinglePlane_(_In_ const Image& srcImage, _In_ const Image& destImage) noexcept
+    {
+        assert(srcImage.width == destImage.width);
+        assert(srcImage.height == destImage.height);
+
+        const uint8_t *pSrc = srcImage.pixels;
+        uint8_t *pDest = destImage.pixels;
+        if (!pSrc || !pDest)
+            return E_POINTER;
+
+        switch (srcImage.format)
+        {
+        case DXGI_FORMAT_NV12:
+            assert(destImage.format == DXGI_FORMAT_YUY2);
+            if ((srcImage.width % 2) != 0 || (srcImage.height % 2) != 0)
+                return E_INVALIDARG;
+
+            CONVERT_420_TO_422(uint8_t, XMUBYTEN4);
+            return S_OK;
+
+        case DXGI_FORMAT_P010:
+            assert(destImage.format == DXGI_FORMAT_Y210);
+            if ((srcImage.width % 2) != 0 || (srcImage.height % 2) != 0)
+                return E_INVALIDARG;
+
+            CONVERT_420_TO_422(uint16_t, XMUSHORTN4);
+            return S_OK;
+
+        case DXGI_FORMAT_P016:
+            assert(destImage.format == DXGI_FORMAT_Y216);
+            if ((srcImage.width % 2) != 0 || (srcImage.height % 2) != 0)
+                return E_INVALIDARG;
+
+            CONVERT_420_TO_422(uint16_t, XMUSHORTN4);
+            return S_OK;
+
+        case DXGI_FORMAT_NV11:
+            assert(destImage.format == DXGI_FORMAT_YUY2);
+            if ((srcImage.width % 4) != 0)
+                return E_INVALIDARG;
+
+            // Convert 4:1:1 to 4:2:2
+            {
+                const size_t rowPitch = srcImage.rowPitch;
+
+                const uint8_t* sourceE = pSrc + srcImage.slicePitch;
+                const uint8_t* pSrcUV = pSrc + (srcImage.height * rowPitch);
+
+                for (size_t y = 0; y < srcImage.height; ++y)
+                {
+                    const uint8_t* sPtrY = pSrc;
+                    const uint8_t* sPtrUV = pSrcUV;
+
+                    XMUBYTEN4 * __restrict dPtr = reinterpret_cast<XMUBYTEN4*>(pDest);
+
+                    for (size_t x = 0; x < srcImage.width; x += 4)
+                    {
+                        if ((sPtrUV + 1) >= sourceE) break;
+
+                        const uint8_t u = *(sPtrUV++);
+                        const uint8_t v = *(sPtrUV++);
+
+                        dPtr->x = *(sPtrY++);
+                        dPtr->y = u;
+                        dPtr->z = *(sPtrY++);
+                        dPtr->w = v;
+                        ++dPtr;
+
+                        dPtr->x = *(sPtrY++);
+                        dPtr->y = u;
+                        dPtr->z = *(sPtrY++);
+                        dPtr->w = v;
+                        ++dPtr;
+                    }
+
+                    pSrc += rowPitch;
+                    pSrcUV += (rowPitch >> 1);
+
+                    pDest += destImage.rowPitch;
+                }
+            }
+            return S_OK;
+
+        default:
+            return E_UNEXPECTED;
+        }
+    }
+
+#undef CONVERT_420_TO_422
+}
+
+
+//=====================================================================================
+// Entry-points
+//=====================================================================================
+
+//-------------------------------------------------------------------------------------
+// Convert image
+//-------------------------------------------------------------------------------------
+_Use_decl_annotations_
+HRESULT DirectX::Convert(
+    const Image& srcImage,
+    DXGI_FORMAT format,
+    TEX_FILTER_FLAGS filter,
+    float threshold,
+    ScratchImage& image) noexcept
+{
+    ConvertOptions options = {};
+    options.filter = filter;
+    options.threshold = threshold;
+
+    return ConvertEx(srcImage, format, options, image, nullptr);
+}
+
+_Use_decl_annotations_
+HRESULT DirectX::ConvertEx(
+    const Image& srcImage,
+    DXGI_FORMAT format,
+    const ConvertOptions& options,
+    ScratchImage& image,
+    std::function<bool __cdecl(size_t, size_t)> statusCallback)
+{
+    if ((srcImage.format == format) || !IsValid(format))
+        return E_INVALIDARG;
+
+    if (!srcImage.pixels)
+        return E_POINTER;
+
+    if (IsCompressed(srcImage.format) || IsCompressed(format)
+        || IsPlanar(srcImage.format) || IsPlanar(format)
+        || IsPalettized(srcImage.format) || IsPalettized(format)
+        || IsTypeless(srcImage.format) || IsTypeless(format))
+        return HRESULT_E_NOT_SUPPORTED;
+
+    if ((srcImage.width > UINT32_MAX) || (srcImage.height > UINT32_MAX))
+        return E_INVALIDARG;
+
+    HRESULT hr = image.Initialize2D(format, srcImage.width, srcImage.height, 1, 1);
+    if (FAILED(hr))
+        return hr;
+
+    const Image *rimage = image.GetImage(0, 0, 0);
+    if (!rimage)
+    {
+        image.Release();
+        return E_POINTER;
+    }
+
+    if (statusCallback)
+    {
+        if (!statusCallback(0, rimage->height))
+        {
+            image.Release();
+            return E_ABORT;
+        }
+    }
+
+    WICPixelFormatGUID pfGUID, targetGUID;
+    if (UseWICConversion(options.filter, srcImage.format, format, pfGUID, targetGUID))
+    {
+        hr = ConvertUsingWIC(srcImage, pfGUID, targetGUID, options.filter, options.threshold, *rimage);
+    }
+    else
+    {
+        hr = ConvertCustom(srcImage, options.filter, *rimage, options.threshold, 0, statusCallback);
+    }
+
+    if (FAILED(hr))
+    {
+        image.Release();
+        return hr;
+    }
+
+    if (statusCallback)
+    {
+        if (!statusCallback(rimage->height, rimage->height))
+        {
+            image.Release();
+            return E_ABORT;
+        }
+    }
+
+    return S_OK;
+}
+
+
+//-------------------------------------------------------------------------------------
+// Convert image (complex)
+//-------------------------------------------------------------------------------------
+_Use_decl_annotations_
+HRESULT DirectX::Convert(
+    const Image* srcImages,
+    size_t nimages,
+    const TexMetadata& metadata,
+    DXGI_FORMAT format,
+    TEX_FILTER_FLAGS filter,
+    float threshold,
+    ScratchImage& result) noexcept
+{
+    ConvertOptions options = {};
+    options.filter = filter;
+    options.threshold = threshold;
+
+    return ConvertEx(srcImages, nimages, metadata, format, options, result, nullptr);
+}
+
+_Use_decl_annotations_
+HRESULT DirectX::ConvertEx(
+    const Image* srcImages,
+    size_t nimages,
+    const TexMetadata& metadata,
+    DXGI_FORMAT format,
+    const ConvertOptions& options,
+    ScratchImage& result,
+    std::function<bool __cdecl(size_t, size_t)> statusCallback)
+{
+    if (!srcImages || !nimages || (metadata.format == format) || !IsValid(format))
+        return E_INVALIDARG;
+
+    if (IsCompressed(metadata.format) || IsCompressed(format)
+        || IsPlanar(metadata.format) || IsPlanar(format)
+        || IsPalettized(metadata.format) || IsPalettized(format)
+        || IsTypeless(metadata.format) || IsTypeless(format))
+        return HRESULT_E_NOT_SUPPORTED;
+
+    if ((metadata.width > UINT32_MAX) || (metadata.height > UINT32_MAX))
+        return E_INVALIDARG;
+
+    if (statusCallback
+        && nimages == 1
+        && !metadata.IsVolumemap()
+        && metadata.mipLevels == 1
+        && metadata.arraySize == 1)
+    {
+        // If progress reporting is requested when converting a single 1D or 2D image, call
+        // the ConvertEx overload that takes a single image.
+        // This provides a better user experience as progress will be reported as the image
+        // is being processed, instead of after processing has been completed.
+        return ConvertEx(srcImages[0], format, options, result, statusCallback);
+    }
+
+    TexMetadata mdata2 = metadata;
+    mdata2.format = format;
+    HRESULT hr = result.Initialize(mdata2);
+    if (FAILED(hr))
+        return hr;
+
+    if (nimages != result.GetImageCount())
+    {
+        result.Release();
+        return E_FAIL;
+    }
+
+    const Image* dest = result.GetImages();
+    if (!dest)
+    {
+        result.Release();
+        return E_POINTER;
+    }
+
+    if (statusCallback)
+    {
+        if (!statusCallback(0, nimages))
+        {
+            result.Release();
+            return E_ABORT;
+        }
+    }
+
+    WICPixelFormatGUID pfGUID, targetGUID;
+    const bool usewic = !metadata.IsPMAlpha() && UseWICConversion(options.filter, metadata.format, format, pfGUID, targetGUID);
+
+    switch (metadata.dimension)
+    {
+    case TEX_DIMENSION_TEXTURE1D:
+    case TEX_DIMENSION_TEXTURE2D:
+        for (size_t index = 0; index < nimages; ++index)
+        {
+            const Image& src = srcImages[index];
+            if (src.format != metadata.format)
+            {
+                result.Release();
+                return E_FAIL;
+            }
+
+            if ((src.width > UINT32_MAX) || (src.height > UINT32_MAX))
+            {
+                result.Release();
+                return E_FAIL;
+            }
+
+            const Image& dst = dest[index];
+            assert(dst.format == format);
+
+            if (src.width != dst.width || src.height != dst.height)
+            {
+                result.Release();
+                return E_FAIL;
+            }
+
+            if (usewic)
+            {
+                hr = ConvertUsingWIC(src, pfGUID, targetGUID, options.filter, options.threshold, dst);
+            }
+            else
+            {
+                hr = ConvertCustom(src, options.filter, dst, options.threshold, 0, nullptr);
+            }
+
+            if (FAILED(hr))
+            {
+                result.Release();
+                return hr;
+            }
+
+            if (statusCallback)
+            {
+                if (!statusCallback(index, nimages))
+                {
+                    result.Release();
+                    return E_ABORT;
+                }
+            }
+        }
+        break;
+
+    case TEX_DIMENSION_TEXTURE3D:
+        {
+            size_t index = 0;
+            size_t d = metadata.depth;
+            for (size_t level = 0; level < metadata.mipLevels; ++level)
+            {
+                for (size_t slice = 0; slice < d; ++slice, ++index)
+                {
+                    if (index >= nimages)
+                    {
+                        result.Release();
+                        return E_FAIL;
+                    }
+
+                    const Image& src = srcImages[index];
+                    if (src.format != metadata.format)
+                    {
+                        result.Release();
+                        return E_FAIL;
+                    }
+
+                    if ((src.width > UINT32_MAX) || (src.height > UINT32_MAX))
+                    {
+                        result.Release();
+                        return E_FAIL;
+                    }
+
+                    const Image& dst = dest[index];
+                    assert(dst.format == format);
+
+                    if (src.width != dst.width || src.height != dst.height)
+                    {
+                        result.Release();
+                        return E_FAIL;
+                    }
+
+                    if (usewic)
+                    {
+                        hr = ConvertUsingWIC(src, pfGUID, targetGUID, options.filter, options.threshold, dst);
+                    }
+                    else
+                    {
+                        hr = ConvertCustom(src, options.filter, dst, options.threshold, slice, nullptr);
+                    }
+
+                    if (FAILED(hr))
+                    {
+                        result.Release();
+                        return hr;
+                    }
+
+                    if (statusCallback)
+                    {
+                        if (!statusCallback(index, nimages))
+                        {
+                            result.Release();
+                            return E_ABORT;
+                        }
+                    }
+                }
+
+                if (d > 1)
+                    d >>= 1;
+            }
+        }
+        break;
+
+    default:
+        result.Release();
+        return E_FAIL;
+    }
+
+    if (statusCallback)
+    {
+        if (!statusCallback(nimages, nimages))
+        {
+            result.Release();
+            return E_ABORT;
+        }
+    }
+
+    return S_OK;
+}
+
+
+//-------------------------------------------------------------------------------------
+// Convert image from planar to single plane (image)
+//-------------------------------------------------------------------------------------
+_Use_decl_annotations_
+HRESULT DirectX::ConvertToSinglePlane(const Image& srcImage, ScratchImage& image) noexcept
+{
+    if (!IsPlanar(srcImage.format))
+        return E_INVALIDARG;
+
+    if (!srcImage.pixels)
+        return E_POINTER;
+
+    const DXGI_FORMAT format = PlanarToSingle(srcImage.format);
+    if (format == DXGI_FORMAT_UNKNOWN)
+        return HRESULT_E_NOT_SUPPORTED;
+
+    if ((srcImage.width > UINT32_MAX) || (srcImage.height > UINT32_MAX))
+        return E_INVALIDARG;
+
+    HRESULT hr = image.Initialize2D(format, srcImage.width, srcImage.height, 1, 1);
+    if (FAILED(hr))
+        return hr;
+
+    const Image *rimage = image.GetImage(0, 0, 0);
+    if (!rimage)
+    {
+        image.Release();
+        return E_POINTER;
+    }
+
+    hr = ConvertToSinglePlane_(srcImage, *rimage);
+    if (FAILED(hr))
+    {
+        image.Release();
+        return hr;
+    }
+
+    return S_OK;
+}
+
+
+//-------------------------------------------------------------------------------------
+// Convert image from planar to single plane (complex)
+//-------------------------------------------------------------------------------------
+_Use_decl_annotations_
+HRESULT DirectX::ConvertToSinglePlane(
+    const Image* srcImages,
+    size_t nimages,
+    const TexMetadata& metadata,
+    ScratchImage& result) noexcept
+{
+    if (!srcImages || !nimages)
+        return E_INVALIDARG;
+
+    if (metadata.IsVolumemap())
+    {
+        // Direct3D does not support any planar formats for Texture3D
+        return HRESULT_E_NOT_SUPPORTED;
+    }
+
+    const DXGI_FORMAT format = PlanarToSingle(metadata.format);
+    if (format == DXGI_FORMAT_UNKNOWN)
+        return HRESULT_E_NOT_SUPPORTED;
+
+    if ((metadata.width > UINT32_MAX) || (metadata.height > UINT32_MAX))
+        return E_INVALIDARG;
+
+    TexMetadata mdata2 = metadata;
+    mdata2.format = format;
+    HRESULT hr = result.Initialize(mdata2);
+    if (FAILED(hr))
+        return hr;
+
+    if (nimages != result.GetImageCount())
+    {
+        result.Release();
+        return E_FAIL;
+    }
+
+    const Image* dest = result.GetImages();
+    if (!dest)
+    {
+        result.Release();
+        return E_POINTER;
+    }
+
+    for (size_t index = 0; index < nimages; ++index)
+    {
+        const Image& src = srcImages[index];
+        if (src.format != metadata.format)
+        {
+            result.Release();
+            return E_FAIL;
+        }
+
+        if ((src.width > UINT32_MAX) || (src.height > UINT32_MAX))
+            return E_FAIL;
+
+        const Image& dst = dest[index];
+        assert(dst.format == format);
+
+        if (src.width != dst.width || src.height != dst.height)
+        {
+            result.Release();
+            return E_FAIL;
+        }
+
+        hr = ConvertToSinglePlane_(src, dst);
+        if (FAILED(hr))
+        {
+            result.Release();
+            return hr;
+        }
+    }
+
+    return S_OK;
+}
+
+
+//-------------------------------------------------------------------------------------
+// Returns the data type of a DXGI_FORMAT
+//-------------------------------------------------------------------------------------
+DirectX::FORMAT_TYPE DirectX::FormatDataType(_In_ DXGI_FORMAT fmt) noexcept
+{
+    const auto cflags = GetConvertFlags(fmt);
+
+    switch (cflags & (CONVF_FLOAT | CONVF_UNORM | CONVF_UINT | CONVF_SNORM | CONVF_SINT))
+    {
+    case CONVF_FLOAT:
+        return FORMAT_TYPE_FLOAT;
+
+    case CONVF_UNORM:
+        return FORMAT_TYPE_UNORM;
+
+    case CONVF_UINT:
+        return FORMAT_TYPE_UINT;
+
+    case CONVF_SNORM:
+        return FORMAT_TYPE_SNORM;
+
+    case CONVF_SINT:
+        return FORMAT_TYPE_SINT;
+
+    default:
+        return FORMAT_TYPE_TYPELESS;
+    }
+}

--- a/DirectXTex/DirectXTex/DirectXTexDDS.cpp
+++ b/DirectXTex/DirectXTex/DirectXTexDDS.cpp
@@ -1,0 +1,2728 @@
+//-------------------------------------------------------------------------------------
+// DirectXTexDDS.cpp
+//
+// DirectX Texture Library - Microsoft DirectDraw Surface (DDS) file format reader/writer
+//
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+//
+// http://go.microsoft.com/fwlink/?LinkId=248926
+//-------------------------------------------------------------------------------------
+
+#include "DirectXTexP.h"
+
+#include "DDS.h"
+
+using namespace DirectX;
+using namespace DirectX::Internal;
+
+static_assert(static_cast<int>(TEX_DIMENSION_TEXTURE1D) == static_cast<int>(DDS_DIMENSION_TEXTURE1D), "header enum mismatch");
+static_assert(static_cast<int>(TEX_DIMENSION_TEXTURE2D) == static_cast<int>(DDS_DIMENSION_TEXTURE2D), "header enum mismatch");
+static_assert(static_cast<int>(TEX_DIMENSION_TEXTURE3D) == static_cast<int>(DDS_DIMENSION_TEXTURE3D), "header enum mismatch");
+
+namespace
+{
+    constexpr size_t MAX_HEADER_SIZE = sizeof(uint32_t) + sizeof(DDS_HEADER) + sizeof(DDS_HEADER_DXT10);
+
+    //-------------------------------------------------------------------------------------
+    // Legacy format mapping table (used for DDS files without 'DX10' extended header)
+    //-------------------------------------------------------------------------------------
+    enum CONVERSION_FLAGS : uint32_t
+    {
+        CONV_FLAGS_NONE = 0x0,
+        CONV_FLAGS_EXPAND = 0x1,        // Conversion requires expanded pixel size
+        CONV_FLAGS_NOALPHA = 0x2,       // Conversion requires setting alpha to known value
+        CONV_FLAGS_SWIZZLE = 0x4,       // BGR/RGB order swizzling required
+        CONV_FLAGS_PAL8 = 0x8,          // Has an 8-bit palette
+        CONV_FLAGS_888 = 0x10,          // Source is an 8:8:8 (24bpp) format
+        CONV_FLAGS_565 = 0x20,          // Source is a 5:6:5 (16bpp) format
+        CONV_FLAGS_5551 = 0x40,         // Source is a 5:5:5:1 (16bpp) format
+        CONV_FLAGS_4444 = 0x80,         // Source is a 4:4:4:4 (16bpp) format
+        CONV_FLAGS_44 = 0x100,          // Source is a 4:4 (8bpp) format
+        CONV_FLAGS_332 = 0x200,         // Source is a 3:3:2 (8bpp) format
+        CONV_FLAGS_8332 = 0x400,        // Source is a 8:3:3:2 (16bpp) format
+        CONV_FLAGS_A8P8 = 0x800,        // Has an 8-bit palette with an alpha channel
+        CONF_FLAGS_11ON12 = 0x1000,     // D3D11on12 format
+        CONV_FLAGS_DX10 = 0x10000,      // Has the 'DX10' extension header
+        CONV_FLAGS_PMALPHA = 0x20000,   // Contains premultiplied alpha data
+        CONV_FLAGS_L8 = 0x40000,        // Source is a 8 luminance format
+        CONV_FLAGS_L16 = 0x80000,       // Source is a 16 luminance format
+        CONV_FLAGS_A8L8 = 0x100000,     // Source is a 8:8 luminance format
+    };
+
+    struct LegacyDDS
+    {
+        DXGI_FORMAT     format;
+        uint32_t        convFlags;
+        DDS_PIXELFORMAT ddpf;
+    };
+
+    const LegacyDDS g_LegacyDDSMap[] =
+    {
+        { DXGI_FORMAT_BC1_UNORM,          CONV_FLAGS_NONE,        DDSPF_DXT1 }, // D3DFMT_DXT1
+        { DXGI_FORMAT_BC2_UNORM,          CONV_FLAGS_NONE,        DDSPF_DXT3 }, // D3DFMT_DXT3
+        { DXGI_FORMAT_BC3_UNORM,          CONV_FLAGS_NONE,        DDSPF_DXT5 }, // D3DFMT_DXT5
+
+        { DXGI_FORMAT_BC2_UNORM,          CONV_FLAGS_PMALPHA,     DDSPF_DXT2 }, // D3DFMT_DXT2
+        { DXGI_FORMAT_BC3_UNORM,          CONV_FLAGS_PMALPHA,     DDSPF_DXT4 }, // D3DFMT_DXT4
+
+        // These DXT5 variants have various swizzled channels. They are returned 'as is' to the client as BC3.
+        { DXGI_FORMAT_BC3_UNORM,          CONV_FLAGS_NONE,        { sizeof(DDS_PIXELFORMAT), DDS_FOURCC, MAKEFOURCC('A', '2', 'D', '5'), 0, 0, 0, 0, 0 } },
+        { DXGI_FORMAT_BC3_UNORM,          CONV_FLAGS_NONE,        { sizeof(DDS_PIXELFORMAT), DDS_FOURCC, MAKEFOURCC('x', 'G', 'B', 'R'), 0, 0, 0, 0, 0 } },
+        { DXGI_FORMAT_BC3_UNORM,          CONV_FLAGS_NONE,        { sizeof(DDS_PIXELFORMAT), DDS_FOURCC, MAKEFOURCC('R', 'x', 'B', 'G'), 0, 0, 0, 0, 0 } },
+        { DXGI_FORMAT_BC3_UNORM,          CONV_FLAGS_NONE,        { sizeof(DDS_PIXELFORMAT), DDS_FOURCC, MAKEFOURCC('R', 'B', 'x', 'G'), 0, 0, 0, 0, 0 } },
+        { DXGI_FORMAT_BC3_UNORM,          CONV_FLAGS_NONE,        { sizeof(DDS_PIXELFORMAT), DDS_FOURCC, MAKEFOURCC('x', 'R', 'B', 'G'), 0, 0, 0, 0, 0 } },
+        { DXGI_FORMAT_BC3_UNORM,          CONV_FLAGS_NONE,        { sizeof(DDS_PIXELFORMAT), DDS_FOURCC, MAKEFOURCC('R', 'G', 'x', 'B'), 0, 0, 0, 0, 0 } },
+        { DXGI_FORMAT_BC3_UNORM,          CONV_FLAGS_NONE,        { sizeof(DDS_PIXELFORMAT), DDS_FOURCC, MAKEFOURCC('x', 'G', 'x', 'R'), 0, 0, 0, 0, 0 } },
+        { DXGI_FORMAT_BC3_UNORM,          CONV_FLAGS_NONE,        { sizeof(DDS_PIXELFORMAT), DDS_FOURCC, MAKEFOURCC('G', 'X', 'R', 'B'), 0, 0, 0, 0, 0 } },
+        { DXGI_FORMAT_BC3_UNORM,          CONV_FLAGS_NONE,        { sizeof(DDS_PIXELFORMAT), DDS_FOURCC, MAKEFOURCC('G', 'R', 'X', 'B'), 0, 0, 0, 0, 0 } },
+        { DXGI_FORMAT_BC3_UNORM,          CONV_FLAGS_NONE,        { sizeof(DDS_PIXELFORMAT), DDS_FOURCC, MAKEFOURCC('R', 'X', 'G', 'B'), 0, 0, 0, 0, 0 } },
+        { DXGI_FORMAT_BC3_UNORM,          CONV_FLAGS_NONE,        { sizeof(DDS_PIXELFORMAT), DDS_FOURCC, MAKEFOURCC('B', 'R', 'G', 'X'), 0, 0, 0, 0, 0 } },
+
+        { DXGI_FORMAT_BC4_UNORM,          CONV_FLAGS_NONE,        DDSPF_BC4_UNORM },
+        { DXGI_FORMAT_BC4_SNORM,          CONV_FLAGS_NONE,        DDSPF_BC4_SNORM },
+        { DXGI_FORMAT_BC5_UNORM,          CONV_FLAGS_NONE,        DDSPF_BC5_UNORM },
+        { DXGI_FORMAT_BC5_SNORM,          CONV_FLAGS_NONE,        DDSPF_BC5_SNORM },
+
+        { DXGI_FORMAT_BC4_UNORM,          CONV_FLAGS_NONE,        { sizeof(DDS_PIXELFORMAT), DDS_FOURCC, MAKEFOURCC('A', 'T', 'I', '1'), 0, 0, 0, 0, 0 } },
+        { DXGI_FORMAT_BC5_UNORM,          CONV_FLAGS_NONE,        { sizeof(DDS_PIXELFORMAT), DDS_FOURCC, MAKEFOURCC('A', 'T', 'I', '2'), 0, 0, 0, 0, 0 } },
+        { DXGI_FORMAT_BC5_UNORM,          CONV_FLAGS_NONE,        { sizeof(DDS_PIXELFORMAT), DDS_FOURCC, MAKEFOURCC('A', '2', 'X', 'Y'), 0, 0, 0, 0, 0 } },
+
+        { DXGI_FORMAT_BC6H_UF16,          CONV_FLAGS_NONE,        { sizeof(DDS_PIXELFORMAT), DDS_FOURCC, MAKEFOURCC('B', 'C', '6', 'H'), 0, 0, 0, 0, 0 } },
+        { DXGI_FORMAT_BC7_UNORM,          CONV_FLAGS_NONE,        { sizeof(DDS_PIXELFORMAT), DDS_FOURCC, MAKEFOURCC('B', 'C', '7', 'L'), 0, 0, 0, 0, 0 } },
+        { DXGI_FORMAT_BC7_UNORM,          CONV_FLAGS_NONE,        { sizeof(DDS_PIXELFORMAT), DDS_FOURCC, MAKEFOURCC('B', 'C', '7', '\0'), 0, 0, 0, 0, 0 } },
+
+        { DXGI_FORMAT_R8G8_B8G8_UNORM,    CONV_FLAGS_NONE,        DDSPF_R8G8_B8G8 }, // D3DFMT_R8G8_B8G8
+        { DXGI_FORMAT_G8R8_G8B8_UNORM,    CONV_FLAGS_NONE,        DDSPF_G8R8_G8B8 }, // D3DFMT_G8R8_G8B8
+
+        { DXGI_FORMAT_B8G8R8A8_UNORM,     CONV_FLAGS_NONE,        DDSPF_A8R8G8B8 }, // D3DFMT_A8R8G8B8 (uses DXGI 1.1 format)
+        { DXGI_FORMAT_B8G8R8X8_UNORM,     CONV_FLAGS_NONE,        DDSPF_X8R8G8B8 }, // D3DFMT_X8R8G8B8 (uses DXGI 1.1 format)
+        { DXGI_FORMAT_R8G8B8A8_UNORM,     CONV_FLAGS_NONE,        DDSPF_A8B8G8R8 }, // D3DFMT_A8B8G8R8
+        { DXGI_FORMAT_R8G8B8A8_UNORM,     CONV_FLAGS_NOALPHA,     DDSPF_X8B8G8R8 }, // D3DFMT_X8B8G8R8
+        { DXGI_FORMAT_R16G16_UNORM,       CONV_FLAGS_NONE,        DDSPF_G16R16   }, // D3DFMT_G16R16
+
+        { DXGI_FORMAT_R10G10B10A2_UNORM,  CONV_FLAGS_SWIZZLE,     DDSPF_A2R10G10B10 }, // D3DFMT_A2R10G10B10 (D3DX reversal issue)
+        { DXGI_FORMAT_R10G10B10A2_UNORM,  CONV_FLAGS_NONE,        DDSPF_A2B10G10R10 }, // D3DFMT_A2B10G10R10 (D3DX reversal issue)
+
+        { DXGI_FORMAT_R8G8B8A8_UNORM,     CONV_FLAGS_EXPAND
+                                          | CONV_FLAGS_NOALPHA
+                                          | CONV_FLAGS_888,       DDSPF_R8G8B8 }, // D3DFMT_R8G8B8
+
+        { DXGI_FORMAT_B5G6R5_UNORM,       CONV_FLAGS_565,         DDSPF_R5G6B5 }, // D3DFMT_R5G6B5
+        { DXGI_FORMAT_B5G5R5A1_UNORM,     CONV_FLAGS_5551,        DDSPF_A1R5G5B5 }, // D3DFMT_A1R5G5B5
+        { DXGI_FORMAT_B5G5R5A1_UNORM,     CONV_FLAGS_5551
+                                          | CONV_FLAGS_NOALPHA,   DDSPF_X1R5G5B5 }, // D3DFMT_X1R5G5B5
+
+        { DXGI_FORMAT_R8G8B8A8_UNORM,     CONV_FLAGS_EXPAND
+                                          | CONV_FLAGS_8332,      DDSPF_A8R3G3B2 }, // D3DFMT_A8R3G3B2
+        { DXGI_FORMAT_B5G6R5_UNORM,       CONV_FLAGS_EXPAND
+                                          | CONV_FLAGS_332,       DDSPF_R3G3B2 }, // D3DFMT_R3G3B2
+
+        { DXGI_FORMAT_R8_UNORM,           CONV_FLAGS_NONE,        DDSPF_L8 }, // D3DFMT_L8
+        { DXGI_FORMAT_R16_UNORM,          CONV_FLAGS_NONE,        DDSPF_L16 }, // D3DFMT_L16
+        { DXGI_FORMAT_R8G8_UNORM,         CONV_FLAGS_NONE,        DDSPF_A8L8 }, // D3DFMT_A8L8
+        { DXGI_FORMAT_R8G8_UNORM,         CONV_FLAGS_NONE,        DDSPF_A8L8_ALT }, // D3DFMT_A8L8 (alternative bitcount)
+
+        // NVTT v1 wrote these with RGB instead of LUMINANCE
+        { DXGI_FORMAT_R8_UNORM,           CONV_FLAGS_NONE,        DDSPF_L8_NVTT1 }, // D3DFMT_L8
+        { DXGI_FORMAT_R16_UNORM,          CONV_FLAGS_NONE,        DDSPF_L16_NVTT1  }, // D3DFMT_L16
+        { DXGI_FORMAT_R8G8_UNORM,         CONV_FLAGS_NONE,        DDSPF_A8L8_NVTT1 }, // D3DFMT_A8L8
+
+        { DXGI_FORMAT_A8_UNORM,           CONV_FLAGS_NONE,        DDSPF_A8   }, // D3DFMT_A8
+
+        { DXGI_FORMAT_R16G16B16A16_UNORM, CONV_FLAGS_NONE,        { sizeof(DDS_PIXELFORMAT), DDS_FOURCC,   36,  0, 0, 0, 0, 0 } }, // D3DFMT_A16B16G16R16
+        { DXGI_FORMAT_R16G16B16A16_SNORM, CONV_FLAGS_NONE,        { sizeof(DDS_PIXELFORMAT), DDS_FOURCC,  110,  0, 0, 0, 0, 0 } }, // D3DFMT_Q16W16V16U16
+        { DXGI_FORMAT_R16_FLOAT,          CONV_FLAGS_NONE,        { sizeof(DDS_PIXELFORMAT), DDS_FOURCC,  111,  0, 0, 0, 0, 0 } }, // D3DFMT_R16F
+        { DXGI_FORMAT_R16G16_FLOAT,       CONV_FLAGS_NONE,        { sizeof(DDS_PIXELFORMAT), DDS_FOURCC,  112,  0, 0, 0, 0, 0 } }, // D3DFMT_G16R16F
+        { DXGI_FORMAT_R16G16B16A16_FLOAT, CONV_FLAGS_NONE,        { sizeof(DDS_PIXELFORMAT), DDS_FOURCC,  113,  0, 0, 0, 0, 0 } }, // D3DFMT_A16B16G16R16F
+        { DXGI_FORMAT_R32_FLOAT,          CONV_FLAGS_NONE,        { sizeof(DDS_PIXELFORMAT), DDS_FOURCC,  114,  0, 0, 0, 0, 0 } }, // D3DFMT_R32F
+        { DXGI_FORMAT_R32G32_FLOAT,       CONV_FLAGS_NONE,        { sizeof(DDS_PIXELFORMAT), DDS_FOURCC,  115,  0, 0, 0, 0, 0 } }, // D3DFMT_G32R32F
+        { DXGI_FORMAT_R32G32B32A32_FLOAT, CONV_FLAGS_NONE,        { sizeof(DDS_PIXELFORMAT), DDS_FOURCC,  116,  0, 0, 0, 0, 0 } }, // D3DFMT_A32B32G32R32F
+
+        { DXGI_FORMAT_R32_FLOAT,          CONV_FLAGS_NONE,        { sizeof(DDS_PIXELFORMAT), DDS_RGB,       0, 32, 0xffffffff, 0, 0, 0 } }, // D3DFMT_R32F (D3DX uses FourCC 114 instead)
+
+        { DXGI_FORMAT_R8G8B8A8_UNORM,     CONV_FLAGS_EXPAND
+                                          | CONV_FLAGS_PAL8
+                                          | CONV_FLAGS_A8P8,      { sizeof(DDS_PIXELFORMAT), DDS_PAL8A,     0, 16, 0, 0, 0, 0 } }, // D3DFMT_A8P8
+        { DXGI_FORMAT_R8G8B8A8_UNORM,     CONV_FLAGS_EXPAND
+                                          | CONV_FLAGS_PAL8,      { sizeof(DDS_PIXELFORMAT), DDS_PAL8,      0,  8, 0, 0, 0, 0 } }, // D3DFMT_P8
+
+        { DXGI_FORMAT_B4G4R4A4_UNORM,     CONV_FLAGS_4444,        DDSPF_A4R4G4B4 }, // D3DFMT_A4R4G4B4 (uses DXGI 1.2 format)
+        { DXGI_FORMAT_B4G4R4A4_UNORM,     CONV_FLAGS_NOALPHA
+                                          | CONV_FLAGS_4444,      DDSPF_X4R4G4B4 }, // D3DFMT_X4R4G4B4 (uses DXGI 1.2 format)
+        { DXGI_FORMAT_B4G4R4A4_UNORM,     CONV_FLAGS_EXPAND
+                                          | CONV_FLAGS_44,        DDSPF_A4L4 }, // D3DFMT_A4L4 (uses DXGI 1.2 format)
+
+        { DXGI_FORMAT_YUY2,               CONV_FLAGS_NONE,        DDSPF_YUY2 }, // D3DFMT_YUY2 (uses DXGI 1.2 format)
+        { DXGI_FORMAT_YUY2,               CONV_FLAGS_SWIZZLE,     DDSPF_UYVY }, // D3DFMT_UYVY (uses DXGI 1.2 format)
+
+        { DXGI_FORMAT_R8G8_SNORM,         CONV_FLAGS_NONE,        DDSPF_V8U8 },     // D3DFMT_V8U8
+        { DXGI_FORMAT_R8G8B8A8_SNORM,     CONV_FLAGS_NONE,        DDSPF_Q8W8V8U8 }, // D3DFMT_Q8W8V8U8
+        { DXGI_FORMAT_R16G16_SNORM,       CONV_FLAGS_NONE,        DDSPF_V16U16 },   // D3DFMT_V16U16
+    };
+
+    // Note that many common DDS reader/writers (including D3DX) swap the
+    // the RED/BLUE masks for 10:10:10:2 formats. We assumme
+    // below that the 'backwards' header mask is being used since it is most
+    // likely written by D3DX. The more robust solution is to use the 'DX10'
+    // header extension and specify the DXGI_FORMAT_R10G10B10A2_UNORM format directly
+
+    // We do not support the following legacy Direct3D 9 formats:
+    //      BumpDuDv D3DFMT_A2W10V10U10
+    //      BumpLuminance D3DFMT_L6V5U5, D3DFMT_X8L8V8U8
+    //      FourCC 117 D3DFMT_CxV8U8
+    //      ZBuffer D3DFMT_D16_LOCKABLE
+    //      FourCC 82 D3DFMT_D32F_LOCKABLE
+
+    // We do not support the following known FourCC codes:
+    //      FourCC CTX1 (Xbox 360 only)
+    //      FourCC EAR, EARG, ET2, ET2A (Ericsson Texture Compression)
+
+    DXGI_FORMAT GetDXGIFormat(const DDS_HEADER& hdr, const DDS_PIXELFORMAT& ddpf,
+        DDS_FLAGS flags,
+        _Inout_ uint32_t& convFlags) noexcept
+    {
+        uint32_t ddpfFlags = ddpf.flags;
+        if (hdr.reserved1[9] == MAKEFOURCC('N', 'V', 'T', 'T'))
+        {
+            // Clear out non-standard nVidia DDS flags
+            ddpfFlags &= ~0xC0000000 /* DDPF_SRGB | DDPF_NORMAL */;
+        }
+
+        constexpr size_t MAP_SIZE = sizeof(g_LegacyDDSMap) / sizeof(LegacyDDS);
+        size_t index = 0;
+        if (ddpf.size == 0 && ddpf.flags == 0 && ddpf.fourCC != 0)
+        {
+            // Handle some DDS files where the DDPF_PIXELFORMAT is mostly zero
+            for (index = 0; index < MAP_SIZE; ++index)
+            {
+                const LegacyDDS* entry = &g_LegacyDDSMap[index];
+
+                if (entry->ddpf.flags & DDS_FOURCC)
+                {
+                    if (ddpf.fourCC == entry->ddpf.fourCC)
+                        break;
+                }
+            }
+        }
+        else
+        {
+            for (index = 0; index < MAP_SIZE; ++index)
+            {
+                const LegacyDDS* entry = &g_LegacyDDSMap[index];
+
+                if ((ddpfFlags & DDS_FOURCC) && (entry->ddpf.flags & DDS_FOURCC))
+                {
+                    // In case of FourCC codes, ignore any other bits in ddpf.flags
+                    if (ddpf.fourCC == entry->ddpf.fourCC)
+                        break;
+                }
+                else if (ddpfFlags == entry->ddpf.flags)
+                {
+                    if (entry->ddpf.flags & DDS_PAL8)
+                    {
+                        if (ddpf.RGBBitCount == entry->ddpf.RGBBitCount)
+                            break;
+                    }
+                    else if (entry->ddpf.flags & DDS_ALPHA)
+                    {
+                        if (ddpf.RGBBitCount == entry->ddpf.RGBBitCount
+                            && ddpf.ABitMask == entry->ddpf.ABitMask)
+                            break;
+                    }
+                    else if (entry->ddpf.flags & DDS_LUMINANCE)
+                    {
+                        if (entry->ddpf.flags & DDS_ALPHAPIXELS)
+                        {
+                            // LUMINANCEA
+                            if (ddpf.RGBBitCount == entry->ddpf.RGBBitCount
+                                && ddpf.RBitMask == entry->ddpf.RBitMask
+                                && ddpf.ABitMask == entry->ddpf.ABitMask)
+                                break;
+                        }
+                        else
+                        {
+                            // LUMINANCE
+                            if (ddpf.RGBBitCount == entry->ddpf.RGBBitCount
+                                && ddpf.RBitMask == entry->ddpf.RBitMask)
+                                break;
+                        }
+                    }
+                    else if (entry->ddpf.flags & DDS_BUMPDUDV)
+                    {
+                        if (ddpf.RGBBitCount == entry->ddpf.RGBBitCount
+                            && ddpf.RBitMask == entry->ddpf.RBitMask
+                            && ddpf.GBitMask == entry->ddpf.GBitMask
+                            && ddpf.BBitMask == entry->ddpf.BBitMask
+                            && ddpf.ABitMask == entry->ddpf.ABitMask)
+                            break;
+                    }
+                    else if (ddpf.RGBBitCount == entry->ddpf.RGBBitCount)
+                    {
+                        if (entry->ddpf.flags & DDS_ALPHAPIXELS)
+                        {
+                            // RGBA
+                            if (ddpf.RBitMask == entry->ddpf.RBitMask
+                                && ddpf.GBitMask == entry->ddpf.GBitMask
+                                && ddpf.BBitMask == entry->ddpf.BBitMask
+                                && ddpf.ABitMask == entry->ddpf.ABitMask)
+                                break;
+                        }
+                        else
+                        {
+                            // RGB
+                            if (ddpf.RBitMask == entry->ddpf.RBitMask
+                                && ddpf.GBitMask == entry->ddpf.GBitMask
+                                && ddpf.BBitMask == entry->ddpf.BBitMask)
+                                break;
+                        }
+                    }
+                }
+            }
+        }
+
+        if (index >= MAP_SIZE)
+            return DXGI_FORMAT_UNKNOWN;
+
+        uint32_t cflags = g_LegacyDDSMap[index].convFlags;
+        DXGI_FORMAT format = g_LegacyDDSMap[index].format;
+
+        if ((cflags & CONV_FLAGS_EXPAND) && (flags & DDS_FLAGS_NO_LEGACY_EXPANSION))
+            return DXGI_FORMAT_UNKNOWN;
+
+        if ((format == DXGI_FORMAT_R10G10B10A2_UNORM) && (flags & DDS_FLAGS_NO_R10B10G10A2_FIXUP))
+        {
+            cflags ^= CONV_FLAGS_SWIZZLE;
+        }
+
+        if ((hdr.reserved1[9] == MAKEFOURCC('N', 'V', 'T', 'T'))
+            && (ddpf.flags & 0x40000000 /* DDPF_SRGB */))
+        {
+            format = MakeSRGB(format);
+        }
+
+        convFlags = cflags;
+
+        return format;
+    }
+
+    //-------------------------------------------------------------------------------------
+    // Decodes DDS header including optional DX10 extended header
+    //-------------------------------------------------------------------------------------
+    HRESULT DecodeDDSHeader(
+        _In_reads_bytes_(size) const void* pSource,
+        size_t size,
+        DDS_FLAGS flags,
+        _Out_ TexMetadata& metadata,
+        _Out_opt_ DDSMetaData* ddPixelFormat,
+        _Inout_ uint32_t& convFlags) noexcept
+    {
+        if (!pSource)
+            return E_INVALIDARG;
+
+        metadata = {};
+        if (ddPixelFormat)
+        {
+            *ddPixelFormat = {};
+        }
+
+        if (size < (sizeof(DDS_HEADER) + sizeof(uint32_t)))
+        {
+            return HRESULT_E_INVALID_DATA;
+        }
+
+        // DDS files always start with the same magic number ("DDS ")
+        auto const dwMagicNumber = *static_cast<const uint32_t*>(pSource);
+        if (dwMagicNumber != DDS_MAGIC)
+        {
+            return E_FAIL;
+        }
+
+        auto pHeader = reinterpret_cast<const DDS_HEADER*>(static_cast<const uint8_t*>(pSource) + sizeof(uint32_t));
+
+        // Verify header to validate DDS file
+        if (flags & DDS_FLAGS_PERMISSIVE)
+        {
+            if (pHeader->size != 24 /* Known variant */
+                && pHeader->size != sizeof(DDS_HEADER))
+            {
+                return HRESULT_E_NOT_SUPPORTED;
+            }
+        }
+        else if (pHeader->size != sizeof(DDS_HEADER))
+        {
+            return HRESULT_E_NOT_SUPPORTED;
+        }
+
+        if (flags & DDS_FLAGS_PERMISSIVE)
+        {
+            if (pHeader->ddspf.size != 0 /* Known variant */
+                && pHeader->ddspf.size != 24 /* Known variant */
+                && pHeader->ddspf.size != sizeof(DDS_PIXELFORMAT))
+            {
+                return HRESULT_E_NOT_SUPPORTED;
+            }
+        }
+        else if (pHeader->ddspf.size != sizeof(DDS_PIXELFORMAT))
+        {
+            return HRESULT_E_NOT_SUPPORTED;
+        }
+
+        metadata.mipLevels = pHeader->mipMapCount;
+        if (metadata.mipLevels == 0)
+            metadata.mipLevels = 1;
+
+        // Check for DX10 extension
+        if ((pHeader->ddspf.flags & DDS_FOURCC)
+            && (MAKEFOURCC('D', 'X', '1', '0') == pHeader->ddspf.fourCC))
+        {
+            if (pHeader->size != sizeof(DDS_HEADER)
+                || pHeader->ddspf.size != sizeof(DDS_PIXELFORMAT))
+            {
+                // We do not accept legacy DX9 'known variants' for modern "DX10" extension header files.
+                return E_FAIL;
+            }
+
+            // Buffer must be big enough for both headers and magic value
+            if (size < (sizeof(DDS_HEADER) + sizeof(uint32_t) + sizeof(DDS_HEADER_DXT10)))
+            {
+                return E_FAIL;
+            }
+
+            auto d3d10ext = reinterpret_cast<const DDS_HEADER_DXT10*>(static_cast<const uint8_t*>(pSource) + sizeof(uint32_t) + sizeof(DDS_HEADER));
+            convFlags |= CONV_FLAGS_DX10;
+
+            metadata.arraySize = d3d10ext->arraySize;
+            if (metadata.arraySize == 0)
+            {
+                return HRESULT_E_INVALID_DATA;
+            }
+
+            metadata.format = d3d10ext->dxgiFormat;
+            if (!IsValid(metadata.format) || IsPalettized(metadata.format))
+            {
+                return HRESULT_E_NOT_SUPPORTED;
+            }
+
+            static_assert(static_cast<int>(TEX_MISC_TEXTURECUBE) == static_cast<int>(DDS_RESOURCE_MISC_TEXTURECUBE), "DDS header mismatch");
+
+            metadata.miscFlags = d3d10ext->miscFlag & ~static_cast<uint32_t>(TEX_MISC_TEXTURECUBE);
+
+            switch (d3d10ext->resourceDimension)
+            {
+            case DDS_DIMENSION_TEXTURE1D:
+
+                // D3DX writes 1D textures with a fixed Height of 1
+                if ((pHeader->flags & DDS_HEIGHT) && pHeader->height != 1)
+                {
+                    return HRESULT_E_INVALID_DATA;
+                }
+
+                metadata.width = pHeader->width;
+                metadata.height = 1;
+                metadata.depth = 1;
+                metadata.dimension = TEX_DIMENSION_TEXTURE1D;
+                break;
+
+            case DDS_DIMENSION_TEXTURE2D:
+                if (d3d10ext->miscFlag & DDS_RESOURCE_MISC_TEXTURECUBE)
+                {
+                    metadata.miscFlags |= TEX_MISC_TEXTURECUBE;
+                    metadata.arraySize *= 6;
+                }
+
+                metadata.width = pHeader->width;
+                metadata.height = pHeader->height;
+                metadata.depth = 1;
+                metadata.dimension = TEX_DIMENSION_TEXTURE2D;
+                break;
+
+            case DDS_DIMENSION_TEXTURE3D:
+                if (!(pHeader->flags & DDS_HEADER_FLAGS_VOLUME))
+                {
+                    return HRESULT_E_INVALID_DATA;
+                }
+
+                if (metadata.arraySize > 1)
+                    return HRESULT_E_NOT_SUPPORTED;
+
+                metadata.width = pHeader->width;
+                metadata.height = pHeader->height;
+                metadata.depth = pHeader->depth;
+                metadata.dimension = TEX_DIMENSION_TEXTURE3D;
+                break;
+
+            default:
+                return HRESULT_E_INVALID_DATA;
+            }
+
+            static_assert(static_cast<int>(TEX_MISC2_ALPHA_MODE_MASK) == static_cast<int>(DDS_MISC_FLAGS2_ALPHA_MODE_MASK), "DDS header mismatch");
+
+            static_assert(static_cast<int>(TEX_ALPHA_MODE_UNKNOWN) == static_cast<int>(DDS_ALPHA_MODE_UNKNOWN), "DDS header mismatch");
+            static_assert(static_cast<int>(TEX_ALPHA_MODE_STRAIGHT) == static_cast<int>(DDS_ALPHA_MODE_STRAIGHT), "DDS header mismatch");
+            static_assert(static_cast<int>(TEX_ALPHA_MODE_PREMULTIPLIED) == static_cast<int>(DDS_ALPHA_MODE_PREMULTIPLIED), "DDS header mismatch");
+            static_assert(static_cast<int>(TEX_ALPHA_MODE_OPAQUE) == static_cast<int>(DDS_ALPHA_MODE_OPAQUE), "DDS header mismatch");
+            static_assert(static_cast<int>(TEX_ALPHA_MODE_CUSTOM) == static_cast<int>(DDS_ALPHA_MODE_CUSTOM), "DDS header mismatch");
+
+            metadata.miscFlags2 = d3d10ext->miscFlags2;
+        }
+        else
+        {
+            metadata.arraySize = 1;
+
+            if (pHeader->flags & DDS_HEADER_FLAGS_VOLUME)
+            {
+                metadata.width = pHeader->width;
+                metadata.height = pHeader->height;
+                metadata.depth = pHeader->depth;
+                metadata.dimension = TEX_DIMENSION_TEXTURE3D;
+
+                if (flags & DDS_FLAGS_PERMISSIVE)
+                {
+                    // Allow cases where mipCount was computed incorrectly
+                    size_t maxMips = 0;
+                    std::ignore = Internal::CalculateMipLevels3D(metadata.width, metadata.height, metadata.depth, maxMips);
+                    metadata.mipLevels = std::min(metadata.mipLevels, maxMips);
+                }
+            }
+            else
+            {
+                if (pHeader->caps2 & DDS_CUBEMAP)
+                {
+                    // We require all six faces to be defined
+                    if ((pHeader->caps2 & DDS_CUBEMAP_ALLFACES) != DDS_CUBEMAP_ALLFACES)
+                        return HRESULT_E_NOT_SUPPORTED;
+
+                    metadata.arraySize = 6;
+                    metadata.miscFlags |= TEX_MISC_TEXTURECUBE;
+                }
+
+                metadata.width = pHeader->width;
+                metadata.height = pHeader->height;
+                metadata.depth = 1;
+                metadata.dimension = TEX_DIMENSION_TEXTURE2D;
+
+                // Note there's no way for a legacy Direct3D 9 DDS to express a '1D' texture
+
+                if (flags & DDS_FLAGS_PERMISSIVE)
+                {
+                    // Allow cases where mipCount was computed incorrectly
+                    size_t maxMips = 0;
+                    std::ignore = Internal::CalculateMipLevels(metadata.width, metadata.height, maxMips);
+                    metadata.mipLevels = std::min(metadata.mipLevels, maxMips);
+                }
+            }
+
+            metadata.format = GetDXGIFormat(*pHeader, pHeader->ddspf, flags, convFlags);
+
+            if (metadata.format == DXGI_FORMAT_UNKNOWN)
+                return HRESULT_E_NOT_SUPPORTED;
+
+            // Special flag for handling LUMINANCE legacy formats
+            if (flags & DDS_FLAGS_EXPAND_LUMINANCE)
+            {
+                switch (metadata.format)
+                {
+                case DXGI_FORMAT_R8_UNORM:
+                    metadata.format = DXGI_FORMAT_R8G8B8A8_UNORM;
+                    convFlags |= CONV_FLAGS_L8 | CONV_FLAGS_EXPAND;
+                    break;
+
+                case DXGI_FORMAT_R8G8_UNORM:
+                    metadata.format = DXGI_FORMAT_R8G8B8A8_UNORM;
+                    convFlags |= CONV_FLAGS_A8L8 | CONV_FLAGS_EXPAND;
+                    break;
+
+                case DXGI_FORMAT_R16_UNORM:
+                    metadata.format = DXGI_FORMAT_R16G16B16A16_UNORM;
+                    convFlags |= CONV_FLAGS_L16 | CONV_FLAGS_EXPAND;
+                    break;
+
+                default:
+                    break;
+                }
+            }
+        }
+
+        // Special flag for handling BGR DXGI 1.1 formats
+        if (flags & DDS_FLAGS_FORCE_RGB)
+        {
+            switch (metadata.format)
+            {
+            case DXGI_FORMAT_B8G8R8A8_UNORM:
+                metadata.format = DXGI_FORMAT_R8G8B8A8_UNORM;
+                convFlags |= CONV_FLAGS_SWIZZLE;
+                break;
+
+            case DXGI_FORMAT_B8G8R8X8_UNORM:
+                metadata.format = DXGI_FORMAT_R8G8B8A8_UNORM;
+                convFlags |= CONV_FLAGS_SWIZZLE | CONV_FLAGS_NOALPHA;
+                break;
+
+            case DXGI_FORMAT_B8G8R8A8_TYPELESS:
+                metadata.format = DXGI_FORMAT_R8G8B8A8_TYPELESS;
+                convFlags |= CONV_FLAGS_SWIZZLE;
+                break;
+
+            case DXGI_FORMAT_B8G8R8A8_UNORM_SRGB:
+                metadata.format = DXGI_FORMAT_R8G8B8A8_UNORM_SRGB;
+                convFlags |= CONV_FLAGS_SWIZZLE;
+                break;
+
+            case DXGI_FORMAT_B8G8R8X8_TYPELESS:
+                metadata.format = DXGI_FORMAT_R8G8B8A8_TYPELESS;
+                convFlags |= CONV_FLAGS_SWIZZLE | CONV_FLAGS_NOALPHA;
+                break;
+
+            case DXGI_FORMAT_B8G8R8X8_UNORM_SRGB:
+                metadata.format = DXGI_FORMAT_R8G8B8A8_UNORM_SRGB;
+                convFlags |= CONV_FLAGS_SWIZZLE | CONV_FLAGS_NOALPHA;
+                break;
+
+            default:
+                break;
+            }
+        }
+
+        // Special flag for handling 16bpp formats
+        if (flags & DDS_FLAGS_NO_16BPP)
+        {
+            switch (static_cast<int>(metadata.format))
+            {
+            case DXGI_FORMAT_B5G6R5_UNORM:
+            case DXGI_FORMAT_B5G5R5A1_UNORM:
+            case DXGI_FORMAT_B4G4R4A4_UNORM:
+            case WIN11_DXGI_FORMAT_A4B4G4R4_UNORM:
+                if (metadata.format == DXGI_FORMAT_B5G6R5_UNORM)
+                {
+                    convFlags |= CONV_FLAGS_NOALPHA;
+                }
+                if (metadata.format == WIN11_DXGI_FORMAT_A4B4G4R4_UNORM)
+                {
+                    convFlags |= CONV_FLAGS_4444 | CONF_FLAGS_11ON12;
+                }
+                metadata.format = DXGI_FORMAT_R8G8B8A8_UNORM;
+                convFlags |= CONV_FLAGS_EXPAND;
+                break;
+
+            default:
+                break;
+            }
+        }
+
+        // Implicit alpha mode
+        if (convFlags & CONV_FLAGS_NOALPHA)
+        {
+            metadata.SetAlphaMode(TEX_ALPHA_MODE_OPAQUE);
+        }
+        else if (convFlags & CONV_FLAGS_PMALPHA)
+        {
+            metadata.SetAlphaMode(TEX_ALPHA_MODE_PREMULTIPLIED);
+        }
+
+        // Check for .dds files that exceed known hardware support
+        if (!(flags & DDS_FLAGS_ALLOW_LARGE_FILES))
+        {
+            // 16k is the maximum required resource size supported by Direct3D
+            if (metadata.width > 16384u /* D3D12_REQ_TEXTURE1D_U_DIMENSION, D3D12_REQ_TEXTURE2D_U_OR_V_DIMENSION */
+                || metadata.height > 16384u /* D3D12_REQ_TEXTURE2D_U_OR_V_DIMENSION */
+                || metadata.mipLevels > 15u /* D3D12_REQ_MIP_LEVELS */)
+            {
+                return HRESULT_E_NOT_SUPPORTED;
+            }
+
+            // 2048 is the maximum required depth/array size supported by Direct3D
+            if (metadata.arraySize > 2048u /* D3D12_REQ_TEXTURE1D_ARRAY_AXIS_DIMENSION, D3D12_REQ_TEXTURE2D_ARRAY_AXIS_DIMENSION */
+                || metadata.depth > 2048u /* D3D12_REQ_TEXTURE3D_U_V_OR_W_DIMENSION */)
+            {
+                return HRESULT_E_NOT_SUPPORTED;
+            }
+        }
+
+        // Handle DDS-specific metadata
+        if (ddPixelFormat)
+        {
+            ddPixelFormat->size = pHeader->ddspf.size;
+            ddPixelFormat->flags = pHeader->ddspf.flags;
+            ddPixelFormat->fourCC = pHeader->ddspf.fourCC;
+            ddPixelFormat->RGBBitCount = pHeader->ddspf.RGBBitCount;
+            ddPixelFormat->RBitMask = pHeader->ddspf.RBitMask;
+            ddPixelFormat->GBitMask = pHeader->ddspf.GBitMask;
+            ddPixelFormat->BBitMask = pHeader->ddspf.BBitMask;
+            ddPixelFormat->ABitMask = pHeader->ddspf.ABitMask;
+        }
+
+        return S_OK;
+    }
+}
+
+
+//-------------------------------------------------------------------------------------
+// Encodes DDS file header (magic value, header, optional DX10 extended header)
+//-------------------------------------------------------------------------------------
+_Use_decl_annotations_
+HRESULT DirectX::EncodeDDSHeader(
+    const TexMetadata& metadata,
+    DDS_FLAGS flags,
+    void* pDestination,
+    size_t maxsize,
+    size_t& required) noexcept
+{
+    if (!IsValid(metadata.format))
+        return E_INVALIDARG;
+
+    if (IsPalettized(metadata.format))
+        return HRESULT_E_NOT_SUPPORTED;
+
+    if (metadata.arraySize > 1)
+    {
+        if ((metadata.arraySize != 6) || (metadata.dimension != TEX_DIMENSION_TEXTURE2D) || !(metadata.IsCubemap()))
+        {
+            // Texture1D arrays, Texture2D arrays, and Cubemap arrays must be stored using 'DX10' extended header
+            if (flags & DDS_FLAGS_FORCE_DX9_LEGACY)
+                return HRESULT_E_CANNOT_MAKE;
+
+            flags |= DDS_FLAGS_FORCE_DX10_EXT;
+        }
+    }
+
+    if (flags & DDS_FLAGS_FORCE_DX10_EXT_MISC2)
+    {
+        flags |= DDS_FLAGS_FORCE_DX10_EXT;
+    }
+
+	bool forceRGB = (flags & DDS_FLAGS_FORCE_RGB) != 0;
+
+    DDS_PIXELFORMAT ddpf = {};
+    if (!(flags & DDS_FLAGS_FORCE_DX10_EXT))
+    {
+        if (forceRGB) 
+        {
+            switch (metadata.format) 
+            {
+            case DXGI_FORMAT_B8G8R8A8_TYPELESS:
+            case DXGI_FORMAT_B8G8R8A8_UNORM:
+            case DXGI_FORMAT_B8G8R8A8_UNORM_SRGB:
+            case DXGI_FORMAT_B8G8R8X8_UNORM:
+            case DXGI_FORMAT_B8G8R8X8_UNORM_SRGB:
+                memcpy(&ddpf, &DDSPF_R8G8B8, sizeof(DDS_PIXELFORMAT));
+                break;
+            default:
+                break;
+            }
+        }
+        else 
+        {
+            switch (metadata.format)
+            {
+            case DXGI_FORMAT_R8G8B8A8_UNORM:        memcpy(&ddpf, &DDSPF_A8B8G8R8, sizeof(DDS_PIXELFORMAT)); break;
+            case DXGI_FORMAT_R16G16_UNORM:          memcpy(&ddpf, &DDSPF_G16R16, sizeof(DDS_PIXELFORMAT)); break;
+            case DXGI_FORMAT_R8G8_UNORM:            memcpy(&ddpf, &DDSPF_A8L8, sizeof(DDS_PIXELFORMAT)); break;
+            case DXGI_FORMAT_R16_UNORM:             memcpy(&ddpf, &DDSPF_L16, sizeof(DDS_PIXELFORMAT)); break;
+            case DXGI_FORMAT_R8_UNORM:              memcpy(&ddpf, &DDSPF_L8, sizeof(DDS_PIXELFORMAT)); break;
+            case DXGI_FORMAT_A8_UNORM:              memcpy(&ddpf, &DDSPF_A8, sizeof(DDS_PIXELFORMAT)); break;
+            case DXGI_FORMAT_R8G8_B8G8_UNORM:       memcpy(&ddpf, &DDSPF_R8G8_B8G8, sizeof(DDS_PIXELFORMAT)); break;
+            case DXGI_FORMAT_G8R8_G8B8_UNORM:       memcpy(&ddpf, &DDSPF_G8R8_G8B8, sizeof(DDS_PIXELFORMAT)); break;
+            case DXGI_FORMAT_BC1_UNORM:             memcpy(&ddpf, &DDSPF_DXT1, sizeof(DDS_PIXELFORMAT)); break;
+            case DXGI_FORMAT_BC2_UNORM:             memcpy(&ddpf, metadata.IsPMAlpha() ? (&DDSPF_DXT2) : (&DDSPF_DXT3), sizeof(DDS_PIXELFORMAT)); break;
+            case DXGI_FORMAT_BC4_SNORM:             memcpy(&ddpf, &DDSPF_BC4_SNORM, sizeof(DDS_PIXELFORMAT)); break;
+            case DXGI_FORMAT_BC5_SNORM:             memcpy(&ddpf, &DDSPF_BC5_SNORM, sizeof(DDS_PIXELFORMAT)); break;
+            case DXGI_FORMAT_B5G6R5_UNORM:          memcpy(&ddpf, &DDSPF_R5G6B5, sizeof(DDS_PIXELFORMAT)); break;
+            case DXGI_FORMAT_B5G5R5A1_UNORM:        memcpy(&ddpf, &DDSPF_A1R5G5B5, sizeof(DDS_PIXELFORMAT)); break;
+            case DXGI_FORMAT_R8G8_SNORM:            memcpy(&ddpf, &DDSPF_V8U8, sizeof(DDS_PIXELFORMAT)); break;
+            case DXGI_FORMAT_R8G8B8A8_SNORM:        memcpy(&ddpf, &DDSPF_Q8W8V8U8, sizeof(DDS_PIXELFORMAT)); break;
+            case DXGI_FORMAT_R16G16_SNORM:          memcpy(&ddpf, &DDSPF_V16U16, sizeof(DDS_PIXELFORMAT)); break;
+            case DXGI_FORMAT_B8G8R8A8_UNORM:        memcpy(&ddpf, &DDSPF_A8R8G8B8, sizeof(DDS_PIXELFORMAT)); break; // DXGI 1.1
+            case DXGI_FORMAT_B8G8R8X8_UNORM:        memcpy(&ddpf, &DDSPF_X8R8G8B8, sizeof(DDS_PIXELFORMAT)); break; // DXGI 1.1
+            case DXGI_FORMAT_B4G4R4A4_UNORM:        memcpy(&ddpf, &DDSPF_A4R4G4B4, sizeof(DDS_PIXELFORMAT)); break; // DXGI 1.2
+            case DXGI_FORMAT_YUY2:                  memcpy(&ddpf, &DDSPF_YUY2, sizeof(DDS_PIXELFORMAT)); break; // DXGI 1.2
+
+            case DXGI_FORMAT_BC3_UNORM:
+                memcpy(&ddpf, metadata.IsPMAlpha() ? (&DDSPF_DXT4) : (&DDSPF_DXT5), sizeof(DDS_PIXELFORMAT));
+                if (flags & DDS_FLAGS_FORCE_DXT5_RXGB)
+                {
+                    ddpf.fourCC = MAKEFOURCC('R', 'X', 'G', 'B');
+                }
+                break;
+
+                // Legacy D3DX formats using D3DFMT enum value as FourCC
+            case DXGI_FORMAT_R32G32B32A32_FLOAT:
+                ddpf.size = sizeof(DDS_PIXELFORMAT); ddpf.flags = DDS_FOURCC; ddpf.fourCC = 116;  // D3DFMT_A32B32G32R32F
+                break;
+            case DXGI_FORMAT_R16G16B16A16_FLOAT:
+                ddpf.size = sizeof(DDS_PIXELFORMAT); ddpf.flags = DDS_FOURCC; ddpf.fourCC = 113;  // D3DFMT_A16B16G16R16F
+                break;
+            case DXGI_FORMAT_R16G16B16A16_UNORM:
+                ddpf.size = sizeof(DDS_PIXELFORMAT); ddpf.flags = DDS_FOURCC; ddpf.fourCC = 36;  // D3DFMT_A16B16G16R16
+                break;
+            case DXGI_FORMAT_R16G16B16A16_SNORM:
+                ddpf.size = sizeof(DDS_PIXELFORMAT); ddpf.flags = DDS_FOURCC; ddpf.fourCC = 110;  // D3DFMT_Q16W16V16U16
+                break;
+            case DXGI_FORMAT_R32G32_FLOAT:
+                ddpf.size = sizeof(DDS_PIXELFORMAT); ddpf.flags = DDS_FOURCC; ddpf.fourCC = 115;  // D3DFMT_G32R32F
+                break;
+            case DXGI_FORMAT_R16G16_FLOAT:
+                ddpf.size = sizeof(DDS_PIXELFORMAT); ddpf.flags = DDS_FOURCC; ddpf.fourCC = 112;  // D3DFMT_G16R16F
+                break;
+            case DXGI_FORMAT_R32_FLOAT:
+                ddpf.size = sizeof(DDS_PIXELFORMAT); ddpf.flags = DDS_FOURCC; ddpf.fourCC = 114;  // D3DFMT_R32F
+                break;
+            case DXGI_FORMAT_R16_FLOAT:
+                ddpf.size = sizeof(DDS_PIXELFORMAT); ddpf.flags = DDS_FOURCC; ddpf.fourCC = 111;  // D3DFMT_R16F
+                break;
+
+                // DX9 legacy pixel formats
+            case DXGI_FORMAT_R10G10B10A2_UNORM:
+                if (flags & DDS_FLAGS_FORCE_DX9_LEGACY)
+                {
+                    // Write using the 'incorrect' mask version to match D3DX bug
+                    memcpy(&ddpf, &DDSPF_A2B10G10R10, sizeof(DDS_PIXELFORMAT));
+                }
+                break;
+
+            case DXGI_FORMAT_R8G8B8A8_UNORM_SRGB:
+                if (flags & DDS_FLAGS_FORCE_DX9_LEGACY)
+                {
+                    memcpy(&ddpf, &DDSPF_A8B8G8R8, sizeof(DDS_PIXELFORMAT));
+                }
+                break;
+
+            case DXGI_FORMAT_BC1_UNORM_SRGB:
+                if (flags & DDS_FLAGS_FORCE_DX9_LEGACY)
+                {
+                    memcpy(&ddpf, &DDSPF_DXT1, sizeof(DDS_PIXELFORMAT));
+                }
+                break;
+
+            case DXGI_FORMAT_BC2_UNORM_SRGB:
+                if (flags & DDS_FLAGS_FORCE_DX9_LEGACY)
+                {
+                    memcpy(&ddpf, metadata.IsPMAlpha() ? (&DDSPF_DXT2) : (&DDSPF_DXT3), sizeof(DDS_PIXELFORMAT));
+                }
+                break;
+
+            case DXGI_FORMAT_BC3_UNORM_SRGB:
+                if (flags & DDS_FLAGS_FORCE_DX9_LEGACY)
+                {
+                    memcpy(&ddpf, metadata.IsPMAlpha() ? (&DDSPF_DXT4) : (&DDSPF_DXT5), sizeof(DDS_PIXELFORMAT));
+                }
+                break;
+
+            case DXGI_FORMAT_BC4_UNORM:
+                memcpy(&ddpf, &DDSPF_BC4_UNORM, sizeof(DDS_PIXELFORMAT));
+                if (flags & DDS_FLAGS_FORCE_DX9_LEGACY)
+                {
+                    ddpf.fourCC = MAKEFOURCC('A', 'T', 'I', '1');
+                }
+                break;
+
+            case DXGI_FORMAT_BC5_UNORM:
+                memcpy(&ddpf, &DDSPF_BC5_UNORM, sizeof(DDS_PIXELFORMAT));
+                if (flags & DDS_FLAGS_FORCE_DX9_LEGACY)
+                {
+                    ddpf.fourCC = MAKEFOURCC('A', 'T', 'I', '2');
+                }
+                break;
+
+            case DXGI_FORMAT_B8G8R8A8_UNORM_SRGB:
+                if (flags & DDS_FLAGS_FORCE_DX9_LEGACY)
+                {
+                    memcpy(&ddpf, &DDSPF_A8R8G8B8, sizeof(DDS_PIXELFORMAT));
+                }
+                break;
+
+            case DXGI_FORMAT_B8G8R8X8_UNORM_SRGB:
+                if (flags & DDS_FLAGS_FORCE_DX9_LEGACY)
+                {
+                    memcpy(&ddpf, &DDSPF_X8R8G8B8, sizeof(DDS_PIXELFORMAT));
+                }
+                break;
+
+            default:
+                break;
+            }
+        }
+    }
+
+    required = sizeof(uint32_t) + sizeof(DDS_HEADER);
+
+    if (ddpf.size == 0)
+    {
+        if (flags & DDS_FLAGS_FORCE_DX9_LEGACY)
+            return HRESULT_E_CANNOT_MAKE;
+
+        required += sizeof(DDS_HEADER_DXT10);
+    }
+
+    if (!pDestination)
+        return S_OK;
+
+    if (maxsize < required)
+        return E_NOT_SUFFICIENT_BUFFER;
+
+    *static_cast<uint32_t*>(pDestination) = DDS_MAGIC;
+
+    auto header = reinterpret_cast<DDS_HEADER*>(static_cast<uint8_t*>(pDestination) + sizeof(uint32_t));
+    assert(header);
+
+    memset(header, 0, sizeof(DDS_HEADER));
+    header->size = sizeof(DDS_HEADER);
+    header->flags = DDS_HEADER_FLAGS_TEXTURE;
+    header->caps = DDS_SURFACE_FLAGS_TEXTURE;
+
+    if (metadata.mipLevels > 0)
+    {
+        header->flags |= DDS_HEADER_FLAGS_MIPMAP;
+
+        if (metadata.mipLevels > UINT16_MAX)
+            return E_INVALIDARG;
+
+        header->mipMapCount = static_cast<uint32_t>(metadata.mipLevels);
+
+        if (header->mipMapCount > 1)
+            header->caps |= DDS_SURFACE_FLAGS_MIPMAP;
+    }
+
+    switch (metadata.dimension)
+    {
+    case TEX_DIMENSION_TEXTURE1D:
+        if (metadata.width > UINT32_MAX)
+            return E_INVALIDARG;
+
+        header->width = static_cast<uint32_t>(metadata.width);
+        header->height = header->depth = 1;
+        break;
+
+    case TEX_DIMENSION_TEXTURE2D:
+        if (metadata.height > UINT32_MAX
+            || metadata.width > UINT32_MAX)
+            return E_INVALIDARG;
+
+        header->height = static_cast<uint32_t>(metadata.height);
+        header->width = static_cast<uint32_t>(metadata.width);
+        header->depth = 1;
+
+        if (metadata.IsCubemap())
+        {
+            header->caps |= DDS_SURFACE_FLAGS_CUBEMAP;
+            header->caps2 |= DDS_CUBEMAP_ALLFACES;
+        }
+        break;
+
+    case TEX_DIMENSION_TEXTURE3D:
+        if (metadata.height > UINT32_MAX
+            || metadata.width > UINT32_MAX
+            || metadata.depth > UINT16_MAX)
+            return E_INVALIDARG;
+
+        header->flags |= DDS_HEADER_FLAGS_VOLUME;
+        header->caps2 |= DDS_FLAGS_VOLUME;
+        header->height = static_cast<uint32_t>(metadata.height);
+        header->width = static_cast<uint32_t>(metadata.width);
+        header->depth = static_cast<uint32_t>(metadata.depth);
+        break;
+
+    default:
+        return E_FAIL;
+    }
+
+    size_t rowPitch, slicePitch;
+    HRESULT hr = ComputePitch(metadata.format, metadata.width, metadata.height, rowPitch, slicePitch, forceRGB ? CP_FLAGS_24BPP : CP_FLAGS_NONE);
+    if (FAILED(hr))
+        return hr;
+
+    if (slicePitch > UINT32_MAX
+        || rowPitch > UINT32_MAX)
+        return E_FAIL;
+
+    if (IsCompressed(metadata.format))
+    {
+        header->flags |= DDS_HEADER_FLAGS_LINEARSIZE;
+        header->pitchOrLinearSize = static_cast<uint32_t>(slicePitch);
+    }
+    else
+    {
+        header->flags |= DDS_HEADER_FLAGS_PITCH;
+        header->pitchOrLinearSize = static_cast<uint32_t>(rowPitch);
+    }
+
+    if (ddpf.size == 0)
+    {
+        memcpy(&header->ddspf, &DDSPF_DX10, sizeof(DDS_PIXELFORMAT));
+
+        auto ext = reinterpret_cast<DDS_HEADER_DXT10*>(reinterpret_cast<uint8_t*>(header) + sizeof(DDS_HEADER));
+        assert(ext);
+
+        memset(ext, 0, sizeof(DDS_HEADER_DXT10));
+        ext->dxgiFormat = metadata.format;
+        ext->resourceDimension = metadata.dimension;
+
+        if (metadata.arraySize > UINT16_MAX)
+            return E_INVALIDARG;
+
+        static_assert(static_cast<int>(TEX_MISC_TEXTURECUBE) == static_cast<int>(DDS_RESOURCE_MISC_TEXTURECUBE), "DDS header mismatch");
+
+        ext->miscFlag = metadata.miscFlags & ~static_cast<uint32_t>(TEX_MISC_TEXTURECUBE);
+
+        if (metadata.miscFlags & TEX_MISC_TEXTURECUBE)
+        {
+            ext->miscFlag |= TEX_MISC_TEXTURECUBE;
+            assert((metadata.arraySize % 6) == 0);
+            ext->arraySize = static_cast<UINT>(metadata.arraySize / 6);
+        }
+        else
+        {
+            ext->arraySize = static_cast<UINT>(metadata.arraySize);
+        }
+
+        static_assert(static_cast<int>(TEX_MISC2_ALPHA_MODE_MASK) == static_cast<int>(DDS_MISC_FLAGS2_ALPHA_MODE_MASK), "DDS header mismatch");
+
+        static_assert(static_cast<int>(TEX_ALPHA_MODE_UNKNOWN) == static_cast<int>(DDS_ALPHA_MODE_UNKNOWN), "DDS header mismatch");
+        static_assert(static_cast<int>(TEX_ALPHA_MODE_STRAIGHT) == static_cast<int>(DDS_ALPHA_MODE_STRAIGHT), "DDS header mismatch");
+        static_assert(static_cast<int>(TEX_ALPHA_MODE_PREMULTIPLIED) == static_cast<int>(DDS_ALPHA_MODE_PREMULTIPLIED), "DDS header mismatch");
+        static_assert(static_cast<int>(TEX_ALPHA_MODE_OPAQUE) == static_cast<int>(DDS_ALPHA_MODE_OPAQUE), "DDS header mismatch");
+        static_assert(static_cast<int>(TEX_ALPHA_MODE_CUSTOM) == static_cast<int>(DDS_ALPHA_MODE_CUSTOM), "DDS header mismatch");
+
+        if (flags & DDS_FLAGS_FORCE_DX10_EXT_MISC2)
+        {
+            // This was formerly 'reserved'. D3DX10 and D3DX11 will fail if this value is anything other than 0
+            ext->miscFlags2 = metadata.miscFlags2;
+        }
+    }
+    else
+    {
+        memcpy(&header->ddspf, &ddpf, sizeof(ddpf));
+    }
+
+    return S_OK;
+}
+
+
+namespace
+{
+    //-------------------------------------------------------------------------------------
+    // Converts an image row with optional clearing of alpha value to 1.0
+    // Returns true if supported, false if expansion case not supported
+    //-------------------------------------------------------------------------------------
+    enum TEXP_LEGACY_FORMAT
+    {
+        TEXP_LEGACY_UNKNOWN = 0,
+        TEXP_LEGACY_R8G8B8,
+        TEXP_LEGACY_R3G3B2,
+        TEXP_LEGACY_A8R3G3B2,
+        TEXP_LEGACY_P8,
+        TEXP_LEGACY_A8P8,
+        TEXP_LEGACY_A4L4,
+        TEXP_LEGACY_B4G4R4A4,
+        TEXP_LEGACY_L8,
+        TEXP_LEGACY_L16,
+        TEXP_LEGACY_A8L8
+    };
+
+    constexpr TEXP_LEGACY_FORMAT FindLegacyFormat(uint32_t flags) noexcept
+    {
+        TEXP_LEGACY_FORMAT lformat = TEXP_LEGACY_UNKNOWN;
+
+        if (flags & CONV_FLAGS_PAL8)
+        {
+            lformat = (flags & CONV_FLAGS_A8P8) ? TEXP_LEGACY_A8P8 : TEXP_LEGACY_P8;
+        }
+        else if (flags & CONV_FLAGS_888)
+            lformat = TEXP_LEGACY_R8G8B8;
+        else if (flags & CONV_FLAGS_332)
+            lformat = TEXP_LEGACY_R3G3B2;
+        else if (flags & CONV_FLAGS_8332)
+            lformat = TEXP_LEGACY_A8R3G3B2;
+        else if (flags & CONV_FLAGS_44)
+            lformat = TEXP_LEGACY_A4L4;
+        else if (flags & CONV_FLAGS_4444)
+            lformat = TEXP_LEGACY_B4G4R4A4;
+        else if (flags & CONV_FLAGS_L8)
+            lformat = TEXP_LEGACY_L8;
+        else if (flags & CONV_FLAGS_L16)
+            lformat = TEXP_LEGACY_L16;
+        else if (flags & CONV_FLAGS_A8L8)
+            lformat = TEXP_LEGACY_A8L8;
+
+        return lformat;
+    }
+
+    _Success_(return)
+        bool LegacyExpandScanline(
+            _Out_writes_bytes_(outSize) void* pDestination,
+            size_t outSize,
+            _In_ DXGI_FORMAT outFormat,
+            _In_reads_bytes_(inSize) const void* pSource,
+            size_t inSize,
+            _In_ TEXP_LEGACY_FORMAT inFormat,
+            _In_reads_opt_(256) const uint32_t* pal8,
+            _In_ uint32_t tflags) noexcept
+    {
+        assert(pDestination && outSize > 0);
+        assert(pSource && inSize > 0);
+        assert(IsValid(outFormat) && !IsPlanar(outFormat) && !IsPalettized(outFormat));
+
+        switch (inFormat)
+        {
+        case TEXP_LEGACY_R8G8B8:
+            if (outFormat != DXGI_FORMAT_R8G8B8A8_UNORM)
+                return false;
+
+            // D3DFMT_R8G8B8 -> DXGI_FORMAT_R8G8B8A8_UNORM
+            if (inSize >= 3 && outSize >= 4)
+            {
+                const uint8_t * __restrict sPtr = static_cast<const uint8_t*>(pSource);
+                uint32_t * __restrict dPtr = static_cast<uint32_t*>(pDestination);
+
+                for (size_t ocount = 0, icount = 0; ((icount < (inSize - 2)) && (ocount < (outSize - 3))); icount += 3, ocount += 4)
+                {
+                    // 24bpp Direct3D 9 files are actually BGR, so need to swizzle as well
+                    uint32_t t1 = uint32_t(*(sPtr) << 16);
+                    uint32_t t2 = uint32_t(*(sPtr + 1) << 8);
+                    uint32_t t3 = uint32_t(*(sPtr + 2));
+
+                    *(dPtr++) = t1 | t2 | t3 | 0xff000000;
+                    sPtr += 3;
+                }
+                return true;
+            }
+            return false;
+
+        case TEXP_LEGACY_R3G3B2:
+            switch (outFormat)
+            {
+            case DXGI_FORMAT_R8G8B8A8_UNORM:
+                // D3DFMT_R3G3B2 -> DXGI_FORMAT_R8G8B8A8_UNORM
+                if (inSize >= 1 && outSize >= 4)
+                {
+                    const uint8_t* __restrict sPtr = static_cast<const uint8_t*>(pSource);
+                    uint32_t * __restrict dPtr = static_cast<uint32_t*>(pDestination);
+
+                    for (size_t ocount = 0, icount = 0; ((icount < inSize) && (ocount < (outSize - 3))); ++icount, ocount += 4)
+                    {
+                        const uint8_t t = *(sPtr++);
+
+                        uint32_t t1 = uint32_t((t & 0xe0) | ((t & 0xe0) >> 3) | ((t & 0xc0) >> 6));
+                        uint32_t t2 = uint32_t(((t & 0x1c) << 11) | ((t & 0x1c) << 8) | ((t & 0x18) << 5));
+                        uint32_t t3 = uint32_t(((t & 0x03) << 22) | ((t & 0x03) << 20) | ((t & 0x03) << 18) | ((t & 0x03) << 16));
+
+                        *(dPtr++) = t1 | t2 | t3 | 0xff000000;
+                    }
+                    return true;
+                }
+                return false;
+
+            case DXGI_FORMAT_B5G6R5_UNORM:
+                // D3DFMT_R3G3B2 -> DXGI_FORMAT_B5G6R5_UNORM
+                if (inSize >= 1 && outSize >= 2)
+                {
+                    const uint8_t* __restrict sPtr = static_cast<const uint8_t*>(pSource);
+                    uint16_t * __restrict dPtr = static_cast<uint16_t*>(pDestination);
+
+                    for (size_t ocount = 0, icount = 0; ((icount < inSize) && (ocount < (outSize - 1))); ++icount, ocount += 2)
+                    {
+                        const unsigned t = *(sPtr++);
+
+                        unsigned t1 = ((t & 0xe0u) << 8) | ((t & 0xc0u) << 5);
+                        unsigned t2 = ((t & 0x1cu) << 6) | ((t & 0x1cu) << 3);
+                        unsigned t3 = ((t & 0x03u) << 3) | ((t & 0x03u) << 1) | ((t & 0x02) >> 1);
+
+                        *(dPtr++) = static_cast<uint16_t>(t1 | t2 | t3);
+                    }
+                    return true;
+                }
+                return false;
+
+            default:
+                return false;
+            }
+
+        case TEXP_LEGACY_A8R3G3B2:
+            if (outFormat != DXGI_FORMAT_R8G8B8A8_UNORM)
+                return false;
+
+            // D3DFMT_A8R3G3B2 -> DXGI_FORMAT_R8G8B8A8_UNORM
+            if (inSize >= 2 && outSize >= 4)
+            {
+                const uint16_t* __restrict sPtr = static_cast<const uint16_t*>(pSource);
+                uint32_t * __restrict dPtr = static_cast<uint32_t*>(pDestination);
+
+                for (size_t ocount = 0, icount = 0; ((icount < (inSize - 1)) && (ocount < (outSize - 3))); icount += 2, ocount += 4)
+                {
+                    const uint16_t t = *(sPtr++);
+
+                    uint32_t t1 = uint32_t((t & 0x00e0) | ((t & 0x00e0) >> 3) | ((t & 0x00c0) >> 6));
+                    uint32_t t2 = uint32_t(((t & 0x001c) << 11) | ((t & 0x001c) << 8) | ((t & 0x0018) << 5));
+                    uint32_t t3 = uint32_t(((t & 0x0003) << 22) | ((t & 0x0003) << 20) | ((t & 0x0003) << 18) | ((t & 0x0003) << 16));
+                    uint32_t ta = (tflags & TEXP_SCANLINE_SETALPHA) ? 0xff000000 : uint32_t((t & 0xff00) << 16);
+
+                    *(dPtr++) = t1 | t2 | t3 | ta;
+                }
+                return true;
+            }
+            return false;
+
+        case TEXP_LEGACY_P8:
+            if ((outFormat != DXGI_FORMAT_R8G8B8A8_UNORM) || !pal8)
+                return false;
+
+            // D3DFMT_P8 -> DXGI_FORMAT_R8G8B8A8_UNORM
+            if (inSize >= 1 && outSize >= 4)
+            {
+                const uint8_t* __restrict sPtr = static_cast<const uint8_t*>(pSource);
+                uint32_t * __restrict dPtr = static_cast<uint32_t*>(pDestination);
+
+                for (size_t ocount = 0, icount = 0; ((icount < inSize) && (ocount < (outSize - 3))); ++icount, ocount += 4)
+                {
+                    uint8_t t = *(sPtr++);
+
+                    *(dPtr++) = pal8[t];
+                }
+                return true;
+            }
+            return false;
+
+        case TEXP_LEGACY_A8P8:
+            if ((outFormat != DXGI_FORMAT_R8G8B8A8_UNORM) || !pal8)
+                return false;
+
+            // D3DFMT_A8P8 -> DXGI_FORMAT_R8G8B8A8_UNORM
+            if (inSize >= 2 && outSize >= 4)
+            {
+                const uint16_t* __restrict sPtr = static_cast<const uint16_t*>(pSource);
+                uint32_t * __restrict dPtr = static_cast<uint32_t*>(pDestination);
+
+                for (size_t ocount = 0, icount = 0; ((icount < (inSize - 1)) && (ocount < (outSize - 3))); icount += 2, ocount += 4)
+                {
+                    const uint16_t t = *(sPtr++);
+
+                    uint32_t t1 = pal8[t & 0xff];
+                    uint32_t ta = (tflags & TEXP_SCANLINE_SETALPHA) ? 0xff000000 : uint32_t((t & 0xff00) << 16);
+
+                    *(dPtr++) = t1 | ta;
+                }
+                return true;
+            }
+            return false;
+
+        case TEXP_LEGACY_A4L4:
+            switch (outFormat)
+            {
+            case DXGI_FORMAT_B4G4R4A4_UNORM:
+                // D3DFMT_A4L4 -> DXGI_FORMAT_B4G4R4A4_UNORM
+                if (inSize >= 1 && outSize >= 2)
+                {
+                    const uint8_t * __restrict sPtr = static_cast<const uint8_t*>(pSource);
+                    uint16_t * __restrict dPtr = static_cast<uint16_t*>(pDestination);
+
+                    for (size_t ocount = 0, icount = 0; ((icount < inSize) && (ocount < (outSize - 1))); ++icount, ocount += 2)
+                    {
+                        const unsigned t = *(sPtr++);
+
+                        unsigned t1 = (t & 0x0fu);
+                        unsigned ta = (tflags & TEXP_SCANLINE_SETALPHA) ? 0xf000u : ((t & 0xf0u) << 8);
+
+                        *(dPtr++) = static_cast<uint16_t>(t1 | (t1 << 4) | (t1 << 8) | ta);
+                    }
+                    return true;
+                }
+                return false;
+
+            case DXGI_FORMAT_R8G8B8A8_UNORM:
+                // D3DFMT_A4L4 -> DXGI_FORMAT_R8G8B8A8_UNORM
+                if (inSize >= 1 && outSize >= 4)
+                {
+                    const uint8_t * __restrict sPtr = static_cast<const uint8_t*>(pSource);
+                    uint32_t * __restrict dPtr = static_cast<uint32_t*>(pDestination);
+
+                    for (size_t ocount = 0, icount = 0; ((icount < inSize) && (ocount < (outSize - 3))); ++icount, ocount += 4)
+                    {
+                        const uint8_t t = *(sPtr++);
+
+                        uint32_t t1 = uint32_t(((t & 0x0f) << 4) | (t & 0x0f));
+                        uint32_t ta = (tflags & TEXP_SCANLINE_SETALPHA) ? 0xff000000 : uint32_t(((t & 0xf0) << 24) | ((t & 0xf0) << 20));
+
+                        *(dPtr++) = t1 | (t1 << 8) | (t1 << 16) | ta;
+                    }
+                    return true;
+                }
+                return false;
+
+            default:
+                return false;
+            }
+
+        case TEXP_LEGACY_B4G4R4A4:
+            if (outFormat != DXGI_FORMAT_R8G8B8A8_UNORM)
+                return false;
+
+            // D3DFMT_A4R4G4B4 -> DXGI_FORMAT_R8G8B8A8_UNORM
+            if (inSize >= 2 && outSize >= 4)
+            {
+                const uint16_t * __restrict sPtr = static_cast<const uint16_t*>(pSource);
+                uint32_t * __restrict dPtr = static_cast<uint32_t*>(pDestination);
+
+                for (size_t ocount = 0, icount = 0; ((icount < (inSize - 1)) && (ocount < (outSize - 3))); icount += 2, ocount += 4)
+                {
+                    const uint32_t t = *(sPtr++);
+
+                    uint32_t t1 = uint32_t((t & 0x0f00) >> 4) | ((t & 0x0f00) >> 8);
+                    uint32_t t2 = uint32_t((t & 0x00f0) << 8) | ((t & 0x00f0) << 4);
+                    uint32_t t3 = uint32_t((t & 0x000f) << 20) | ((t & 0x000f) << 16);
+                    uint32_t ta = uint32_t((tflags & TEXP_SCANLINE_SETALPHA) ? 0xff000000 : (((t & 0xf000) << 16) | ((t & 0xf000) << 12)));
+
+                    *(dPtr++) = t1 | t2 | t3 | ta;
+                }
+                return true;
+            }
+            return false;
+
+        case TEXP_LEGACY_L8:
+            if (outFormat != DXGI_FORMAT_R8G8B8A8_UNORM)
+                return false;
+
+            // D3DFMT_L8 -> DXGI_FORMAT_R8G8B8A8_UNORM
+            if (inSize >= 1 && outSize >= 4)
+            {
+                const uint8_t * __restrict sPtr = static_cast<const uint8_t*>(pSource);
+                uint32_t * __restrict dPtr = static_cast<uint32_t*>(pDestination);
+
+                for (size_t ocount = 0, icount = 0; ((icount < inSize) && (ocount < (outSize - 3))); ++icount, ocount += 4)
+                {
+                    uint32_t t1 = *(sPtr++);
+                    uint32_t t2 = (t1 << 8);
+                    uint32_t t3 = (t1 << 16);
+
+                    *(dPtr++) = t1 | t2 | t3 | 0xff000000;
+                }
+                return true;
+            }
+            return false;
+
+        case TEXP_LEGACY_L16:
+            if (outFormat != DXGI_FORMAT_R16G16B16A16_UNORM)
+                return false;
+
+            // D3DFMT_L16 -> DXGI_FORMAT_R16G16B16A16_UNORM
+            if (inSize >= 2 && outSize >= 8)
+            {
+                const uint16_t* __restrict sPtr = static_cast<const uint16_t*>(pSource);
+                uint64_t * __restrict dPtr = static_cast<uint64_t*>(pDestination);
+
+                for (size_t ocount = 0, icount = 0; ((icount < (inSize - 1)) && (ocount < (outSize - 7))); icount += 2, ocount += 8)
+                {
+                    const uint16_t t = *(sPtr++);
+
+                    uint64_t t1 = t;
+                    uint64_t t2 = (t1 << 16);
+                    uint64_t t3 = (t1 << 32);
+
+                    *(dPtr++) = t1 | t2 | t3 | 0xffff000000000000;
+                }
+                return true;
+            }
+            return false;
+
+        case TEXP_LEGACY_A8L8:
+            if (outFormat != DXGI_FORMAT_R8G8B8A8_UNORM)
+                return false;
+
+            // D3DFMT_A8L8 -> DXGI_FORMAT_R8G8B8A8_UNORM
+            if (inSize >= 2 && outSize >= 4)
+            {
+                const uint16_t* __restrict sPtr = static_cast<const uint16_t*>(pSource);
+                uint32_t * __restrict dPtr = static_cast<uint32_t*>(pDestination);
+
+                for (size_t ocount = 0, icount = 0; ((icount < (inSize - 1)) && (ocount < (outSize - 3))); icount += 2, ocount += 4)
+                {
+                    const uint16_t t = *(sPtr++);
+
+                    uint32_t t1 = uint32_t(t & 0xff);
+                    uint32_t t2 = uint32_t(t1 << 8);
+                    uint32_t t3 = uint32_t(t1 << 16);
+                    uint32_t ta = (tflags & TEXP_SCANLINE_SETALPHA) ? 0xff000000 : uint32_t((t & 0xff00) << 16);
+
+                    *(dPtr++) = t1 | t2 | t3 | ta;
+                }
+                return true;
+            }
+            return false;
+
+        default:
+            return false;
+        }
+    }
+
+
+    //-------------------------------------------------------------------------------------
+    // Converts or copies image data from pPixels into scratch image data
+    //-------------------------------------------------------------------------------------
+    HRESULT CopyImage(
+        _In_reads_bytes_(size) const void* pPixels,
+        _In_ size_t size,
+        _In_ const TexMetadata& metadata,
+        _In_ CP_FLAGS cpFlags,
+        _In_ uint32_t convFlags,
+        _In_reads_opt_(256) const uint32_t *pal8,
+        _In_ const ScratchImage& image) noexcept
+    {
+        assert(pPixels);
+        assert(image.GetPixels());
+
+        if (!size)
+            return E_FAIL;
+
+        if (convFlags & CONV_FLAGS_EXPAND)
+        {
+            if (convFlags & CONV_FLAGS_888)
+                cpFlags |= CP_FLAGS_24BPP;
+            else if (convFlags & (CONV_FLAGS_565 | CONV_FLAGS_5551 | CONV_FLAGS_4444 | CONV_FLAGS_8332 | CONV_FLAGS_A8P8 | CONV_FLAGS_L16 | CONV_FLAGS_A8L8))
+                cpFlags |= CP_FLAGS_16BPP;
+            else if (convFlags & (CONV_FLAGS_44 | CONV_FLAGS_332 | CONV_FLAGS_PAL8 | CONV_FLAGS_L8))
+                cpFlags |= CP_FLAGS_8BPP;
+        }
+
+        size_t pixelSize, nimages;
+        HRESULT hr = DetermineImageArray(metadata, cpFlags, nimages, pixelSize);
+        if (FAILED(hr))
+            return hr;
+
+        if ((nimages == 0) || (nimages != image.GetImageCount()))
+        {
+            return E_FAIL;
+        }
+
+        if (pixelSize > size)
+        {
+            return HRESULT_E_HANDLE_EOF;
+        }
+
+        std::unique_ptr<Image[]> timages(new (std::nothrow) Image[nimages]);
+        if (!timages)
+        {
+            return E_OUTOFMEMORY;
+        }
+
+        if (!SetupImageArray(
+            const_cast<uint8_t*>(reinterpret_cast<const uint8_t*>(pPixels)),
+            pixelSize,
+            metadata,
+            cpFlags,
+            timages.get(),
+            nimages))
+        {
+            return E_FAIL;
+        }
+
+        if (nimages != image.GetImageCount())
+        {
+            return E_FAIL;
+        }
+
+        const Image* images = image.GetImages();
+        if (!images)
+        {
+            return E_FAIL;
+        }
+
+        uint32_t tflags = (convFlags & CONV_FLAGS_NOALPHA) ? TEXP_SCANLINE_SETALPHA : 0u;
+        if (convFlags & CONV_FLAGS_SWIZZLE)
+            tflags |= TEXP_SCANLINE_LEGACY;
+
+        switch (metadata.dimension)
+        {
+        case TEX_DIMENSION_TEXTURE1D:
+        case TEX_DIMENSION_TEXTURE2D:
+            {
+                size_t index = 0;
+                for (size_t item = 0; item < metadata.arraySize; ++item)
+                {
+                    size_t lastgood = 0;
+                    for (size_t level = 0; level < metadata.mipLevels; ++level, ++index)
+                    {
+                        if (index >= nimages)
+                            return E_FAIL;
+
+                        if (images[index].height != timages[index].height)
+                            return E_FAIL;
+
+                        size_t dpitch = images[index].rowPitch;
+                        const size_t spitch = timages[index].rowPitch;
+
+                        const uint8_t *pSrc = timages[index].pixels;
+                        if (!pSrc)
+                            return E_POINTER;
+
+                        uint8_t *pDest = images[index].pixels;
+                        if (!pDest)
+                            return E_POINTER;
+
+                        if (IsCompressed(metadata.format))
+                        {
+                            size_t csize = std::min<size_t>(images[index].slicePitch, timages[index].slicePitch);
+                            memcpy(pDest, pSrc, csize);
+
+                            if (cpFlags & CP_FLAGS_BAD_DXTN_TAILS)
+                            {
+                                if (images[index].width < 4 || images[index].height < 4)
+                                {
+                                    csize = std::min<size_t>(images[index].slicePitch, timages[lastgood].slicePitch);
+                                    memcpy(pDest, timages[lastgood].pixels, csize);
+                                }
+                                else
+                                {
+                                    lastgood = index;
+                                }
+                            }
+                        }
+                        else if (IsPlanar(metadata.format))
+                        {
+                            const size_t count = ComputeScanlines(metadata.format, images[index].height);
+                            if (!count)
+                                return E_UNEXPECTED;
+
+                            const size_t csize = std::min<size_t>(dpitch, spitch);
+                            for (size_t h = 0; h < count; ++h)
+                            {
+                                memcpy(pDest, pSrc, csize);
+                                pSrc += spitch;
+                                pDest += dpitch;
+                            }
+                        }
+                        else
+                        {
+                            for (size_t h = 0; h < images[index].height; ++h)
+                            {
+                                if (convFlags & CONV_FLAGS_EXPAND)
+                                {
+                                    if (convFlags & CONV_FLAGS_4444)
+                                    {
+                                        if (!ExpandScanline(pDest, dpitch, DXGI_FORMAT_R8G8B8A8_UNORM,
+                                            pSrc, spitch,
+                                            (convFlags & CONF_FLAGS_11ON12) ? WIN11_DXGI_FORMAT_A4B4G4R4_UNORM : DXGI_FORMAT_B4G4R4A4_UNORM,
+                                            tflags))
+                                            return E_FAIL;
+                                    }
+                                    else if (convFlags & (CONV_FLAGS_565 | CONV_FLAGS_5551))
+                                    {
+                                        if (!ExpandScanline(pDest, dpitch, DXGI_FORMAT_R8G8B8A8_UNORM,
+                                            pSrc, spitch,
+                                            (convFlags & CONV_FLAGS_565) ? DXGI_FORMAT_B5G6R5_UNORM : DXGI_FORMAT_B5G5R5A1_UNORM,
+                                            tflags))
+                                            return E_FAIL;
+                                    }
+                                    else
+                                    {
+                                        const TEXP_LEGACY_FORMAT lformat = FindLegacyFormat(convFlags);
+                                        if (!LegacyExpandScanline(pDest, dpitch, metadata.format,
+                                            pSrc, spitch, lformat, pal8,
+                                            tflags))
+                                            return E_FAIL;
+                                    }
+                                }
+                                else if (convFlags & CONV_FLAGS_SWIZZLE)
+                                {
+                                    SwizzleScanline(pDest, dpitch, pSrc, spitch,
+                                        metadata.format, tflags);
+                                }
+                                else
+                                {
+                                    CopyScanline(pDest, dpitch, pSrc, spitch,
+                                        metadata.format, tflags);
+                                }
+
+                                pSrc += spitch;
+                                pDest += dpitch;
+                            }
+                        }
+                    }
+                }
+            }
+            break;
+
+        case TEX_DIMENSION_TEXTURE3D:
+            {
+                size_t index = 0;
+                size_t d = metadata.depth;
+
+                size_t lastgood = 0;
+                for (size_t level = 0; level < metadata.mipLevels; ++level)
+                {
+                    for (size_t slice = 0; slice < d; ++slice, ++index)
+                    {
+                        if (index >= nimages)
+                            return E_FAIL;
+
+                        if (images[index].height != timages[index].height)
+                            return E_FAIL;
+
+                        size_t dpitch = images[index].rowPitch;
+                        const size_t spitch = timages[index].rowPitch;
+
+                        const uint8_t *pSrc = timages[index].pixels;
+                        if (!pSrc)
+                            return E_POINTER;
+
+                        uint8_t *pDest = images[index].pixels;
+                        if (!pDest)
+                            return E_POINTER;
+
+                        if (IsCompressed(metadata.format))
+                        {
+                            size_t csize = std::min<size_t>(images[index].slicePitch, timages[index].slicePitch);
+                            memcpy(pDest, pSrc, csize);
+
+                            if (cpFlags & CP_FLAGS_BAD_DXTN_TAILS)
+                            {
+                                if (images[index].width < 4 || images[index].height < 4)
+                                {
+                                    csize = std::min<size_t>(images[index].slicePitch, timages[lastgood + slice].slicePitch);
+                                    memcpy(pDest, timages[lastgood + slice].pixels, csize);
+                                }
+                                else if (!slice)
+                                {
+                                    lastgood = index;
+                                }
+                            }
+                        }
+                        else if (IsPlanar(metadata.format))
+                        {
+                            // Direct3D does not support any planar formats for Texture3D
+                            return HRESULT_E_NOT_SUPPORTED;
+                        }
+                        else
+                        {
+                            for (size_t h = 0; h < images[index].height; ++h)
+                            {
+                                if (convFlags & CONV_FLAGS_EXPAND)
+                                {
+                                    if (convFlags & CONV_FLAGS_4444)
+                                    {
+                                        if (!ExpandScanline(pDest, dpitch, DXGI_FORMAT_R8G8B8A8_UNORM,
+                                            pSrc, spitch,
+                                            (convFlags & CONF_FLAGS_11ON12) ? WIN11_DXGI_FORMAT_A4B4G4R4_UNORM : DXGI_FORMAT_B4G4R4A4_UNORM,
+                                            tflags))
+                                            return E_FAIL;
+                                    }
+                                    else if (convFlags & (CONV_FLAGS_565 | CONV_FLAGS_5551))
+                                    {
+                                        if (!ExpandScanline(pDest, dpitch, DXGI_FORMAT_R8G8B8A8_UNORM,
+                                            pSrc, spitch,
+                                            (convFlags & CONV_FLAGS_565) ? DXGI_FORMAT_B5G6R5_UNORM : DXGI_FORMAT_B5G5R5A1_UNORM,
+                                            tflags))
+                                            return E_FAIL;
+                                    }
+                                    else
+                                    {
+                                        const TEXP_LEGACY_FORMAT lformat = FindLegacyFormat(convFlags);
+                                        if (!LegacyExpandScanline(pDest, dpitch, metadata.format,
+                                            pSrc, spitch, lformat, pal8,
+                                            tflags))
+                                            return E_FAIL;
+                                    }
+                                }
+                                else if (convFlags & CONV_FLAGS_SWIZZLE)
+                                {
+                                    SwizzleScanline(pDest, dpitch, pSrc, spitch, metadata.format, tflags);
+                                }
+                                else
+                                {
+                                    CopyScanline(pDest, dpitch, pSrc, spitch, metadata.format, tflags);
+                                }
+
+                                pSrc += spitch;
+                                pDest += dpitch;
+                            }
+                        }
+                    }
+
+                    if (d > 1)
+                        d >>= 1;
+                }
+            }
+            break;
+
+        default:
+            return E_FAIL;
+        }
+
+        return S_OK;
+    }
+
+    HRESULT CopyImageInPlace(uint32_t convFlags, _In_ const ScratchImage& image) noexcept
+    {
+        if (!image.GetPixels())
+            return E_FAIL;
+
+        const Image* images = image.GetImages();
+        if (!images)
+            return E_FAIL;
+
+        const TexMetadata& metadata = image.GetMetadata();
+
+        if (IsPlanar(metadata.format))
+            return HRESULT_E_NOT_SUPPORTED;
+
+        uint32_t tflags = (convFlags & CONV_FLAGS_NOALPHA) ? TEXP_SCANLINE_SETALPHA : 0u;
+        if (convFlags & CONV_FLAGS_SWIZZLE)
+            tflags |= TEXP_SCANLINE_LEGACY;
+
+        for (size_t i = 0; i < image.GetImageCount(); ++i)
+        {
+            const Image* img = &images[i];
+            uint8_t *pPixels = img->pixels;
+            if (!pPixels)
+                return E_POINTER;
+
+            size_t rowPitch = img->rowPitch;
+
+            for (size_t h = 0; h < img->height; ++h)
+            {
+                if (convFlags & CONV_FLAGS_SWIZZLE)
+                {
+                    SwizzleScanline(pPixels, rowPitch, pPixels, rowPitch, metadata.format, tflags);
+                }
+                else
+                {
+                    CopyScanline(pPixels, rowPitch, pPixels, rowPitch, metadata.format, tflags);
+                }
+
+                pPixels += rowPitch;
+            }
+        }
+
+        return S_OK;
+    }
+}
+
+
+//=====================================================================================
+// Entry-points
+//=====================================================================================
+
+//-------------------------------------------------------------------------------------
+// Obtain metadata from DDS file in memory/on disk
+//-------------------------------------------------------------------------------------
+
+_Use_decl_annotations_
+HRESULT DirectX::GetMetadataFromDDSMemory(
+    const void* pSource,
+    size_t size,
+    DDS_FLAGS flags,
+    TexMetadata& metadata) noexcept
+{
+    return GetMetadataFromDDSMemoryEx(pSource, size, flags, metadata, nullptr);
+}
+
+_Use_decl_annotations_
+HRESULT DirectX::GetMetadataFromDDSMemoryEx(
+    const void* pSource,
+    size_t size,
+    DDS_FLAGS flags,
+    TexMetadata& metadata,
+    DDSMetaData* ddPixelFormat) noexcept
+{
+    if (!pSource || size == 0)
+        return E_INVALIDARG;
+
+    uint32_t convFlags = 0;
+    return DecodeDDSHeader(pSource, size, flags, metadata, ddPixelFormat, convFlags);
+}
+
+_Use_decl_annotations_
+HRESULT DirectX::GetMetadataFromDDSFile(
+    const wchar_t* szFile,
+    DDS_FLAGS flags,
+    TexMetadata& metadata) noexcept
+{
+    return GetMetadataFromDDSFileEx(szFile, flags, metadata, nullptr);
+}
+
+_Use_decl_annotations_
+HRESULT DirectX::GetMetadataFromDDSFileEx(
+    const wchar_t* szFile,
+    DDS_FLAGS flags,
+    TexMetadata& metadata,
+    DDSMetaData* ddPixelFormat) noexcept
+{
+    if (!szFile)
+        return E_INVALIDARG;
+
+#ifdef _WIN32
+#if (_WIN32_WINNT >= _WIN32_WINNT_WIN8)
+    ScopedHandle hFile(safe_handle(CreateFile2(szFile, GENERIC_READ, FILE_SHARE_READ, OPEN_EXISTING, nullptr)));
+#else
+    ScopedHandle hFile(safe_handle(CreateFileW(szFile, GENERIC_READ, FILE_SHARE_READ, nullptr, OPEN_EXISTING,
+        FILE_FLAG_SEQUENTIAL_SCAN, nullptr)));
+#endif
+    if (!hFile)
+    {
+        return HRESULT_FROM_WIN32(GetLastError());
+    }
+
+    // Get the file size
+    FILE_STANDARD_INFO fileInfo;
+    if (!GetFileInformationByHandleEx(hFile.get(), FileStandardInfo, &fileInfo, sizeof(fileInfo)))
+    {
+        return HRESULT_FROM_WIN32(GetLastError());
+    }
+
+    // File is too big for 32-bit allocation, so reject read (4 GB should be plenty large enough for a valid DDS file)
+    if (fileInfo.EndOfFile.HighPart > 0)
+    {
+        return HRESULT_E_FILE_TOO_LARGE;
+    }
+
+    const size_t len = fileInfo.EndOfFile.LowPart;
+#else // !WIN32
+    std::ifstream inFile(std::filesystem::path(szFile), std::ios::in | std::ios::binary | std::ios::ate);
+    if (!inFile)
+        return E_FAIL;
+
+    std::streampos fileLen = inFile.tellg();
+    if (!inFile)
+        return E_FAIL;
+
+    if (fileLen > UINT32_MAX)
+        return HRESULT_E_FILE_TOO_LARGE;
+
+    inFile.seekg(0, std::ios::beg);
+    if (!inFile)
+        return E_FAIL;
+
+    const size_t len = fileLen;
+#endif
+
+    // Need at least enough data to fill the standard header and magic number to be a valid DDS
+    if (len < (sizeof(DDS_HEADER) + sizeof(uint32_t)))
+    {
+        return E_FAIL;
+    }
+
+    // Read the header in (including extended header if present)
+    uint8_t header[MAX_HEADER_SIZE] = {};
+
+#ifdef _WIN32
+    DWORD bytesRead = 0;
+    if (!ReadFile(hFile.get(), header, MAX_HEADER_SIZE, &bytesRead, nullptr))
+    {
+        return HRESULT_FROM_WIN32(GetLastError());
+    }
+
+    auto const headerLen = static_cast<size_t>(bytesRead);
+#else
+    auto const headerLen = std::min<size_t>(len, MAX_HEADER_SIZE);
+
+    inFile.read(reinterpret_cast<char*>(header), headerLen);
+    if (!inFile)
+        return E_FAIL;
+#endif
+
+    uint32_t convFlags = 0;
+    return DecodeDDSHeader(header, headerLen, flags, metadata, ddPixelFormat, convFlags);
+}
+
+
+//-------------------------------------------------------------------------------------
+// Load a DDS file in memory
+//-------------------------------------------------------------------------------------
+_Use_decl_annotations_
+HRESULT DirectX::LoadFromDDSMemory(
+    const void* pSource,
+    size_t size,
+    DDS_FLAGS flags,
+    TexMetadata* metadata,
+    ScratchImage& image) noexcept
+{
+    return LoadFromDDSMemoryEx(pSource, size, flags, metadata, nullptr, image);
+}
+
+_Use_decl_annotations_
+HRESULT DirectX::LoadFromDDSMemoryEx(
+    const void* pSource,
+    size_t size,
+    DDS_FLAGS flags,
+    TexMetadata* metadata,
+    DDSMetaData* ddPixelFormat,
+    ScratchImage& image) noexcept
+{
+    if (!pSource || size == 0)
+        return E_INVALIDARG;
+
+    image.Release();
+
+    uint32_t convFlags = 0;
+    TexMetadata mdata;
+    HRESULT hr = DecodeDDSHeader(pSource, size, flags, mdata, ddPixelFormat, convFlags);
+    if (FAILED(hr))
+        return hr;
+
+    size_t offset = sizeof(uint32_t) + sizeof(DDS_HEADER);
+    if (convFlags & CONV_FLAGS_DX10)
+        offset += sizeof(DDS_HEADER_DXT10);
+
+    assert(offset <= size);
+
+    const uint32_t *pal8 = nullptr;
+    if (convFlags & CONV_FLAGS_PAL8)
+    {
+        pal8 = reinterpret_cast<const uint32_t*>(static_cast<const uint8_t*>(pSource) + offset);
+        assert(pal8);
+        offset += (256 * sizeof(uint32_t));
+        if (size < offset)
+            return E_FAIL;
+    }
+
+    hr = image.Initialize(mdata);
+    if (FAILED(hr))
+        return hr;
+
+    CP_FLAGS cflags = CP_FLAGS_NONE;
+    if (flags & DDS_FLAGS_LEGACY_DWORD)
+    {
+        cflags |= CP_FLAGS_LEGACY_DWORD;
+    }
+    if (flags & DDS_FLAGS_BAD_DXTN_TAILS)
+    {
+        cflags |= CP_FLAGS_BAD_DXTN_TAILS;
+    }
+
+    const void* pPixels = static_cast<const uint8_t*>(pSource) + offset;
+    assert(pPixels);
+    hr = CopyImage(pPixels,
+        size - offset,
+        mdata,
+        cflags,
+        convFlags,
+        pal8,
+        image);
+    if (FAILED(hr))
+    {
+        image.Release();
+        return hr;
+    }
+    if (metadata)
+        memcpy(metadata, &mdata, sizeof(TexMetadata));
+
+    return S_OK;
+}
+
+
+//-------------------------------------------------------------------------------------
+// Load a DDS file from disk
+//-------------------------------------------------------------------------------------
+_Use_decl_annotations_
+HRESULT DirectX::LoadFromDDSFile(
+    const wchar_t* szFile,
+    DDS_FLAGS flags,
+    TexMetadata* metadata,
+    ScratchImage& image) noexcept
+{
+    return LoadFromDDSFileEx(szFile, flags, metadata, nullptr, image);
+}
+
+_Use_decl_annotations_
+HRESULT DirectX::LoadFromDDSFileEx(
+    const wchar_t* szFile,
+    DDS_FLAGS flags,
+    TexMetadata* metadata,
+    DDSMetaData* ddPixelFormat,
+    ScratchImage& image) noexcept
+{
+    if (!szFile)
+        return E_INVALIDARG;
+
+    image.Release();
+
+#ifdef _WIN32
+#if (_WIN32_WINNT >= _WIN32_WINNT_WIN8)
+    ScopedHandle hFile(safe_handle(CreateFile2(szFile, GENERIC_READ, FILE_SHARE_READ, OPEN_EXISTING, nullptr)));
+#else
+    ScopedHandle hFile(safe_handle(CreateFileW(szFile, GENERIC_READ, FILE_SHARE_READ, nullptr, OPEN_EXISTING,
+        FILE_FLAG_SEQUENTIAL_SCAN, nullptr)));
+#endif
+    if (!hFile)
+    {
+        return HRESULT_FROM_WIN32(GetLastError());
+    }
+
+    // Get the file size
+    FILE_STANDARD_INFO fileInfo;
+    if (!GetFileInformationByHandleEx(hFile.get(), FileStandardInfo, &fileInfo, sizeof(fileInfo)))
+    {
+        return HRESULT_FROM_WIN32(GetLastError());
+    }
+
+    // File is too big for 32-bit allocation, so reject read (4 GB should be plenty large enough for a valid DDS file)
+    if (fileInfo.EndOfFile.HighPart > 0)
+        return HRESULT_E_FILE_TOO_LARGE;
+
+    const size_t len = fileInfo.EndOfFile.LowPart;
+#else // !WIN32
+    std::ifstream inFile(std::filesystem::path(szFile), std::ios::in | std::ios::binary | std::ios::ate);
+    if (!inFile)
+        return E_FAIL;
+
+    std::streampos fileLen = inFile.tellg();
+    if (!inFile)
+        return E_FAIL;
+
+    if (fileLen > UINT32_MAX)
+        return HRESULT_E_FILE_TOO_LARGE;
+
+    inFile.seekg(0, std::ios::beg);
+    if (!inFile)
+        return E_FAIL;
+
+    const size_t len = fileLen;
+#endif
+
+    // Need at least enough data to fill the standard header and magic number to be a valid DDS
+    if (len < (sizeof(DDS_HEADER) + sizeof(uint32_t)))
+    {
+        return E_FAIL;
+    }
+
+    // Read the header in (including extended header if present)
+    uint8_t header[MAX_HEADER_SIZE] = {};
+
+#ifdef _WIN32
+    DWORD bytesRead = 0;
+    if (!ReadFile(hFile.get(), header, MAX_HEADER_SIZE, &bytesRead, nullptr))
+    {
+        return HRESULT_FROM_WIN32(GetLastError());
+    }
+
+    auto const headerLen = static_cast<size_t>(bytesRead);
+#else
+    auto const headerLen = std::min<size_t>(len, MAX_HEADER_SIZE);
+
+    inFile.read(reinterpret_cast<char*>(header), headerLen);
+    if (!inFile)
+        return E_FAIL;
+#endif
+
+    uint32_t convFlags = 0;
+    TexMetadata mdata;
+    HRESULT hr = DecodeDDSHeader(header, headerLen, flags, mdata, ddPixelFormat, convFlags);
+    if (FAILED(hr))
+        return hr;
+
+    size_t offset = MAX_HEADER_SIZE;
+
+    if (!(convFlags & CONV_FLAGS_DX10))
+    {
+    #ifdef _WIN32
+            // Must reset file position since we read more than the standard header above
+        const LARGE_INTEGER filePos = { { sizeof(uint32_t) + sizeof(DDS_HEADER), 0 } };
+        if (!SetFilePointerEx(hFile.get(), filePos, nullptr, FILE_BEGIN))
+        {
+            return HRESULT_FROM_WIN32(GetLastError());
+        }
+    #else
+        inFile.seekg(sizeof(uint32_t) + sizeof(DDS_HEADER), std::ios::beg);
+        if (!inFile)
+            return E_FAIL;
+    #endif
+
+        offset = sizeof(uint32_t) + sizeof(DDS_HEADER);
+    }
+
+    std::unique_ptr<uint32_t[]> pal8;
+    if (convFlags & CONV_FLAGS_PAL8)
+    {
+        pal8.reset(new (std::nothrow) uint32_t[256]);
+        if (!pal8)
+        {
+            return E_OUTOFMEMORY;
+        }
+
+    #ifdef _WIN32
+        if (!ReadFile(hFile.get(), pal8.get(), 256 * sizeof(uint32_t), &bytesRead, nullptr))
+        {
+            return HRESULT_FROM_WIN32(GetLastError());
+        }
+
+        if (bytesRead != (256 * sizeof(uint32_t)))
+        {
+            return E_FAIL;
+        }
+    #else
+        inFile.read(reinterpret_cast<char*>(pal8.get()), 256 * sizeof(uint32_t));
+        if (!inFile)
+            return E_FAIL;
+    #endif
+
+        offset += (256 * sizeof(uint32_t));
+    }
+
+    const size_t remaining = len - offset;
+    if (remaining == 0)
+        return E_FAIL;
+
+    hr = image.Initialize(mdata);
+    if (FAILED(hr))
+        return hr;
+
+    if ((convFlags & CONV_FLAGS_EXPAND) || (flags & (DDS_FLAGS_LEGACY_DWORD | DDS_FLAGS_BAD_DXTN_TAILS)))
+    {
+        std::unique_ptr<uint8_t[]> temp(new (std::nothrow) uint8_t[remaining]);
+        if (!temp)
+        {
+            image.Release();
+            return E_OUTOFMEMORY;
+        }
+
+    #ifdef _WIN32
+        if (!ReadFile(hFile.get(), temp.get(), static_cast<DWORD>(remaining), &bytesRead, nullptr))
+        {
+            image.Release();
+            return HRESULT_FROM_WIN32(GetLastError());
+        }
+
+        if (bytesRead != remaining)
+        {
+            image.Release();
+            return E_FAIL;
+        }
+    #else
+        inFile.read(reinterpret_cast<char*>(temp.get()), remaining);
+        if (!inFile)
+        {
+            image.Release();
+            return E_FAIL;
+        }
+    #endif
+
+        CP_FLAGS cflags = CP_FLAGS_NONE;
+        if (flags & DDS_FLAGS_LEGACY_DWORD)
+        {
+            cflags |= CP_FLAGS_LEGACY_DWORD;
+        }
+        if (flags & DDS_FLAGS_BAD_DXTN_TAILS)
+        {
+            cflags |= CP_FLAGS_BAD_DXTN_TAILS;
+        }
+
+        hr = CopyImage(temp.get(),
+            remaining,
+            mdata,
+            cflags,
+            convFlags,
+            pal8.get(),
+            image);
+        if (FAILED(hr))
+        {
+            image.Release();
+            return hr;
+        }
+    }
+    else
+    {
+        if (remaining < image.GetPixelsSize())
+        {
+            image.Release();
+            return HRESULT_E_HANDLE_EOF;
+        }
+
+        if (image.GetPixelsSize() > UINT32_MAX)
+        {
+            image.Release();
+            return HRESULT_E_ARITHMETIC_OVERFLOW;
+        }
+
+    #ifdef _WIN32
+        auto const pixelBytes = static_cast<DWORD>(image.GetPixelsSize());
+        if (!ReadFile(hFile.get(), image.GetPixels(), pixelBytes, &bytesRead, nullptr))
+        {
+            image.Release();
+            return HRESULT_FROM_WIN32(GetLastError());
+        }
+
+        if (bytesRead != pixelBytes)
+        {
+            image.Release();
+            return E_FAIL;
+        }
+    #else
+        inFile.read(reinterpret_cast<char*>(image.GetPixels()), image.GetPixelsSize());
+        if (!inFile)
+        {
+            image.Release();
+            return E_FAIL;
+        }
+    #endif
+
+        if (convFlags & (CONV_FLAGS_SWIZZLE | CONV_FLAGS_NOALPHA))
+        {
+            // Swizzle/copy image in place
+            hr = CopyImageInPlace(convFlags, image);
+            if (FAILED(hr))
+            {
+                image.Release();
+                return hr;
+            }
+        }
+    }
+
+    if (metadata)
+        memcpy(metadata, &mdata, sizeof(TexMetadata));
+
+    return S_OK;
+}
+
+
+//-------------------------------------------------------------------------------------
+// Save a DDS file to memory
+//-------------------------------------------------------------------------------------
+_Use_decl_annotations_
+HRESULT DirectX::SaveToDDSMemory(
+    const Image* images,
+    size_t nimages,
+    const TexMetadata& metadata,
+    DDS_FLAGS flags,
+    Blob& blob) noexcept
+{
+    if (!images || (nimages == 0))
+        return E_INVALIDARG;
+
+    // Determine memory required
+    size_t required = 0;
+    HRESULT hr = EncodeDDSHeader(metadata, flags, nullptr, 0, required);
+    if (FAILED(hr))
+        return hr;
+
+    bool fastpath = true;
+
+    for (size_t i = 0; i < nimages; ++i)
+    {
+        if (!images[i].pixels)
+            return E_POINTER;
+
+        if (images[i].format != metadata.format)
+            return E_FAIL;
+
+        size_t ddsRowPitch, ddsSlicePitch;
+        hr = ComputePitch(metadata.format, images[i].width, images[i].height, ddsRowPitch, ddsSlicePitch, CP_FLAGS_NONE);
+        if (FAILED(hr))
+            return hr;
+
+        assert(images[i].rowPitch > 0);
+        assert(images[i].slicePitch > 0);
+
+        if ((images[i].rowPitch != ddsRowPitch) || (images[i].slicePitch != ddsSlicePitch))
+        {
+            fastpath = false;
+        }
+
+        required += ddsSlicePitch;
+    }
+
+    assert(required > 0);
+
+    blob.Release();
+
+    hr = blob.Initialize(required);
+    if (FAILED(hr))
+        return hr;
+
+    auto pDestination = static_cast<uint8_t*>(blob.GetBufferPointer());
+    assert(pDestination);
+
+    hr = EncodeDDSHeader(metadata, flags, pDestination, blob.GetBufferSize(), required);
+    if (FAILED(hr))
+    {
+        blob.Release();
+        return hr;
+    }
+
+    size_t remaining = blob.GetBufferSize() - required;
+    pDestination += required;
+
+    if (!remaining)
+    {
+        blob.Release();
+        return E_FAIL;
+    }
+
+    switch (static_cast<DDS_RESOURCE_DIMENSION>(metadata.dimension))
+    {
+    case DDS_DIMENSION_TEXTURE1D:
+    case DDS_DIMENSION_TEXTURE2D:
+        {
+            size_t index = 0;
+            for (size_t item = 0; item < metadata.arraySize; ++item)
+            {
+                for (size_t level = 0; level < metadata.mipLevels; ++level)
+                {
+                    if (index >= nimages)
+                    {
+                        blob.Release();
+                        return E_FAIL;
+                    }
+
+                    if (fastpath)
+                    {
+                        size_t pixsize = images[index].slicePitch;
+                        memcpy(pDestination, images[index].pixels, pixsize);
+
+                        pDestination += pixsize;
+                        remaining -= pixsize;
+                    }
+                    else
+                    {
+                        size_t ddsRowPitch, ddsSlicePitch;
+                        hr = ComputePitch(metadata.format, images[index].width, images[index].height, ddsRowPitch, ddsSlicePitch, CP_FLAGS_NONE);
+                        if (FAILED(hr))
+                        {
+                            blob.Release();
+                            return hr;
+                        }
+
+                        const size_t rowPitch = images[index].rowPitch;
+
+                        const uint8_t * __restrict sPtr = images[index].pixels;
+                        uint8_t * __restrict dPtr = pDestination;
+
+                        const size_t lines = ComputeScanlines(metadata.format, images[index].height);
+                        const size_t csize = std::min<size_t>(rowPitch, ddsRowPitch);
+                        size_t tremaining = remaining;
+                        for (size_t j = 0; j < lines; ++j)
+                        {
+                            if (tremaining < csize)
+                            {
+                                blob.Release();
+                                return E_FAIL;
+                            }
+
+                            memcpy(dPtr, sPtr, csize);
+
+                            sPtr += rowPitch;
+                            dPtr += ddsRowPitch;
+                            tremaining -= ddsRowPitch;
+                        }
+
+                        pDestination += ddsSlicePitch;
+                        remaining -= ddsSlicePitch;
+                    }
+
+                    ++index;
+                }
+            }
+        }
+        break;
+
+    case DDS_DIMENSION_TEXTURE3D:
+        {
+            if (metadata.arraySize != 1)
+            {
+                blob.Release();
+                return E_FAIL;
+            }
+
+            size_t d = metadata.depth;
+
+            size_t index = 0;
+            for (size_t level = 0; level < metadata.mipLevels; ++level)
+            {
+                for (size_t slice = 0; slice < d; ++slice)
+                {
+                    if (index >= nimages)
+                    {
+                        blob.Release();
+                        return E_FAIL;
+                    }
+
+                    if (fastpath)
+                    {
+                        size_t pixsize = images[index].slicePitch;
+                        memcpy(pDestination, images[index].pixels, pixsize);
+
+                        pDestination += pixsize;
+                        remaining -= pixsize;
+                    }
+                    else
+                    {
+                        size_t ddsRowPitch, ddsSlicePitch;
+                        hr = ComputePitch(metadata.format, images[index].width, images[index].height, ddsRowPitch, ddsSlicePitch, CP_FLAGS_NONE);
+                        if (FAILED(hr))
+                        {
+                            blob.Release();
+                            return hr;
+                        }
+
+                        const size_t rowPitch = images[index].rowPitch;
+
+                        const uint8_t * __restrict sPtr = images[index].pixels;
+                        uint8_t * __restrict dPtr = pDestination;
+
+                        const size_t lines = ComputeScanlines(metadata.format, images[index].height);
+                        const size_t csize = std::min<size_t>(rowPitch, ddsRowPitch);
+                        size_t tremaining = remaining;
+                        for (size_t j = 0; j < lines; ++j)
+                        {
+                            if (tremaining < csize)
+                            {
+                                blob.Release();
+                                return E_FAIL;
+                            }
+
+                            memcpy(dPtr, sPtr, csize);
+
+                            sPtr += rowPitch;
+                            dPtr += ddsRowPitch;
+                            tremaining -= ddsRowPitch;
+                        }
+
+                        pDestination += ddsSlicePitch;
+                        remaining -= ddsSlicePitch;
+                    }
+
+                    ++index;
+                }
+
+                if (d > 1)
+                    d >>= 1;
+            }
+        }
+        break;
+
+    default:
+        blob.Release();
+        return E_FAIL;
+    }
+
+    return S_OK;
+}
+
+
+//-------------------------------------------------------------------------------------
+// Save a DDS file to disk
+// Wall_SoGB - Added shoddy support for BGR formats
+//-------------------------------------------------------------------------------------
+_Use_decl_annotations_
+HRESULT DirectX::SaveToDDSFile(
+    const Image* images,
+    size_t nimages,
+    const TexMetadata& metadata,
+    DDS_FLAGS flags,
+    const wchar_t* szFile) noexcept
+{
+    if (!szFile)
+        return E_INVALIDARG;
+
+    bool forceRGB = (flags & DDS_FLAGS_FORCE_RGB) != 0;
+
+	// We only support 8-bit RGB formats for DDS_FLAGS_FORCE_RGB
+    if (forceRGB) 
+    {
+        switch (metadata.format) 
+        {
+        case DXGI_FORMAT_B8G8R8A8_TYPELESS:
+        case DXGI_FORMAT_B8G8R8A8_UNORM:
+        case DXGI_FORMAT_B8G8R8A8_UNORM_SRGB:
+        case DXGI_FORMAT_B8G8R8X8_UNORM:
+        case DXGI_FORMAT_B8G8R8X8_UNORM_SRGB:
+            break;
+        default:
+            flags &= ~DDS_FLAGS_FORCE_RGB;
+            forceRGB = false;
+            break;
+        }
+    }
+
+    // Create DDS Header
+    uint8_t header[MAX_HEADER_SIZE];
+    size_t required;
+    HRESULT hr = EncodeDDSHeader(metadata, flags, header, MAX_HEADER_SIZE, required);
+    if (FAILED(hr))
+        return hr;
+
+    // Create file and write header
+#ifdef _WIN32
+#if (_WIN32_WINNT >= _WIN32_WINNT_WIN8)
+    ScopedHandle hFile(safe_handle(CreateFile2(szFile,
+        GENERIC_WRITE | DELETE, 0, CREATE_ALWAYS, nullptr)));
+#else
+    ScopedHandle hFile(safe_handle(CreateFileW(szFile,
+        GENERIC_WRITE | DELETE, 0, nullptr, CREATE_ALWAYS, FILE_ATTRIBUTE_NORMAL, nullptr)));
+#endif
+    if (!hFile)
+    {
+        return HRESULT_FROM_WIN32(GetLastError());
+    }
+
+    auto_delete_file delonfail(hFile.get());
+
+    DWORD bytesWritten;
+    if (!WriteFile(hFile.get(), header, static_cast<DWORD>(required), &bytesWritten, nullptr))
+    {
+        return HRESULT_FROM_WIN32(GetLastError());
+    }
+
+    if (bytesWritten != required)
+    {
+        return E_FAIL;
+    }
+#else // !WIN32
+    std::ofstream outFile(std::filesystem::path(szFile), std::ios::out | std::ios::binary | std::ios::trunc);
+    if (!outFile)
+        return E_FAIL;
+
+    outFile.write(reinterpret_cast<char*>(header), static_cast<std::streamsize>(required));
+    if (!outFile)
+        return E_FAIL;
+#endif
+
+    // Write images
+    switch (static_cast<DDS_RESOURCE_DIMENSION>(metadata.dimension))
+    {
+    case DDS_DIMENSION_TEXTURE1D:
+    case DDS_DIMENSION_TEXTURE2D:
+        {
+            size_t index = 0;
+            for (size_t item = 0; item < metadata.arraySize; ++item)
+            {
+                for (size_t level = 0; level < metadata.mipLevels; ++level, ++index)
+                {
+                    if (index >= nimages)
+                        return E_FAIL;
+
+                    if (!images[index].pixels)
+                        return E_POINTER;
+
+                    assert(images[index].rowPitch > 0);
+                    assert(images[index].slicePitch > 0);
+
+                    size_t ddsRowPitch, ddsSlicePitch;
+                    hr = ComputePitch(metadata.format, images[index].width, images[index].height, ddsRowPitch, ddsSlicePitch, forceRGB ? CP_FLAGS_24BPP : CP_FLAGS_NONE);
+                    if (FAILED(hr))
+                        return hr;
+
+                    if ((images[index].slicePitch == ddsSlicePitch) && (ddsSlicePitch <= UINT32_MAX))
+                    {
+                    #ifdef _WIN32
+                        if (!WriteFile(hFile.get(), images[index].pixels, static_cast<DWORD>(ddsSlicePitch), &bytesWritten, nullptr))
+                        {
+                            return HRESULT_FROM_WIN32(GetLastError());
+                        }
+
+                        if (bytesWritten != ddsSlicePitch)
+                        {
+                            return E_FAIL;
+                        }
+                    #else
+                        outFile.write(reinterpret_cast<char*>(images[index].pixels), static_cast<std::streamsize>(ddsSlicePitch));
+                        if (!outFile)
+                            return E_FAIL;
+                    #endif
+                    }
+                    else
+                    {
+                        ddsRowPitch = forceRGB ? 3 : ddsRowPitch;
+                        const size_t rowPitch = forceRGB ? 4 : images[index].rowPitch;
+                        if (rowPitch < ddsRowPitch && !forceRGB)
+                        {
+                            // DDS uses 1-byte alignment, so if this is happening then the input pitch isn't actually a full line of data
+                            return E_FAIL;
+                        }
+
+                        if (ddsRowPitch > UINT32_MAX)
+                            return HRESULT_E_ARITHMETIC_OVERFLOW;
+
+                        const uint8_t * __restrict sPtr = images[index].pixels;
+
+                        const size_t lines = ComputeScanlines(metadata.format, images[index].height);
+                        const size_t rows = forceRGB ? images[index].width : 1;
+
+                        for (size_t j = 0; j < lines; ++j)
+                        {
+#ifdef _WIN32				
+                            for (size_t l = 0; l < rows; ++l)
+                            {
+                                if (!WriteFile(hFile.get(), sPtr, static_cast<DWORD>(ddsRowPitch), &bytesWritten, nullptr))
+                                {
+                                    return HRESULT_FROM_WIN32(GetLastError());
+                                }
+
+                                if (bytesWritten != ddsRowPitch)
+                                {
+                                    return E_FAIL;
+                                }
+#else
+                                outFile.write(reinterpret_cast<const char*>(sPtr), static_cast<std::streamsize>(ddsRowPitch));
+                                if (!outFile)
+                                    return E_FAIL;
+#endif
+
+                            sPtr += rowPitch;
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        break;
+
+    case DDS_DIMENSION_TEXTURE3D:
+        {
+            if (metadata.arraySize != 1)
+                return E_FAIL;
+
+            size_t d = metadata.depth;
+
+            size_t index = 0;
+            for (size_t level = 0; level < metadata.mipLevels; ++level)
+            {
+                for (size_t slice = 0; slice < d; ++slice, ++index)
+                {
+                    if (index >= nimages)
+                        return E_FAIL;
+
+                    if (!images[index].pixels)
+                        return E_POINTER;
+
+                    assert(images[index].rowPitch > 0);
+                    assert(images[index].slicePitch > 0);
+
+                    size_t ddsRowPitch, ddsSlicePitch;
+                    hr = ComputePitch(metadata.format, images[index].width, images[index].height, ddsRowPitch, ddsSlicePitch, CP_FLAGS_NONE);
+                    if (FAILED(hr))
+                        return hr;
+
+                    if ((images[index].slicePitch == ddsSlicePitch) && (ddsSlicePitch <= UINT32_MAX))
+                    {
+                    #ifdef _WIN32
+                        if (!WriteFile(hFile.get(), images[index].pixels, static_cast<DWORD>(ddsSlicePitch), &bytesWritten, nullptr))
+                        {
+                            return HRESULT_FROM_WIN32(GetLastError());
+                        }
+
+                        if (bytesWritten != ddsSlicePitch)
+                        {
+                            return E_FAIL;
+                        }
+                    #else
+                        outFile.write(reinterpret_cast<char*>(images[index].pixels), static_cast<std::streamsize>(ddsSlicePitch));
+                        if (!outFile)
+                            return E_FAIL;
+                    #endif
+                    }
+                    else
+                    {
+                        const size_t rowPitch = images[index].rowPitch;
+                        if (rowPitch < ddsRowPitch)
+                        {
+                            // DDS uses 1-byte alignment, so if this is happening then the input pitch isn't actually a full line of data
+                            return E_FAIL;
+                        }
+
+                        if (ddsRowPitch > UINT32_MAX)
+                            return HRESULT_E_ARITHMETIC_OVERFLOW;
+
+                        const uint8_t * __restrict sPtr = images[index].pixels;
+
+                        const size_t lines = ComputeScanlines(metadata.format, images[index].height);
+                        for (size_t j = 0; j < lines; ++j)
+                        {
+                        #ifdef _WIN32
+                            if (!WriteFile(hFile.get(), sPtr, static_cast<DWORD>(ddsRowPitch), &bytesWritten, nullptr))
+                            {
+                                return HRESULT_FROM_WIN32(GetLastError());
+                            }
+
+                            if (bytesWritten != ddsRowPitch)
+                            {
+                                return E_FAIL;
+                            }
+                        #else
+                            outFile.write(reinterpret_cast<const char*>(sPtr), static_cast<std::streamsize>(ddsRowPitch));
+                            if (!outFile)
+                                return E_FAIL;
+                        #endif
+                            sPtr += rowPitch;
+                        }
+                    }
+                }
+
+                if (d > 1)
+                    d >>= 1;
+            }
+        }
+        break;
+
+    default:
+        return E_FAIL;
+    }
+
+#ifdef _WIN32
+    delonfail.clear();
+#endif
+
+    return S_OK;
+}
+
+
+//--------------------------------------------------------------------------------------
+// Adapters for /Zc:wchar_t- clients
+
+#if defined(_MSC_VER) && !defined(_NATIVE_WCHAR_T_DEFINED)
+
+namespace DirectX
+{
+    HRESULT __cdecl GetMetadataFromDDSFile(
+        _In_z_ const __wchar_t* szFile,
+        _In_ DDS_FLAGS flags,
+        _Out_ TexMetadata& metadata) noexcept
+    {
+        return GetMetadataFromDDSFile(reinterpret_cast<const unsigned short*>(szFile), flags, metadata);
+    }
+
+    HRESULT __cdecl GetMetadataFromDDSFileEx(
+        _In_z_ const __wchar_t* szFile,
+        _In_ DDS_FLAGS flags,
+        _Out_ TexMetadata& metadata,
+        _Out_opt_ DDSMetaData* ddPixelFormat) noexcept
+    {
+        return GetMetadataFromDDSFileEx(reinterpret_cast<const unsigned short*>(szFile), flags, metadata, ddPixelFormat);
+    }
+
+    HRESULT __cdecl LoadFromDDSFile(
+        _In_z_ const __wchar_t* szFile,
+        _In_ DDS_FLAGS flags,
+        _Out_opt_ TexMetadata* metadata,
+        _Out_ ScratchImage& image) noexcept
+    {
+        return LoadFromDDSFile(reinterpret_cast<const unsigned short*>(szFile), flags, metadata, image);
+    }
+
+    HRESULT __cdecl LoadFromDDSFileEx(
+        _In_z_ const __wchar_t* szFile,
+        _In_ DDS_FLAGS flags,
+        _Out_opt_ TexMetadata* metadata,
+        _Out_opt_ DDSMetaData* ddPixelFormat,
+        _Out_ ScratchImage& image) noexcept
+    {
+        return LoadFromDDSFileEx(reinterpret_cast<const unsigned short*>(szFile), flags, metadata, ddPixelFormat, image);
+    }
+
+    HRESULT __cdecl SaveToDDSFile(
+        _In_ const Image& image,
+        _In_ DDS_FLAGS flags,
+        _In_z_ const __wchar_t* szFile) noexcept
+    {
+        return SaveToDDSFile(image, flags, reinterpret_cast<const unsigned short*>(szFile));
+    }
+
+    HRESULT __cdecl SaveToDDSFile(
+        _In_reads_(nimages) const Image* images,
+        _In_ size_t nimages,
+        _In_ const TexMetadata& metadata,
+        _In_ DDS_FLAGS flags,
+        _In_z_ const __wchar_t* szFile) noexcept
+    {
+        return SaveToDDSFile(images, nimages, metadata, flags, reinterpret_cast<const unsigned short*>(szFile));
+    }
+}
+
+#endif // !_NATIVE_WCHAR_T_DEFINED

--- a/DirectXTex/DirectXTex/DirectXTexImage.cpp
+++ b/DirectXTex/DirectXTex/DirectXTexImage.cpp
@@ -1,0 +1,852 @@
+//-------------------------------------------------------------------------------------
+// DirectXTexImage.cpp
+//
+// DirectX Texture Library - Image container
+//
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+//
+// http://go.microsoft.com/fwlink/?LinkId=248926
+//-------------------------------------------------------------------------------------
+
+#include "DirectXTexP.h"
+
+using namespace DirectX;
+using namespace DirectX::Internal;
+
+#ifndef _WIN32
+namespace
+{
+    inline void * _aligned_malloc(size_t size, size_t alignment)
+    {
+        size = (size + alignment - 1) & ~(alignment - 1);
+        return std::aligned_alloc(alignment, size);
+    }
+
+#define _aligned_free free
+}
+#endif
+
+//-------------------------------------------------------------------------------------
+// Determines number of image array entries and pixel size
+//-------------------------------------------------------------------------------------
+_Use_decl_annotations_
+HRESULT DirectX::Internal::DetermineImageArray(
+    const TexMetadata& metadata,
+    CP_FLAGS cpFlags,
+    size_t& nImages,
+    size_t& pixelSize) noexcept
+{
+    assert(metadata.width > 0 && metadata.height > 0 && metadata.depth > 0);
+    assert(metadata.arraySize > 0);
+    assert(metadata.mipLevels > 0);
+
+    uint64_t totalPixelSize = 0;
+    size_t nimages = 0;
+
+    switch (metadata.dimension)
+    {
+    case TEX_DIMENSION_TEXTURE1D:
+    case TEX_DIMENSION_TEXTURE2D:
+        for (size_t item = 0; item < metadata.arraySize; ++item)
+        {
+            size_t w = metadata.width;
+            size_t h = metadata.height;
+
+            for (size_t level = 0; level < metadata.mipLevels; ++level)
+            {
+                size_t rowPitch, slicePitch;
+                HRESULT hr = ComputePitch(metadata.format, w, h, rowPitch, slicePitch, cpFlags);
+                if (FAILED(hr))
+                {
+                    nImages = pixelSize = 0;
+                    return hr;
+                }
+
+                totalPixelSize += uint64_t(slicePitch);
+                ++nimages;
+
+                if (h > 1)
+                    h >>= 1;
+
+                if (w > 1)
+                    w >>= 1;
+            }
+        }
+        break;
+
+    case TEX_DIMENSION_TEXTURE3D:
+        {
+            size_t w = metadata.width;
+            size_t h = metadata.height;
+            size_t d = metadata.depth;
+
+            for (size_t level = 0; level < metadata.mipLevels; ++level)
+            {
+                size_t rowPitch, slicePitch;
+                HRESULT hr = ComputePitch(metadata.format, w, h, rowPitch, slicePitch, cpFlags);
+                if (FAILED(hr))
+                {
+                    nImages = pixelSize = 0;
+                    return hr;
+                }
+
+                for (size_t slice = 0; slice < d; ++slice)
+                {
+                    totalPixelSize += uint64_t(slicePitch);
+                    ++nimages;
+                }
+
+                if (h > 1)
+                    h >>= 1;
+
+                if (w > 1)
+                    w >>= 1;
+
+                if (d > 1)
+                    d >>= 1;
+            }
+        }
+        break;
+
+    default:
+        nImages = pixelSize = 0;
+        return E_INVALIDARG;
+    }
+
+#if defined(_M_IX86) || defined(_M_ARM) || defined(_M_HYBRID_X86_ARM64)
+    static_assert(sizeof(size_t) == 4, "Not a 32-bit platform!");
+    if (totalPixelSize > UINT32_MAX)
+    {
+        nImages = pixelSize = 0;
+        return HRESULT_E_ARITHMETIC_OVERFLOW;
+    }
+#else
+    static_assert(sizeof(size_t) == 8, "Not a 64-bit platform!");
+
+    if ((cpFlags & CP_FLAGS_LIMIT_4GB) && (totalPixelSize > UINT32_MAX))
+    {
+        nImages = pixelSize = 0;
+        return HRESULT_E_ARITHMETIC_OVERFLOW;
+    }
+#endif
+
+    nImages = nimages;
+    pixelSize = static_cast<size_t>(totalPixelSize);
+
+    return S_OK;
+}
+
+
+//-------------------------------------------------------------------------------------
+// Fills in the image array entries
+//-------------------------------------------------------------------------------------
+_Use_decl_annotations_
+bool DirectX::Internal::SetupImageArray(
+    uint8_t *pMemory,
+    size_t pixelSize,
+    const TexMetadata& metadata,
+    CP_FLAGS cpFlags,
+    Image* images,
+    size_t nImages) noexcept
+{
+    assert(pMemory);
+    assert(pixelSize > 0);
+    assert(nImages > 0);
+
+    if (!images)
+        return false;
+
+    size_t index = 0;
+    uint8_t* pixels = pMemory;
+    const uint8_t* pEndBits = pMemory + pixelSize;
+
+    switch (metadata.dimension)
+    {
+    case TEX_DIMENSION_TEXTURE1D:
+    case TEX_DIMENSION_TEXTURE2D:
+        if (metadata.arraySize == 0 || metadata.mipLevels == 0)
+        {
+            return false;
+        }
+
+        for (size_t item = 0; item < metadata.arraySize; ++item)
+        {
+            size_t w = metadata.width;
+            size_t h = metadata.height;
+
+            for (size_t level = 0; level < metadata.mipLevels; ++level)
+            {
+                if (index >= nImages)
+                {
+                    return false;
+                }
+
+                size_t rowPitch, slicePitch;
+                if (FAILED(ComputePitch(metadata.format, w, h, rowPitch, slicePitch, cpFlags)))
+                    return false;
+
+                images[index].width = w;
+                images[index].height = h;
+                images[index].format = metadata.format;
+                images[index].rowPitch = rowPitch;
+                images[index].slicePitch = slicePitch;
+                images[index].pixels = pixels;
+                ++index;
+
+                pixels += slicePitch;
+                if (pixels > pEndBits)
+                {
+                    return false;
+                }
+
+                if (h > 1)
+                    h >>= 1;
+
+                if (w > 1)
+                    w >>= 1;
+            }
+        }
+        return true;
+
+    case TEX_DIMENSION_TEXTURE3D:
+        {
+            if (metadata.mipLevels == 0 || metadata.depth == 0)
+            {
+                return false;
+            }
+
+            size_t w = metadata.width;
+            size_t h = metadata.height;
+            size_t d = metadata.depth;
+
+            for (size_t level = 0; level < metadata.mipLevels; ++level)
+            {
+                size_t rowPitch, slicePitch;
+                if (FAILED(ComputePitch(metadata.format, w, h, rowPitch, slicePitch, cpFlags)))
+                    return false;
+
+                for (size_t slice = 0; slice < d; ++slice)
+                {
+                    if (index >= nImages)
+                    {
+                        return false;
+                    }
+
+                    // We use the same memory organization that Direct3D 11 needs for D3D11_SUBRESOURCE_DATA
+                    // with all slices of a given miplevel being continuous in memory
+                    images[index].width = w;
+                    images[index].height = h;
+                    images[index].format = metadata.format;
+                    images[index].rowPitch = rowPitch;
+                    images[index].slicePitch = slicePitch;
+                    images[index].pixels = pixels;
+                    ++index;
+
+                    pixels += slicePitch;
+                    if (pixels > pEndBits)
+                    {
+                        return false;
+                    }
+                }
+
+                if (h > 1)
+                    h >>= 1;
+
+                if (w > 1)
+                    w >>= 1;
+
+                if (d > 1)
+                    d >>= 1;
+            }
+        }
+        return true;
+
+    default:
+        return false;
+    }
+}
+
+
+//=====================================================================================
+// ScratchImage - Bitmap image container
+//=====================================================================================
+
+ScratchImage& ScratchImage::operator= (ScratchImage&& moveFrom) noexcept
+{
+    if (this != &moveFrom)
+    {
+        Release();
+
+        m_nimages = moveFrom.m_nimages;
+        m_size = moveFrom.m_size;
+        m_metadata = moveFrom.m_metadata;
+        m_image = moveFrom.m_image;
+        m_memory = moveFrom.m_memory;
+
+        moveFrom.m_nimages = 0;
+        moveFrom.m_size = 0;
+        moveFrom.m_image = nullptr;
+        moveFrom.m_memory = nullptr;
+    }
+    return *this;
+}
+
+
+//-------------------------------------------------------------------------------------
+// Methods
+//-------------------------------------------------------------------------------------
+_Use_decl_annotations_
+HRESULT ScratchImage::Initialize(const TexMetadata& mdata, CP_FLAGS flags) noexcept
+{
+    if (!IsValid(mdata.format))
+        return E_INVALIDARG;
+
+    if (IsPalettized(mdata.format))
+        return HRESULT_E_NOT_SUPPORTED;
+
+    size_t mipLevels = mdata.mipLevels;
+
+    switch (mdata.dimension)
+    {
+    case TEX_DIMENSION_TEXTURE1D:
+        if (!mdata.width || mdata.height != 1 || mdata.depth != 1 || !mdata.arraySize)
+            return E_INVALIDARG;
+
+        if (!CalculateMipLevels(mdata.width, 1, mipLevels))
+            return E_INVALIDARG;
+        break;
+
+    case TEX_DIMENSION_TEXTURE2D:
+        if (!mdata.width || !mdata.height || mdata.depth != 1 || !mdata.arraySize)
+            return E_INVALIDARG;
+
+        if (mdata.IsCubemap())
+        {
+            if ((mdata.arraySize % 6) != 0)
+                return E_INVALIDARG;
+        }
+
+        if (!CalculateMipLevels(mdata.width, mdata.height, mipLevels))
+            return E_INVALIDARG;
+        break;
+
+    case TEX_DIMENSION_TEXTURE3D:
+        if (!mdata.width || !mdata.height || !mdata.depth || mdata.arraySize != 1)
+            return E_INVALIDARG;
+
+        if (!CalculateMipLevels3D(mdata.width, mdata.height, mdata.depth, mipLevels))
+            return E_INVALIDARG;
+        break;
+
+    default:
+        return HRESULT_E_NOT_SUPPORTED;
+    }
+
+    Release();
+
+    m_metadata.width = mdata.width;
+    m_metadata.height = mdata.height;
+    m_metadata.depth = mdata.depth;
+    m_metadata.arraySize = mdata.arraySize;
+    m_metadata.mipLevels = mipLevels;
+    m_metadata.miscFlags = mdata.miscFlags;
+    m_metadata.miscFlags2 = mdata.miscFlags2;
+    m_metadata.format = mdata.format;
+    m_metadata.dimension = mdata.dimension;
+
+    size_t pixelSize, nimages;
+    HRESULT hr = DetermineImageArray(m_metadata, flags, nimages, pixelSize);
+    if (FAILED(hr))
+        return hr;
+
+    m_image = new (std::nothrow) Image[nimages];
+    if (!m_image)
+        return E_OUTOFMEMORY;
+
+    m_nimages = nimages;
+    memset(m_image, 0, sizeof(Image) * nimages);
+
+    m_memory = static_cast<uint8_t*>(_aligned_malloc(pixelSize, 16));
+    if (!m_memory)
+    {
+        Release();
+        return E_OUTOFMEMORY;
+    }
+    memset(m_memory, 0, pixelSize);
+    m_size = pixelSize;
+
+    if (!SetupImageArray(m_memory, pixelSize, m_metadata, flags, m_image, nimages))
+    {
+        Release();
+        return E_FAIL;
+    }
+
+    return S_OK;
+}
+
+_Use_decl_annotations_
+HRESULT ScratchImage::Initialize1D(DXGI_FORMAT fmt, size_t length, size_t arraySize, size_t mipLevels, CP_FLAGS flags) noexcept
+{
+    if (!length || !arraySize)
+        return E_INVALIDARG;
+
+    // 1D is a special case of the 2D case
+    HRESULT hr = Initialize2D(fmt, length, 1, arraySize, mipLevels, flags);
+    if (FAILED(hr))
+        return hr;
+
+    m_metadata.dimension = TEX_DIMENSION_TEXTURE1D;
+
+    return S_OK;
+}
+
+_Use_decl_annotations_
+HRESULT ScratchImage::Initialize2D(DXGI_FORMAT fmt, size_t width, size_t height, size_t arraySize, size_t mipLevels, CP_FLAGS flags) noexcept
+{
+    if (!IsValid(fmt) || !width || !height || !arraySize)
+        return E_INVALIDARG;
+
+    if (IsPalettized(fmt))
+        return HRESULT_E_NOT_SUPPORTED;
+
+    if (!CalculateMipLevels(width, height, mipLevels))
+        return E_INVALIDARG;
+
+    Release();
+
+    m_metadata.width = width;
+    m_metadata.height = height;
+    m_metadata.depth = 1;
+    m_metadata.arraySize = arraySize;
+    m_metadata.mipLevels = mipLevels;
+    m_metadata.miscFlags = 0;
+    m_metadata.miscFlags2 = 0;
+    m_metadata.format = fmt;
+    m_metadata.dimension = TEX_DIMENSION_TEXTURE2D;
+
+    size_t pixelSize, nimages;
+    HRESULT hr = DetermineImageArray(m_metadata, flags, nimages, pixelSize);
+    if (FAILED(hr))
+        return hr;
+
+    m_image = new (std::nothrow) Image[nimages];
+    if (!m_image)
+        return E_OUTOFMEMORY;
+
+    m_nimages = nimages;
+    memset(m_image, 0, sizeof(Image) * nimages);
+
+    m_memory = static_cast<uint8_t*>(_aligned_malloc(pixelSize, 16));
+    if (!m_memory)
+    {
+        Release();
+        return E_OUTOFMEMORY;
+    }
+    memset(m_memory, 0, pixelSize);
+    m_size = pixelSize;
+
+    if (!SetupImageArray(m_memory, pixelSize, m_metadata, flags, m_image, nimages))
+    {
+        Release();
+        return E_FAIL;
+    }
+
+    return S_OK;
+}
+
+_Use_decl_annotations_
+HRESULT ScratchImage::Initialize3D(DXGI_FORMAT fmt, size_t width, size_t height, size_t depth, size_t mipLevels, CP_FLAGS flags) noexcept
+{
+    if (!IsValid(fmt) || !width || !height || !depth)
+        return E_INVALIDARG;
+
+    if (depth > INT16_MAX)
+        return E_INVALIDARG;
+
+    if (IsPalettized(fmt))
+        return HRESULT_E_NOT_SUPPORTED;
+
+    if (!CalculateMipLevels3D(width, height, depth, mipLevels))
+        return E_INVALIDARG;
+
+    Release();
+
+    m_metadata.width = width;
+    m_metadata.height = height;
+    m_metadata.depth = depth;
+    m_metadata.arraySize = 1;    // Direct3D 10.x/11 does not support arrays of 3D textures
+    m_metadata.mipLevels = mipLevels;
+    m_metadata.miscFlags = 0;
+    m_metadata.miscFlags2 = 0;
+    m_metadata.format = fmt;
+    m_metadata.dimension = TEX_DIMENSION_TEXTURE3D;
+
+    size_t pixelSize, nimages;
+    HRESULT hr = DetermineImageArray(m_metadata, flags, nimages, pixelSize);
+    if (FAILED(hr))
+        return hr;
+
+    m_image = new (std::nothrow) Image[nimages];
+    if (!m_image)
+    {
+        Release();
+        return E_OUTOFMEMORY;
+    }
+    m_nimages = nimages;
+    memset(m_image, 0, sizeof(Image) * nimages);
+
+    m_memory = static_cast<uint8_t*>(_aligned_malloc(pixelSize, 16));
+    if (!m_memory)
+    {
+        Release();
+        return E_OUTOFMEMORY;
+    }
+    memset(m_memory, 0, pixelSize);
+    m_size = pixelSize;
+
+    if (!SetupImageArray(m_memory, pixelSize, m_metadata, flags, m_image, nimages))
+    {
+        Release();
+        return E_FAIL;
+    }
+
+    return S_OK;
+}
+
+_Use_decl_annotations_
+HRESULT ScratchImage::InitializeCube(DXGI_FORMAT fmt, size_t width, size_t height, size_t nCubes, size_t mipLevels, CP_FLAGS flags) noexcept
+{
+    if (!width || !height || !nCubes)
+        return E_INVALIDARG;
+
+    // A DirectX11 cubemap is just a 2D texture array that is a multiple of 6 for each cube
+    HRESULT hr = Initialize2D(fmt, width, height, nCubes * 6, mipLevels, flags);
+    if (FAILED(hr))
+        return hr;
+
+    m_metadata.miscFlags |= TEX_MISC_TEXTURECUBE;
+
+    return S_OK;
+}
+
+_Use_decl_annotations_
+HRESULT ScratchImage::InitializeFromImage(const Image& srcImage, bool allow1D, CP_FLAGS flags) noexcept
+{
+    HRESULT hr = (srcImage.height > 1 || !allow1D)
+        ? Initialize2D(srcImage.format, srcImage.width, srcImage.height, 1, 1, flags)
+        : Initialize1D(srcImage.format, srcImage.width, 1, 1, flags);
+
+    if (FAILED(hr))
+        return hr;
+
+    const size_t rowCount = ComputeScanlines(srcImage.format, srcImage.height);
+    if (!rowCount)
+        return E_UNEXPECTED;
+
+    const uint8_t* sptr = srcImage.pixels;
+    if (!sptr)
+        return E_POINTER;
+
+    uint8_t* dptr = m_image[0].pixels;
+    if (!dptr)
+        return E_POINTER;
+
+    const size_t spitch = srcImage.rowPitch;
+    const size_t dpitch = m_image[0].rowPitch;
+
+    const size_t size = std::min<size_t>(dpitch, spitch);
+
+    for (size_t y = 0; y < rowCount; ++y)
+    {
+        memcpy(dptr, sptr, size);
+        sptr += spitch;
+        dptr += dpitch;
+    }
+
+    return S_OK;
+}
+
+_Use_decl_annotations_
+HRESULT ScratchImage::InitializeArrayFromImages(const Image* images, size_t nImages, bool allow1D, CP_FLAGS flags) noexcept
+{
+    if (!images || !nImages)
+        return E_INVALIDARG;
+
+    const DXGI_FORMAT format = images[0].format;
+    const size_t width = images[0].width;
+    const size_t height = images[0].height;
+
+    for (size_t index = 0; index < nImages; ++index)
+    {
+        if (!images[index].pixels)
+            return E_POINTER;
+
+        if (images[index].format != format || images[index].width != width || images[index].height != height)
+        {
+            // All images must be the same format, width, and height
+            return E_FAIL;
+        }
+    }
+
+    HRESULT hr = (height > 1 || !allow1D)
+        ? Initialize2D(format, width, height, nImages, 1, flags)
+        : Initialize1D(format, width, nImages, 1, flags);
+
+    if (FAILED(hr))
+        return hr;
+
+    const size_t rowCount = ComputeScanlines(format, height);
+    if (!rowCount)
+        return E_UNEXPECTED;
+
+    for (size_t index = 0; index < nImages; ++index)
+    {
+        const uint8_t* sptr = images[index].pixels;
+        if (!sptr)
+            return E_POINTER;
+
+        assert(index < m_nimages);
+        uint8_t* dptr = m_image[index].pixels;
+        if (!dptr)
+            return E_POINTER;
+
+        const size_t spitch = images[index].rowPitch;
+        const size_t dpitch = m_image[index].rowPitch;
+
+        const size_t size = std::min<size_t>(dpitch, spitch);
+
+        for (size_t y = 0; y < rowCount; ++y)
+        {
+            memcpy(dptr, sptr, size);
+            sptr += spitch;
+            dptr += dpitch;
+        }
+    }
+
+    return S_OK;
+}
+
+_Use_decl_annotations_
+HRESULT ScratchImage::InitializeCubeFromImages(const Image* images, size_t nImages, CP_FLAGS flags) noexcept
+{
+    if (!images || !nImages)
+        return E_INVALIDARG;
+
+    // A DirectX11 cubemap is just a 2D texture array that is a multiple of 6 for each cube
+    if ((nImages % 6) != 0)
+        return E_INVALIDARG;
+
+    HRESULT hr = InitializeArrayFromImages(images, nImages, false, flags);
+    if (FAILED(hr))
+        return hr;
+
+    m_metadata.miscFlags |= TEX_MISC_TEXTURECUBE;
+
+    return S_OK;
+}
+
+_Use_decl_annotations_
+HRESULT ScratchImage::Initialize3DFromImages(const Image* images, size_t depth, CP_FLAGS flags) noexcept
+{
+    if (!images || !depth)
+        return E_INVALIDARG;
+
+    if (depth > INT16_MAX)
+        return E_INVALIDARG;
+
+    const DXGI_FORMAT format = images[0].format;
+    const size_t width = images[0].width;
+    const size_t height = images[0].height;
+
+    for (size_t slice = 0; slice < depth; ++slice)
+    {
+        if (!images[slice].pixels)
+            return E_POINTER;
+
+        if (images[slice].format != format || images[slice].width != width || images[slice].height != height)
+        {
+            // All images must be the same format, width, and height
+            return E_FAIL;
+        }
+    }
+
+    HRESULT hr = Initialize3D(format, width, height, depth, 1, flags);
+    if (FAILED(hr))
+        return hr;
+
+    const size_t rowCount = ComputeScanlines(format, height);
+    if (!rowCount)
+        return E_UNEXPECTED;
+
+    for (size_t slice = 0; slice < depth; ++slice)
+    {
+        const uint8_t* sptr = images[slice].pixels;
+        if (!sptr)
+            return E_POINTER;
+
+        assert(slice < m_nimages);
+        uint8_t* dptr = m_image[slice].pixels;
+        if (!dptr)
+            return E_POINTER;
+
+        const size_t spitch = images[slice].rowPitch;
+        const size_t dpitch = m_image[slice].rowPitch;
+
+        const size_t size = std::min<size_t>(dpitch, spitch);
+
+        for (size_t y = 0; y < rowCount; ++y)
+        {
+            memcpy(dptr, sptr, size);
+            sptr += spitch;
+            dptr += dpitch;
+        }
+    }
+
+    return S_OK;
+}
+
+void ScratchImage::Release() noexcept
+{
+    m_nimages = 0;
+    m_size = 0;
+
+    if (m_image)
+    {
+        delete[] m_image;
+        m_image = nullptr;
+    }
+
+    if (m_memory)
+    {
+        _aligned_free(m_memory);
+        m_memory = nullptr;
+    }
+
+    memset(&m_metadata, 0, sizeof(m_metadata));
+}
+
+_Use_decl_annotations_
+bool ScratchImage::OverrideFormat(DXGI_FORMAT f) noexcept
+{
+    if (!m_image)
+        return false;
+
+    if (!IsValid(f) || IsPlanar(f) || IsPalettized(f))
+        return false;
+
+    for (size_t index = 0; index < m_nimages; ++index)
+    {
+        m_image[index].format = f;
+    }
+
+    m_metadata.format = f;
+
+    return true;
+}
+
+_Use_decl_annotations_
+const Image* ScratchImage::GetImage(size_t mip, size_t item, size_t slice) const noexcept
+{
+    if (mip >= m_metadata.mipLevels)
+        return nullptr;
+
+    size_t index = 0;
+
+    switch (m_metadata.dimension)
+    {
+    case TEX_DIMENSION_TEXTURE1D:
+    case TEX_DIMENSION_TEXTURE2D:
+        if (slice > 0)
+            return nullptr;
+
+        if (item >= m_metadata.arraySize)
+            return nullptr;
+
+        index = item*(m_metadata.mipLevels) + mip;
+        break;
+
+    case TEX_DIMENSION_TEXTURE3D:
+        if (item > 0)
+        {
+            // No support for arrays of volumes
+            return nullptr;
+        }
+        else
+        {
+            size_t d = m_metadata.depth;
+
+            for (size_t level = 0; level < mip; ++level)
+            {
+                index += d;
+                if (d > 1)
+                    d >>= 1;
+            }
+
+            if (slice >= d)
+                return nullptr;
+
+            index += slice;
+        }
+        break;
+
+    default:
+        return nullptr;
+    }
+
+    return &m_image[index];
+}
+
+bool ScratchImage::IsAlphaAllOpaque() const noexcept
+{
+    if (!m_image)
+        return false;
+
+    if (!HasAlpha(m_metadata.format))
+        return true;
+
+    if (IsCompressed(m_metadata.format))
+    {
+        for (size_t index = 0; index < m_nimages; ++index)
+        {
+            if (!IsAlphaAllOpaqueBC(m_image[index]))
+                return false;
+        }
+    }
+    else
+    {
+        auto scanline = make_AlignedArrayXMVECTOR(m_metadata.width);
+        if (!scanline)
+            return false;
+
+        static const XMVECTORF32 threshold = { { { 0.997f, 0.997f, 0.997f, 0.997f } } };
+
+        for (size_t index = 0; index < m_nimages; ++index)
+        {
+        #pragma warning( suppress : 6011 )
+            const Image& img = m_image[index];
+
+            const uint8_t *pPixels = img.pixels;
+            assert(pPixels);
+
+            for (size_t h = 0; h < img.height; ++h)
+            {
+                if (!LoadScanline(scanline.get(), img.width, pPixels, img.rowPitch, img.format))
+                    return false;
+
+                const XMVECTOR* ptr = scanline.get();
+                for (size_t w = 0; w < img.width; ++w)
+                {
+                    const XMVECTOR alpha = XMVectorSplatW(*ptr);
+                    if (XMVector4Less(alpha, threshold))
+                        return false;
+                    ++ptr;
+                }
+
+                pPixels += img.rowPitch;
+            }
+        }
+    }
+
+    return true;
+}

--- a/DirectXTex/DirectXTex/DirectXTexMipmaps.cpp
+++ b/DirectXTex/DirectXTex/DirectXTexMipmaps.cpp
@@ -1,0 +1,3556 @@
+//-------------------------------------------------------------------------------------
+// DirectXTexMipMaps.cpp
+//
+// DirectX Texture Library - Mip-map generation
+//
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+//
+// http://go.microsoft.com/fwlink/?LinkId=248926
+//-------------------------------------------------------------------------------------
+
+#include "DirectXTexP.h"
+
+#include "filters.h"
+
+using namespace DirectX;
+using namespace DirectX::Internal;
+using Microsoft::WRL::ComPtr;
+
+namespace
+{
+    constexpr bool ispow2(_In_ size_t x) noexcept
+    {
+        return ((x != 0) && !(x & (x - 1)));
+    }
+
+
+    size_t CountMips(_In_ size_t width, _In_ size_t height) noexcept
+    {
+        size_t mipLevels = 1;
+
+        while (height > 1 || width > 1)
+        {
+            if (height > 1)
+                height >>= 1;
+
+            if (width > 1)
+                width >>= 1;
+
+            ++mipLevels;
+        }
+
+        return mipLevels;
+    }
+
+
+    size_t CountMips3D(_In_ size_t width, _In_ size_t height, _In_ size_t depth) noexcept
+    {
+        size_t mipLevels = 1;
+
+        while (height > 1 || width > 1 || depth > 1)
+        {
+            if (height > 1)
+                height >>= 1;
+
+            if (width > 1)
+                width >>= 1;
+
+            if (depth > 1)
+                depth >>= 1;
+
+            ++mipLevels;
+        }
+
+        return mipLevels;
+    }
+
+#ifdef _WIN32
+    HRESULT EnsureWicBitmapPixelFormat(
+        _In_ IWICImagingFactory* pWIC,
+        _In_ IWICBitmap* src,
+        _In_ TEX_FILTER_FLAGS filter,
+        _In_ const WICPixelFormatGUID& desiredPixelFormat,
+        __RPC__deref_out_opt /* needed to match WIC annotation */ IWICBitmap** dest) noexcept
+    {
+        if (!dest)
+            return E_POINTER;
+
+        *dest = nullptr;
+
+        if (!pWIC || !src)
+            return E_POINTER;
+
+        WICPixelFormatGUID actualPixelFormat;
+        HRESULT hr = src->GetPixelFormat(&actualPixelFormat);
+
+        if (SUCCEEDED(hr))
+        {
+            if (memcmp(&actualPixelFormat, &desiredPixelFormat, sizeof(WICPixelFormatGUID)) == 0)
+            {
+                src->AddRef();
+                *dest = src;
+            }
+            else
+            {
+                ComPtr<IWICFormatConverter> converter;
+                hr = pWIC->CreateFormatConverter(converter.GetAddressOf());
+
+                if (SUCCEEDED(hr))
+                {
+                    BOOL canConvert = FALSE;
+                    hr = converter->CanConvert(actualPixelFormat, desiredPixelFormat, &canConvert);
+                    if (FAILED(hr) || !canConvert)
+                    {
+                        return E_UNEXPECTED;
+                    }
+                }
+
+                if (SUCCEEDED(hr))
+                {
+                    hr = converter->Initialize(src, desiredPixelFormat, GetWICDither(filter), nullptr,
+                        0, WICBitmapPaletteTypeMedianCut);
+                }
+
+                if (SUCCEEDED(hr))
+                {
+                    hr = pWIC->CreateBitmapFromSource(converter.Get(), WICBitmapCacheOnDemand, dest);
+                }
+            }
+        }
+
+        return hr;
+    }
+#endif // WIN32
+
+
+#if DIRECTX_MATH_VERSION >= 310
+#define VectorSum XMVectorSum
+#else
+    inline XMVECTOR XM_CALLCONV VectorSum
+    (
+        FXMVECTOR V
+    )
+    {
+        XMVECTOR vTemp = XMVectorSwizzle<2, 3, 0, 1>(V);
+        XMVECTOR vTemp2 = XMVectorAdd(V, vTemp);
+        vTemp = XMVectorSwizzle<1, 0, 3, 2>(vTemp2);
+        return XMVectorAdd(vTemp, vTemp2);
+    }
+#endif
+
+
+    HRESULT ScaleAlpha(
+        const Image& srcImage,
+        float alphaScale,
+        const Image& destImage) noexcept
+    {
+        assert(srcImage.width == destImage.width);
+        assert(srcImage.height == destImage.height);
+
+        auto scanline = make_AlignedArrayXMVECTOR(srcImage.width);
+        if (!scanline)
+        {
+            return E_OUTOFMEMORY;
+        }
+
+        const uint8_t* pSrc = srcImage.pixels;
+        uint8_t* pDest = destImage.pixels;
+        if (!pSrc || !pDest)
+        {
+            return E_POINTER;
+        }
+
+        const XMVECTOR vscale = XMVectorReplicate(alphaScale);
+
+        for (size_t h = 0; h < srcImage.height; ++h)
+        {
+            if (!LoadScanline(scanline.get(), srcImage.width, pSrc, srcImage.rowPitch, srcImage.format))
+            {
+                return E_FAIL;
+            }
+
+            XMVECTOR* ptr = scanline.get();
+            for (size_t w = 0; w < srcImage.width; ++w)
+            {
+                const XMVECTOR v = *ptr;
+                const XMVECTOR alpha = XMVectorMultiply(XMVectorSplatW(v), vscale);
+                *(ptr++) = XMVectorSelect(alpha, v, g_XMSelect1110);
+            }
+
+            if (!StoreScanline(pDest, destImage.rowPitch, destImage.format, scanline.get(), srcImage.width))
+            {
+                return E_FAIL;
+            }
+
+            pSrc += srcImage.rowPitch;
+            pDest += destImage.rowPitch;
+        }
+
+        return S_OK;
+    }
+
+
+    void GenerateAlphaCoverageConvolutionVectors(
+        _In_ size_t N,
+        _Out_writes_(N*N) XMVECTOR* vectors) noexcept
+    {
+        for (size_t sy = 0; sy < N; ++sy)
+        {
+            const float fy = (float(sy) + 0.5f) / float(N);
+            const float ify = 1.0f - fy;
+
+            for (size_t sx = 0; sx < N; ++sx)
+            {
+                const float fx = (float(sx) + 0.5f) / float(N);
+                const float ifx = 1.0f - fx;
+
+                // [0]=(x+0, y+0), [1]=(x+0, y+1), [2]=(x+1, y+0), [3]=(x+1, y+1)
+                vectors[sy * N + sx] = XMVectorSet(ifx * ify, ifx * fy, fx * ify, fx * fy);
+            }
+        }
+    }
+
+
+    HRESULT CalculateAlphaCoverage(
+        const Image& srcImage,
+        float alphaReference,
+        float alphaScale,
+        float& coverage) noexcept
+    {
+        coverage = 0.0f;
+
+        auto row0 = make_AlignedArrayXMVECTOR(srcImage.width);
+        if (!row0)
+        {
+            return E_OUTOFMEMORY;
+        }
+
+        auto row1 = make_AlignedArrayXMVECTOR(srcImage.width);
+        if (!row1)
+        {
+            return E_OUTOFMEMORY;
+        }
+
+        const XMVECTOR scale = XMVectorReplicate(alphaScale);
+
+        const uint8_t *pSrcRow0 = srcImage.pixels;
+        if (!pSrcRow0)
+        {
+            return E_POINTER;
+        }
+
+        constexpr size_t N = 8;
+        XMVECTOR convolution[N * N];
+        GenerateAlphaCoverageConvolutionVectors(N, convolution);
+
+        size_t coverageCount = 0;
+        for (size_t y = 0; y < srcImage.height - 1; ++y)
+        {
+            if (!LoadScanlineLinear(row0.get(), srcImage.width, pSrcRow0, srcImage.rowPitch, srcImage.format, TEX_FILTER_DEFAULT))
+            {
+                return E_FAIL;
+            }
+
+            const uint8_t *pSrcRow1 = pSrcRow0 + srcImage.rowPitch;
+            if (!LoadScanlineLinear(row1.get(), srcImage.width, pSrcRow1, srcImage.rowPitch, srcImage.format, TEX_FILTER_DEFAULT))
+            {
+                return E_FAIL;
+            }
+
+            const XMVECTOR* pRow0 = row0.get();
+            const XMVECTOR* pRow1 = row1.get();
+            for (size_t x = 0; x < srcImage.width - 1; ++x)
+            {
+                // [0]=(x+0, y+0), [1]=(x+0, y+1), [2]=(x+1, y+0), [3]=(x+1, y+1)
+                XMVECTOR r0 = XMVectorSplatW(*pRow0);
+                XMVECTOR r1 = XMVectorSplatW(*pRow1);
+
+                XMVECTOR v1 = XMVectorSaturate(XMVectorMultiply(r0, scale));
+                const XMVECTOR v2 = XMVectorSaturate(XMVectorMultiply(r1, scale));
+
+                r0 = XMVectorSplatW(*(++pRow0));
+                r1 = XMVectorSplatW(*(++pRow1));
+
+                XMVECTOR v3 = XMVectorSaturate(XMVectorMultiply(XMVectorSplatW(r0), scale));
+                const XMVECTOR v4 = XMVectorSaturate(XMVectorMultiply(XMVectorSplatW(r1), scale));
+
+                v1 = XMVectorMergeXY(v1, v2); // [v1.x v2.x --- ---]
+                v3 = XMVectorMergeXY(v3, v4); // [v3.x v4.x --- ---]
+
+                XMVECTOR v = XMVectorPermute<0, 1, 4, 5>(v1, v3); // [v1.x v2.x v3.x v4.x]
+
+                for (size_t sy = 0; sy < N; ++sy)
+                {
+                    const size_t ry = sy * N;
+                    for (size_t sx = 0; sx < N; ++sx)
+                    {
+                        v = VectorSum(XMVectorMultiply(v, convolution[ry + sx]));
+                        if (XMVectorGetX(v) > alphaReference)
+                        {
+                            ++coverageCount;
+                        }
+                    }
+                }
+            }
+
+            pSrcRow0 = pSrcRow1;
+        }
+
+        float cscale = static_cast<float>((srcImage.width - 1) * (srcImage.height - 1) * N * N);
+        if (cscale > 0.f)
+        {
+            coverage = static_cast<float>(coverageCount) / cscale;
+        }
+
+        return S_OK;
+    }
+
+
+    HRESULT EstimateAlphaScaleForCoverage(
+        const Image& srcImage,
+        float alphaReference,
+        float targetCoverage,
+        float& alphaScale) noexcept
+    {
+        float minAlphaScale = 0.0f;
+        float maxAlphaScale = 4.0f;
+        float bestError = FLT_MAX;
+
+        // Determine desired scale using a binary search. Hardcoded to 10 steps max.
+        alphaScale = 1.0f;
+        constexpr size_t N = 10;
+        for (size_t i = 0; i < N; ++i)
+        {
+            float currentCoverage = 0.0f;
+            HRESULT hr = CalculateAlphaCoverage(srcImage, alphaReference, alphaScale, currentCoverage);
+            if (FAILED(hr))
+            {
+                return hr;
+            }
+
+            const float error = fabsf(currentCoverage - targetCoverage);
+            if (error < bestError)
+            {
+                bestError = error;
+            }
+
+            if (currentCoverage < targetCoverage)
+            {
+                minAlphaScale = alphaScale;
+            }
+            else if (currentCoverage > targetCoverage)
+            {
+                maxAlphaScale = alphaScale;
+            }
+            else
+            {
+                break;
+            }
+
+            alphaScale = (minAlphaScale + maxAlphaScale) * 0.5f;
+        }
+
+        return S_OK;
+    }
+}
+
+_Use_decl_annotations_
+bool DirectX::Internal::CalculateMipLevels(
+    size_t width,
+    size_t height,
+    size_t& mipLevels) noexcept
+{
+    if (mipLevels > 1)
+    {
+        const size_t maxMips = CountMips(width, height);
+        if (mipLevels > maxMips)
+            return false;
+    }
+    else if (mipLevels == 0)
+    {
+        mipLevels = CountMips(width, height);
+    }
+    else
+    {
+        mipLevels = 1;
+    }
+    return true;
+}
+
+_Use_decl_annotations_
+bool DirectX::Internal::CalculateMipLevels3D(
+    size_t width,
+    size_t height,
+    size_t depth,
+    size_t& mipLevels) noexcept
+{
+    if (mipLevels > 1)
+    {
+        const size_t maxMips = CountMips3D(width, height, depth);
+        if (mipLevels > maxMips)
+            return false;
+    }
+    else if (mipLevels == 0)
+    {
+        mipLevels = CountMips3D(width, height, depth);
+    }
+    else
+    {
+        mipLevels = 1;
+    }
+    return true;
+}
+
+#ifdef _WIN32
+//--- Resizing color and alpha channels separately using WIC ---
+_Use_decl_annotations_
+HRESULT DirectX::Internal::ResizeSeparateColorAndAlpha(
+    IWICImagingFactory* pWIC,
+    bool iswic2,
+    IWICBitmap* original,
+    size_t newWidth,
+    size_t newHeight,
+    TEX_FILTER_FLAGS filter,
+    const Image* img) noexcept
+{
+    if (!pWIC || !original || !img)
+        return E_POINTER;
+
+    const WICBitmapInterpolationMode interpolationMode = GetWICInterp(filter);
+
+    WICPixelFormatGUID desiredPixelFormat = GUID_WICPixelFormatUndefined;
+    HRESULT hr = original->GetPixelFormat(&desiredPixelFormat);
+
+    size_t colorBytesInPixel = 0;
+    size_t colorBytesPerPixel = 0;
+    size_t colorWithAlphaBytesPerPixel = 0;
+    WICPixelFormatGUID colorPixelFormat = GUID_WICPixelFormatUndefined;
+    WICPixelFormatGUID colorWithAlphaPixelFormat = GUID_WICPixelFormatUndefined;
+
+    if (SUCCEEDED(hr))
+    {
+        ComPtr<IWICComponentInfo> componentInfo;
+        hr = pWIC->CreateComponentInfo(desiredPixelFormat, componentInfo.GetAddressOf());
+
+        ComPtr<IWICPixelFormatInfo> pixelFormatInfo;
+        if (SUCCEEDED(hr))
+        {
+            hr = componentInfo.As(&pixelFormatInfo);
+        }
+
+        UINT bitsPerPixel = 0;
+        if (SUCCEEDED(hr))
+        {
+            hr = pixelFormatInfo->GetBitsPerPixel(&bitsPerPixel);
+        }
+
+        if (SUCCEEDED(hr))
+        {
+            if (bitsPerPixel <= 32)
+            {
+                colorBytesInPixel = colorBytesPerPixel = 3;
+                colorPixelFormat = GUID_WICPixelFormat24bppBGR;
+
+                colorWithAlphaBytesPerPixel = 4;
+                colorWithAlphaPixelFormat = GUID_WICPixelFormat32bppBGRA;
+            }
+            else
+            {
+            #if(_WIN32_WINNT >= _WIN32_WINNT_WIN8) || defined(_WIN7_PLATFORM_UPDATE)
+                if (iswic2)
+                {
+                    colorBytesInPixel = colorBytesPerPixel = 12;
+                    colorPixelFormat = GUID_WICPixelFormat96bppRGBFloat;
+                }
+                else
+                #else
+                UNREFERENCED_PARAMETER(iswic2);
+            #endif
+                {
+                    colorBytesInPixel = 12;
+                    colorBytesPerPixel = 16;
+                    colorPixelFormat = GUID_WICPixelFormat128bppRGBFloat;
+                }
+
+                colorWithAlphaBytesPerPixel = 16;
+                colorWithAlphaPixelFormat = GUID_WICPixelFormat128bppRGBAFloat;
+            }
+        }
+    }
+
+    // Resize color only image (no alpha channel)
+    ComPtr<IWICBitmap> resizedColor;
+    if (SUCCEEDED(hr))
+    {
+        ComPtr<IWICBitmapScaler> colorScaler;
+        hr = pWIC->CreateBitmapScaler(colorScaler.GetAddressOf());
+        if (SUCCEEDED(hr))
+        {
+            ComPtr<IWICBitmap> converted;
+            hr = EnsureWicBitmapPixelFormat(pWIC, original, filter, colorPixelFormat, converted.GetAddressOf());
+            if (SUCCEEDED(hr))
+            {
+                hr = colorScaler->Initialize(converted.Get(), static_cast<UINT>(newWidth), static_cast<UINT>(newHeight), interpolationMode);
+            }
+        }
+
+        if (SUCCEEDED(hr))
+        {
+            ComPtr<IWICBitmap> resized;
+            hr = pWIC->CreateBitmapFromSource(colorScaler.Get(), WICBitmapCacheOnDemand, resized.GetAddressOf());
+            if (SUCCEEDED(hr))
+            {
+                hr = EnsureWicBitmapPixelFormat(pWIC, resized.Get(), filter, colorPixelFormat, resizedColor.GetAddressOf());
+            }
+        }
+    }
+
+    // Resize color+alpha image
+    ComPtr<IWICBitmap> resizedColorWithAlpha;
+    if (SUCCEEDED(hr))
+    {
+        ComPtr<IWICBitmapScaler> colorWithAlphaScaler;
+        hr = pWIC->CreateBitmapScaler(colorWithAlphaScaler.GetAddressOf());
+        if (SUCCEEDED(hr))
+        {
+            ComPtr<IWICBitmap> converted;
+            hr = EnsureWicBitmapPixelFormat(pWIC, original, filter, colorWithAlphaPixelFormat, converted.GetAddressOf());
+            if (SUCCEEDED(hr))
+            {
+                hr = colorWithAlphaScaler->Initialize(converted.Get(), static_cast<UINT>(newWidth), static_cast<UINT>(newHeight), interpolationMode);
+            }
+        }
+
+        if (SUCCEEDED(hr))
+        {
+            ComPtr<IWICBitmap> resized;
+            hr = pWIC->CreateBitmapFromSource(colorWithAlphaScaler.Get(), WICBitmapCacheOnDemand, resized.GetAddressOf());
+            if (SUCCEEDED(hr))
+            {
+                hr = EnsureWicBitmapPixelFormat(pWIC, resized.Get(), filter, colorWithAlphaPixelFormat, resizedColorWithAlpha.GetAddressOf());
+            }
+        }
+    }
+
+    // Merge pixels (copying color channels from color only image to color+alpha image)
+    if (SUCCEEDED(hr))
+    {
+        ComPtr<IWICBitmapLock> colorLock;
+        ComPtr<IWICBitmapLock> colorWithAlphaLock;
+        hr = resizedColor->Lock(nullptr, WICBitmapLockRead, colorLock.GetAddressOf());
+        if (SUCCEEDED(hr))
+        {
+            hr = resizedColorWithAlpha->Lock(nullptr, WICBitmapLockWrite, colorWithAlphaLock.GetAddressOf());
+        }
+
+        if (SUCCEEDED(hr))
+        {
+            BYTE* colorWithAlphaData = nullptr;
+            UINT colorWithAlphaSizeInBytes = 0;
+            UINT colorWithAlphaStride = 0;
+
+            hr = colorWithAlphaLock->GetDataPointer(&colorWithAlphaSizeInBytes, &colorWithAlphaData);
+            if (SUCCEEDED(hr))
+            {
+                if (!colorWithAlphaData)
+                {
+                    hr = E_POINTER;
+                }
+                else
+                {
+                    hr = colorWithAlphaLock->GetStride(&colorWithAlphaStride);
+                }
+            }
+
+            BYTE* colorData = nullptr;
+            UINT colorSizeInBytes = 0;
+            UINT colorStride = 0;
+            if (SUCCEEDED(hr))
+            {
+                hr = colorLock->GetDataPointer(&colorSizeInBytes, &colorData);
+                if (SUCCEEDED(hr))
+                {
+                    if (!colorData)
+                    {
+                        hr = E_POINTER;
+                    }
+                    else
+                    {
+                        hr = colorLock->GetStride(&colorStride);
+                    }
+                }
+            }
+
+            for (size_t j = 0; SUCCEEDED(hr) && j < newHeight; j++)
+            {
+                for (size_t i = 0; SUCCEEDED(hr) && i < newWidth; i++)
+                {
+                    size_t colorWithAlphaIndex = (j * colorWithAlphaStride) + (i * colorWithAlphaBytesPerPixel);
+                    const size_t colorIndex = (j * colorStride) + (i * colorBytesPerPixel);
+
+                    if (((colorWithAlphaIndex + colorBytesInPixel) > colorWithAlphaSizeInBytes)
+                        || ((colorIndex + colorBytesPerPixel) > colorSizeInBytes))
+                    {
+                        hr = E_INVALIDARG;
+                    }
+                    else
+                    {
+                    #pragma warning( suppress : 26014 6386 ) // No overflow possible here
+                        memcpy_s(colorWithAlphaData + colorWithAlphaIndex, colorWithAlphaBytesPerPixel, colorData + colorIndex, colorBytesInPixel);
+                    }
+                }
+            }
+        }
+    }
+
+    if (SUCCEEDED(hr))
+    {
+        if (img->rowPitch > UINT32_MAX || img->slicePitch > UINT32_MAX)
+            return HRESULT_E_ARITHMETIC_OVERFLOW;
+
+        ComPtr<IWICBitmap> wicBitmap;
+        hr = EnsureWicBitmapPixelFormat(pWIC, resizedColorWithAlpha.Get(), filter, desiredPixelFormat, wicBitmap.GetAddressOf());
+        if (SUCCEEDED(hr))
+        {
+            hr = wicBitmap->CopyPixels(nullptr, static_cast<UINT>(img->rowPitch), static_cast<UINT>(img->slicePitch), img->pixels);
+        }
+    }
+
+    return hr;
+}
+#endif // WIN32
+
+namespace
+{
+#ifdef _WIN32
+    //--- determine when to use WIC vs. non-WIC paths ---
+    bool UseWICFiltering(_In_ DXGI_FORMAT format, _In_ TEX_FILTER_FLAGS filter) noexcept
+    {
+        if (filter & TEX_FILTER_FORCE_NON_WIC)
+        {
+            // Explicit flag indicates use of non-WIC code paths
+            return false;
+        }
+
+        if (filter & TEX_FILTER_FORCE_WIC)
+        {
+            // Explicit flag to use WIC code paths, skips all the case checks below
+            return true;
+        }
+
+        if (IsSRGB(format) || (filter & TEX_FILTER_SRGB))
+        {
+            // Use non-WIC code paths for sRGB correct filtering
+            return false;
+        }
+
+    #if (defined(_XBOX_ONE) && defined(_TITLE)) || defined(_GAMING_XBOX)
+        if (format == DXGI_FORMAT_R16G16B16A16_FLOAT
+            || format == DXGI_FORMAT_R16_FLOAT)
+        {
+            // Use non-WIC code paths as these conversions are not supported by Xbox version of WIC
+            return false;
+        }
+    #endif
+
+        static_assert(TEX_FILTER_POINT == 0x100000, "TEX_FILTER_ flag values don't match TEX_FILTER_MODE_MASK");
+
+        switch (filter & TEX_FILTER_MODE_MASK)
+        {
+        case TEX_FILTER_LINEAR:
+            if (filter & TEX_FILTER_WRAP)
+            {
+                // WIC only supports 'clamp' semantics (MIRROR is equivalent to clamp for linear)
+                return false;
+            }
+
+            if (BitsPerColor(format) > 8)
+            {
+                // Avoid the WIC bitmap scaler when doing Linear filtering of XR/HDR formats
+                return false;
+            }
+            break;
+
+        case TEX_FILTER_CUBIC:
+            if (filter & (TEX_FILTER_WRAP | TEX_FILTER_MIRROR))
+            {
+                // WIC only supports 'clamp' semantics
+                return false;
+            }
+
+            if (BitsPerColor(format) > 8)
+            {
+                // Avoid the WIC bitmap scaler when doing Cubic filtering of XR/HDR formats
+                return false;
+            }
+            break;
+
+        case TEX_FILTER_TRIANGLE:
+            // WIC does not implement this filter
+            return false;
+
+        default:
+            if (BitsPerColor(format) > 8)
+            {
+                // Avoid the WIC bitmap scaler when doing filtering of XR/HDR formats
+                return false;
+            }
+            break;
+        }
+
+        return true;
+    }
+
+
+    //--- mipmap (1D/2D) generation using WIC image scalar ---
+    HRESULT GenerateMipMapsUsingWIC(
+        _In_ const Image& baseImage,
+        _In_ TEX_FILTER_FLAGS filter,
+        _In_ size_t levels,
+        _In_ const WICPixelFormatGUID& pfGUID,
+        _In_ const ScratchImage& mipChain,
+        _In_ size_t item) noexcept
+    {
+        assert(levels > 1);
+
+        if (!baseImage.pixels || !mipChain.GetPixels())
+            return E_POINTER;
+
+        bool iswic2 = false;
+        auto pWIC = GetWICFactory(iswic2);
+        if (!pWIC)
+            return E_NOINTERFACE;
+
+        size_t width = baseImage.width;
+        size_t height = baseImage.height;
+
+        if (baseImage.rowPitch > UINT32_MAX || baseImage.slicePitch > UINT32_MAX)
+            return HRESULT_E_ARITHMETIC_OVERFLOW;
+
+        ComPtr<IWICBitmap> source;
+        HRESULT hr = pWIC->CreateBitmapFromMemory(static_cast<UINT>(width), static_cast<UINT>(height), pfGUID,
+            static_cast<UINT>(baseImage.rowPitch), static_cast<UINT>(baseImage.slicePitch),
+            baseImage.pixels, source.GetAddressOf());
+        if (FAILED(hr))
+            return hr;
+
+        // Copy base image to top miplevel
+        const Image *img0 = mipChain.GetImage(0, item, 0);
+        if (!img0)
+            return E_POINTER;
+
+        uint8_t* pDest = img0->pixels;
+        if (!pDest)
+            return E_POINTER;
+
+        const uint8_t *pSrc = baseImage.pixels;
+        for (size_t h = 0; h < height; ++h)
+        {
+            const size_t msize = std::min<size_t>(img0->rowPitch, baseImage.rowPitch);
+            memcpy_s(pDest, img0->rowPitch, pSrc, msize);
+            pSrc += baseImage.rowPitch;
+            pDest += img0->rowPitch;
+        }
+
+        ComPtr<IWICComponentInfo> componentInfo;
+        hr = pWIC->CreateComponentInfo(pfGUID, componentInfo.GetAddressOf());
+        if (FAILED(hr))
+            return hr;
+
+        ComPtr<IWICPixelFormatInfo2> pixelFormatInfo;
+        hr = componentInfo.As(&pixelFormatInfo);
+        if (FAILED(hr))
+            return hr;
+
+        BOOL supportsTransparency = FALSE;
+        hr = pixelFormatInfo->SupportsTransparency(&supportsTransparency);
+        if (FAILED(hr))
+            return hr;
+
+        // Resize base image to each target mip level
+        for (size_t level = 1; level < levels; ++level)
+        {
+            const Image *img = mipChain.GetImage(level, item, 0);
+            if (!img)
+                return E_POINTER;
+
+            if (height > 1)
+                height >>= 1;
+
+            if (width > 1)
+                width >>= 1;
+
+            assert(img->width == width && img->height == height && img->format == baseImage.format);
+
+            if ((filter & TEX_FILTER_SEPARATE_ALPHA) && supportsTransparency)
+            {
+                hr = ResizeSeparateColorAndAlpha(pWIC, iswic2, source.Get(), width, height, filter, img);
+                if (FAILED(hr))
+                    return hr;
+            }
+            else
+            {
+                ComPtr<IWICBitmapScaler> scaler;
+                hr = pWIC->CreateBitmapScaler(scaler.GetAddressOf());
+                if (FAILED(hr))
+                    return hr;
+
+                if (img->rowPitch > UINT32_MAX || img->slicePitch > UINT32_MAX)
+                    return HRESULT_E_ARITHMETIC_OVERFLOW;
+
+                hr = scaler->Initialize(source.Get(),
+                    static_cast<UINT>(width), static_cast<UINT>(height),
+                    GetWICInterp(filter));
+                if (FAILED(hr))
+                    return hr;
+
+                WICPixelFormatGUID pfScaler;
+                hr = scaler->GetPixelFormat(&pfScaler);
+                if (FAILED(hr))
+                    return hr;
+
+                if (memcmp(&pfScaler, &pfGUID, sizeof(WICPixelFormatGUID)) == 0)
+                {
+                    hr = scaler->CopyPixels(nullptr, static_cast<UINT>(img->rowPitch), static_cast<UINT>(img->slicePitch), img->pixels);
+                    if (FAILED(hr))
+                        return hr;
+                }
+                else
+                {
+                    // The WIC bitmap scaler is free to return a different pixel format than the source image, so here we
+                    // convert it back
+                    ComPtr<IWICFormatConverter> FC;
+                    hr = pWIC->CreateFormatConverter(FC.GetAddressOf());
+                    if (FAILED(hr))
+                        return hr;
+
+                    BOOL canConvert = FALSE;
+                    hr = FC->CanConvert(pfScaler, pfGUID, &canConvert);
+                    if (FAILED(hr) || !canConvert)
+                    {
+                        return E_UNEXPECTED;
+                    }
+
+                    hr = FC->Initialize(scaler.Get(), pfGUID, GetWICDither(filter), nullptr,
+                        0, WICBitmapPaletteTypeMedianCut);
+                    if (FAILED(hr))
+                        return hr;
+
+                    hr = FC->CopyPixels(nullptr, static_cast<UINT>(img->rowPitch), static_cast<UINT>(img->slicePitch), img->pixels);
+                    if (FAILED(hr))
+                        return hr;
+                }
+            }
+        }
+
+        return S_OK;
+    }
+#endif // WIN32
+
+
+    //-------------------------------------------------------------------------------------
+    // Generate (1D/2D) mip-map helpers (custom filtering)
+    //-------------------------------------------------------------------------------------
+    HRESULT Setup2DMips(
+        _In_reads_(nimages) const Image* baseImages,
+        _In_ size_t nimages,
+        _In_ const TexMetadata& mdata,
+        _Out_ ScratchImage& mipChain) noexcept
+    {
+        if (!baseImages || !nimages)
+            return E_INVALIDARG;
+
+        assert(mdata.mipLevels > 1);
+        assert(mdata.arraySize == nimages);
+        assert(mdata.depth == 1 && mdata.dimension != TEX_DIMENSION_TEXTURE3D);
+        assert(mdata.width == baseImages[0].width);
+        assert(mdata.height == baseImages[0].height);
+        assert(mdata.format == baseImages[0].format);
+
+        HRESULT hr = mipChain.Initialize(mdata);
+        if (FAILED(hr))
+            return hr;
+
+        // Copy base image(s) to top of mip chain
+        for (size_t item = 0; item < nimages; ++item)
+        {
+            const Image& src = baseImages[item];
+
+            const Image *dest = mipChain.GetImage(0, item, 0);
+            if (!dest)
+            {
+                mipChain.Release();
+                return E_POINTER;
+            }
+
+            assert(src.format == dest->format);
+
+            uint8_t* pDest = dest->pixels;
+            if (!pDest)
+            {
+                mipChain.Release();
+                return E_POINTER;
+            }
+
+            const uint8_t *pSrc = src.pixels;
+            const size_t rowPitch = src.rowPitch;
+            for (size_t h = 0; h < mdata.height; ++h)
+            {
+                const size_t msize = std::min<size_t>(dest->rowPitch, rowPitch);
+                memcpy(pDest, pSrc, msize);
+                pSrc += rowPitch;
+                pDest += dest->rowPitch;
+            }
+        }
+
+        return S_OK;
+    }
+
+    //--- 2D Point Filter ---
+    HRESULT Generate2DMipsPointFilter(size_t levels, const ScratchImage& mipChain, size_t item) noexcept
+    {
+        if (!mipChain.GetImages())
+            return E_INVALIDARG;
+
+        // This assumes that the base image is already placed into the mipChain at the top level... (see _Setup2DMips)
+
+        assert(levels > 1);
+
+        size_t width = mipChain.GetMetadata().width;
+        size_t height = mipChain.GetMetadata().height;
+
+        // Allocate temporary space (2 scanlines)
+        auto scanline = make_AlignedArrayXMVECTOR(uint64_t(width) * 2);
+        if (!scanline)
+            return E_OUTOFMEMORY;
+
+        XMVECTOR* target = scanline.get();
+
+        XMVECTOR* row = target + width;
+
+        // Resize base image to each target mip level
+        for (size_t level = 1; level < levels; ++level)
+        {
+        #ifdef _DEBUG
+            memset(row, 0xCD, sizeof(XMVECTOR)*width);
+        #endif
+
+            // 2D point filter
+            const Image* src = mipChain.GetImage(level - 1, item, 0);
+            const Image* dest = mipChain.GetImage(level, item, 0);
+
+            if (!src || !dest)
+                return E_POINTER;
+
+            const uint8_t* pSrc = src->pixels;
+            uint8_t* pDest = dest->pixels;
+
+            const size_t rowPitch = src->rowPitch;
+
+            const size_t nwidth = (width > 1) ? (width >> 1) : 1;
+            const size_t nheight = (height > 1) ? (height >> 1) : 1;
+
+            const size_t xinc = (width << 16) / nwidth;
+            const size_t yinc = (height << 16) / nheight;
+
+            size_t lasty = size_t(-1);
+
+            size_t sy = 0;
+            for (size_t y = 0; y < nheight; ++y)
+            {
+                if ((lasty ^ sy) >> 16)
+                {
+                    if (!LoadScanline(row, width, pSrc + (rowPitch * (sy >> 16)), rowPitch, src->format))
+                        return E_FAIL;
+                    lasty = sy;
+                }
+
+                size_t sx = 0;
+                for (size_t x = 0; x < nwidth; ++x)
+                {
+                    target[x] = row[sx >> 16];
+                    sx += xinc;
+                }
+
+                if (!StoreScanline(pDest, dest->rowPitch, dest->format, target, nwidth))
+                    return E_FAIL;
+                pDest += dest->rowPitch;
+
+                sy += yinc;
+            }
+
+            if (height > 1)
+                height >>= 1;
+
+            if (width > 1)
+                width >>= 1;
+        }
+
+        return S_OK;
+    }
+
+
+    //--- 2D Box Filter ---
+    HRESULT Generate2DMipsBoxFilter(size_t levels, TEX_FILTER_FLAGS filter, const ScratchImage& mipChain, size_t item) noexcept
+    {
+        using namespace DirectX::Filters;
+
+        if (!mipChain.GetImages())
+            return E_INVALIDARG;
+
+        // This assumes that the base image is already placed into the mipChain at the top level... (see _Setup2DMips)
+
+        assert(levels > 1);
+
+        size_t width = mipChain.GetMetadata().width;
+        size_t height = mipChain.GetMetadata().height;
+
+        if (!ispow2(width) || !ispow2(height))
+            return E_FAIL;
+
+        // Allocate temporary space (3 scanlines)
+        auto scanline = make_AlignedArrayXMVECTOR(uint64_t(width) * 3);
+        if (!scanline)
+            return E_OUTOFMEMORY;
+
+        XMVECTOR* target = scanline.get();
+
+        XMVECTOR* urow0 = target + width;
+        XMVECTOR* urow1 = target + width * 2;
+
+        const XMVECTOR* urow2 = urow0 + 1;
+        const XMVECTOR* urow3 = urow1 + 1;
+
+        // Resize base image to each target mip level
+        for (size_t level = 1; level < levels; ++level)
+        {
+            if (height <= 1)
+            {
+                urow1 = urow0;
+            }
+
+            if (width <= 1)
+            {
+                urow2 = urow0;
+                urow3 = urow1;
+            }
+
+            // 2D box filter
+            const Image* src = mipChain.GetImage(level - 1, item, 0);
+            const Image* dest = mipChain.GetImage(level, item, 0);
+
+            if (!src || !dest)
+                return E_POINTER;
+
+            const uint8_t* pSrc = src->pixels;
+            uint8_t* pDest = dest->pixels;
+
+            const size_t rowPitch = src->rowPitch;
+
+            const size_t nwidth = (width > 1) ? (width >> 1) : 1;
+            const size_t nheight = (height > 1) ? (height >> 1) : 1;
+
+            for (size_t y = 0; y < nheight; ++y)
+            {
+                if (!LoadScanlineLinear(urow0, width, pSrc, rowPitch, src->format, filter))
+                    return E_FAIL;
+                pSrc += rowPitch;
+
+                if (urow0 != urow1)
+                {
+                    if (!LoadScanlineLinear(urow1, width, pSrc, rowPitch, src->format, filter))
+                        return E_FAIL;
+                    pSrc += rowPitch;
+                }
+
+                for (size_t x = 0; x < nwidth; ++x)
+                {
+                    const size_t x2 = x << 1;
+
+                    AVERAGE4(target[x], urow0[x2], urow1[x2], urow2[x2], urow3[x2])
+                }
+
+                if (!StoreScanlineLinear(pDest, dest->rowPitch, dest->format, target, nwidth, filter))
+                    return E_FAIL;
+                pDest += dest->rowPitch;
+            }
+
+            if (height > 1)
+                height >>= 1;
+
+            if (width > 1)
+                width >>= 1;
+        }
+
+        return S_OK;
+    }
+
+
+    //--- 2D Linear Filter ---
+    HRESULT Generate2DMipsLinearFilter(size_t levels, TEX_FILTER_FLAGS filter, const ScratchImage& mipChain, size_t item) noexcept
+    {
+        using namespace DirectX::Filters;
+
+        if (!mipChain.GetImages())
+            return E_INVALIDARG;
+
+        // This assumes that the base image is already placed into the mipChain at the top level... (see _Setup2DMips)
+
+        assert(levels > 1);
+
+        size_t width = mipChain.GetMetadata().width;
+        size_t height = mipChain.GetMetadata().height;
+
+        // Allocate temporary space (3 scanlines, plus X and Y filters)
+        auto scanline = make_AlignedArrayXMVECTOR(uint64_t(width) * 3);
+        if (!scanline)
+            return E_OUTOFMEMORY;
+
+        std::unique_ptr<LinearFilter[]> lf(new (std::nothrow) LinearFilter[width + height]);
+        if (!lf)
+            return E_OUTOFMEMORY;
+
+        LinearFilter* lfX = lf.get();
+        LinearFilter* lfY = lf.get() + width;
+
+        XMVECTOR* target = scanline.get();
+
+        XMVECTOR* row0 = target + width;
+        XMVECTOR* row1 = target + width * 2;
+
+        // Resize base image to each target mip level
+        for (size_t level = 1; level < levels; ++level)
+        {
+            // 2D linear filter
+            const Image* src = mipChain.GetImage(level - 1, item, 0);
+            const Image* dest = mipChain.GetImage(level, item, 0);
+
+            if (!src || !dest)
+                return E_POINTER;
+
+            const uint8_t* pSrc = src->pixels;
+            uint8_t* pDest = dest->pixels;
+
+            const size_t rowPitch = src->rowPitch;
+
+            const size_t nwidth = (width > 1) ? (width >> 1) : 1;
+            CreateLinearFilter(width, nwidth, (filter & TEX_FILTER_WRAP_U) != 0, lfX);
+
+            const size_t nheight = (height > 1) ? (height >> 1) : 1;
+            CreateLinearFilter(height, nheight, (filter & TEX_FILTER_WRAP_V) != 0, lfY);
+
+        #ifdef _DEBUG
+            memset(row0, 0xCD, sizeof(XMVECTOR)*width);
+            memset(row1, 0xDD, sizeof(XMVECTOR)*width);
+        #endif
+
+            size_t u0 = size_t(-1);
+            size_t u1 = size_t(-1);
+
+            for (size_t y = 0; y < nheight; ++y)
+            {
+                auto const& toY = lfY[y];
+
+                if (toY.u0 != u0)
+                {
+                    if (toY.u0 != u1)
+                    {
+                        u0 = toY.u0;
+
+                        if (!LoadScanlineLinear(row0, width, pSrc + (rowPitch * u0), rowPitch, src->format, filter))
+                            return E_FAIL;
+                    }
+                    else
+                    {
+                        u0 = u1;
+                        u1 = size_t(-1);
+
+                        std::swap(row0, row1);
+                    }
+                }
+
+                if (toY.u1 != u1)
+                {
+                    u1 = toY.u1;
+
+                    if (!LoadScanlineLinear(row1, width, pSrc + (rowPitch * u1), rowPitch, src->format, filter))
+                        return E_FAIL;
+                }
+
+                for (size_t x = 0; x < nwidth; ++x)
+                {
+                    auto const& toX = lfX[x];
+
+                    BILINEAR_INTERPOLATE(target[x], toX, toY, row0, row1)
+                }
+
+                if (!StoreScanlineLinear(pDest, dest->rowPitch, dest->format, target, nwidth, filter))
+                    return E_FAIL;
+                pDest += dest->rowPitch;
+            }
+
+            if (height > 1)
+                height >>= 1;
+
+            if (width > 1)
+                width >>= 1;
+        }
+
+        return S_OK;
+    }
+
+    //--- 2D Cubic Filter ---
+#ifdef __clang__
+#pragma clang diagnostic ignored "-Wextra-semi-stmt"
+#endif
+
+    HRESULT Generate2DMipsCubicFilter(size_t levels, TEX_FILTER_FLAGS filter, const ScratchImage& mipChain, size_t item) noexcept
+    {
+        using namespace DirectX::Filters;
+
+        if (!mipChain.GetImages())
+            return E_INVALIDARG;
+
+        // This assumes that the base image is already placed into the mipChain at the top level... (see _Setup2DMips)
+
+        assert(levels > 1);
+
+        size_t width = mipChain.GetMetadata().width;
+        size_t height = mipChain.GetMetadata().height;
+
+        // Allocate temporary space (5 scanlines, plus X and Y filters)
+        auto scanline = make_AlignedArrayXMVECTOR(uint64_t(width) * 5);
+        if (!scanline)
+            return E_OUTOFMEMORY;
+
+        std::unique_ptr<CubicFilter[]> cf(new (std::nothrow) CubicFilter[width + height]);
+        if (!cf)
+            return E_OUTOFMEMORY;
+
+        CubicFilter* cfX = cf.get();
+        CubicFilter* cfY = cf.get() + width;
+
+        XMVECTOR* target = scanline.get();
+
+        XMVECTOR* row0 = target + width;
+        XMVECTOR* row1 = target + width * 2;
+        XMVECTOR* row2 = target + width * 3;
+        XMVECTOR* row3 = target + width * 4;
+
+        // Resize base image to each target mip level
+        for (size_t level = 1; level < levels; ++level)
+        {
+            // 2D cubic filter
+            const Image* src = mipChain.GetImage(level - 1, item, 0);
+            const Image* dest = mipChain.GetImage(level, item, 0);
+
+            if (!src || !dest)
+                return E_POINTER;
+
+            const uint8_t* pSrc = src->pixels;
+            uint8_t* pDest = dest->pixels;
+
+            const size_t rowPitch = src->rowPitch;
+
+            const size_t nwidth = (width > 1) ? (width >> 1) : 1;
+            CreateCubicFilter(width, nwidth, (filter & TEX_FILTER_WRAP_U) != 0, (filter & TEX_FILTER_MIRROR_U) != 0, cfX);
+
+            const size_t nheight = (height > 1) ? (height >> 1) : 1;
+            CreateCubicFilter(height, nheight, (filter & TEX_FILTER_WRAP_V) != 0, (filter & TEX_FILTER_MIRROR_V) != 0, cfY);
+
+        #ifdef _DEBUG
+            memset(row0, 0xCD, sizeof(XMVECTOR)*width);
+            memset(row1, 0xDD, sizeof(XMVECTOR)*width);
+            memset(row2, 0xED, sizeof(XMVECTOR)*width);
+            memset(row3, 0xFD, sizeof(XMVECTOR)*width);
+        #endif
+
+            size_t u0 = size_t(-1);
+            size_t u1 = size_t(-1);
+            size_t u2 = size_t(-1);
+            size_t u3 = size_t(-1);
+
+            for (size_t y = 0; y < nheight; ++y)
+            {
+                auto const& toY = cfY[y];
+
+                // Scanline 1
+                if (toY.u0 != u0)
+                {
+                    if (toY.u0 != u1 && toY.u0 != u2 && toY.u0 != u3)
+                    {
+                        u0 = toY.u0;
+
+                        if (!LoadScanlineLinear(row0, width, pSrc + (rowPitch * u0), rowPitch, src->format, filter))
+                            return E_FAIL;
+                    }
+                    else if (toY.u0 == u1)
+                    {
+                        u0 = u1;
+                        u1 = size_t(-1);
+
+                        std::swap(row0, row1);
+                    }
+                    else if (toY.u0 == u2)
+                    {
+                        u0 = u2;
+                        u2 = size_t(-1);
+
+                        std::swap(row0, row2);
+                    }
+                    else if (toY.u0 == u3)
+                    {
+                        u0 = u3;
+                        u3 = size_t(-1);
+
+                        std::swap(row0, row3);
+                    }
+                }
+
+                // Scanline 2
+                if (toY.u1 != u1)
+                {
+                    if (toY.u1 != u2 && toY.u1 != u3)
+                    {
+                        u1 = toY.u1;
+
+                        if (!LoadScanlineLinear(row1, width, pSrc + (rowPitch * u1), rowPitch, src->format, filter))
+                            return E_FAIL;
+                    }
+                    else if (toY.u1 == u2)
+                    {
+                        u1 = u2;
+                        u2 = size_t(-1);
+
+                        std::swap(row1, row2);
+                    }
+                    else if (toY.u1 == u3)
+                    {
+                        u1 = u3;
+                        u3 = size_t(-1);
+
+                        std::swap(row1, row3);
+                    }
+                }
+
+                // Scanline 3
+                if (toY.u2 != u2)
+                {
+                    if (toY.u2 != u3)
+                    {
+                        u2 = toY.u2;
+
+                        if (!LoadScanlineLinear(row2, width, pSrc + (rowPitch * u2), rowPitch, src->format, filter))
+                            return E_FAIL;
+                    }
+                    else
+                    {
+                        u2 = u3;
+                        u3 = size_t(-1);
+
+                        std::swap(row2, row3);
+                    }
+                }
+
+                // Scanline 4
+                if (toY.u3 != u3)
+                {
+                    u3 = toY.u3;
+
+                    if (!LoadScanlineLinear(row3, width, pSrc + (rowPitch * u3), rowPitch, src->format, filter))
+                        return E_FAIL;
+                }
+
+                for (size_t x = 0; x < nwidth; ++x)
+                {
+                    auto const& toX = cfX[x];
+
+                    XMVECTOR C0, C1, C2, C3;
+
+                    CUBIC_INTERPOLATE(C0, toX.x, row0[toX.u0], row0[toX.u1], row0[toX.u2], row0[toX.u3]);
+                    CUBIC_INTERPOLATE(C1, toX.x, row1[toX.u0], row1[toX.u1], row1[toX.u2], row1[toX.u3]);
+                    CUBIC_INTERPOLATE(C2, toX.x, row2[toX.u0], row2[toX.u1], row2[toX.u2], row2[toX.u3]);
+                    CUBIC_INTERPOLATE(C3, toX.x, row3[toX.u0], row3[toX.u1], row3[toX.u2], row3[toX.u3]);
+
+                    CUBIC_INTERPOLATE(target[x], toY.x, C0, C1, C2, C3);
+                }
+
+                if (!StoreScanlineLinear(pDest, dest->rowPitch, dest->format, target, nwidth, filter))
+                    return E_FAIL;
+                pDest += dest->rowPitch;
+            }
+
+            if (height > 1)
+                height >>= 1;
+
+            if (width > 1)
+                width >>= 1;
+        }
+
+        return S_OK;
+    }
+
+
+    //--- 2D Triangle Filter ---
+    HRESULT Generate2DMipsTriangleFilter(size_t levels, TEX_FILTER_FLAGS filter, const ScratchImage& mipChain, size_t item) noexcept
+    {
+        using namespace DirectX::Filters;
+
+        if (!mipChain.GetImages())
+            return E_INVALIDARG;
+
+        // This assumes that the base image is already placed into the mipChain at the top level... (see _Setup2DMips)
+
+        assert(levels > 1);
+
+        size_t width = mipChain.GetMetadata().width;
+        size_t height = mipChain.GetMetadata().height;
+
+        // Allocate initial temporary space (1 scanline, accumulation rows, plus X and Y filters)
+        auto scanline = make_AlignedArrayXMVECTOR(width);
+        if (!scanline)
+            return E_OUTOFMEMORY;
+
+        std::unique_ptr<TriangleRow[]> rowActive(new (std::nothrow) TriangleRow[height]);
+        if (!rowActive)
+            return E_OUTOFMEMORY;
+
+        TriangleRow * rowFree = nullptr;
+
+        std::unique_ptr<Filter> tfX, tfY;
+
+        XMVECTOR* row = scanline.get();
+
+        // Resize base image to each target mip level
+        for (size_t level = 1; level < levels; ++level)
+        {
+            // 2D triangle filter
+            const Image* src = mipChain.GetImage(level - 1, item, 0);
+            const Image* dest = mipChain.GetImage(level, item, 0);
+
+            if (!src || !dest)
+                return E_POINTER;
+
+            const uint8_t* pSrc = src->pixels;
+            const size_t rowPitch = src->rowPitch;
+            const uint8_t* pEndSrc = pSrc + rowPitch * height;
+
+            uint8_t* pDest = dest->pixels;
+
+            const size_t nwidth = (width > 1) ? (width >> 1) : 1;
+            HRESULT hr = CreateTriangleFilter(width, nwidth, (filter & TEX_FILTER_WRAP_U) != 0, tfX);
+            if (FAILED(hr))
+                return hr;
+
+            const size_t nheight = (height > 1) ? (height >> 1) : 1;
+            hr = CreateTriangleFilter(height, nheight, (filter & TEX_FILTER_WRAP_V) != 0, tfY);
+            if (FAILED(hr))
+                return hr;
+
+        #ifdef _DEBUG
+            memset(row, 0xCD, sizeof(XMVECTOR)*width);
+        #endif
+
+            auto xFromEnd = reinterpret_cast<const FilterFrom*>(reinterpret_cast<const uint8_t*>(tfX.get()) + tfX->sizeInBytes);
+            auto yFromEnd = reinterpret_cast<const FilterFrom*>(reinterpret_cast<const uint8_t*>(tfY.get()) + tfY->sizeInBytes);
+
+            // Count times rows get written (and clear out any leftover accumulation rows from last miplevel)
+            for (FilterFrom* yFrom = tfY->from; yFrom < yFromEnd; )
+            {
+                for (size_t j = 0; j < yFrom->count; ++j)
+                {
+                    const size_t v = yFrom->to[j].u;
+                    assert(v < nheight);
+                    TriangleRow* rowAcc = &rowActive[v];
+
+                    ++rowAcc->remaining;
+
+                    if (rowAcc->scanline)
+                    {
+                        memset(rowAcc->scanline.get(), 0, sizeof(XMVECTOR) * nwidth);
+                    }
+                }
+
+                yFrom = reinterpret_cast<FilterFrom*>(reinterpret_cast<uint8_t*>(yFrom) + yFrom->sizeInBytes);
+            }
+
+            // Filter image
+            for (FilterFrom* yFrom = tfY->from; yFrom < yFromEnd; )
+            {
+                // Create accumulation rows as needed
+                for (size_t j = 0; j < yFrom->count; ++j)
+                {
+                    const size_t v = yFrom->to[j].u;
+                    assert(v < nheight);
+                    TriangleRow* rowAcc = &rowActive[v];
+
+                    if (!rowAcc->scanline)
+                    {
+                        if (rowFree)
+                        {
+                            // Steal and reuse scanline from 'free row' list
+                            // (it will always be at least as wide as nwidth due to loop decending order)
+                            assert(rowFree->scanline != nullptr);
+                            rowAcc->scanline.reset(rowFree->scanline.release());
+                            rowFree = rowFree->next;
+                        }
+                        else
+                        {
+                            auto nscanline = make_AlignedArrayXMVECTOR(nwidth);
+                            if (!nscanline)
+                                return E_OUTOFMEMORY;
+                            rowAcc->scanline.swap(nscanline);
+                        }
+
+                        memset(rowAcc->scanline.get(), 0, sizeof(XMVECTOR) * nwidth);
+                    }
+                }
+
+                // Load source scanline
+                if ((pSrc + rowPitch) > pEndSrc)
+                    return E_FAIL;
+
+                if (!LoadScanlineLinear(row, width, pSrc, rowPitch, src->format, filter))
+                    return E_FAIL;
+
+                pSrc += rowPitch;
+
+                // Process row
+                size_t x = 0;
+                for (FilterFrom* xFrom = tfX->from; xFrom < xFromEnd; ++x)
+                {
+                    for (size_t j = 0; j < yFrom->count; ++j)
+                    {
+                        const size_t v = yFrom->to[j].u;
+                        assert(v < nheight);
+                        const float yweight = yFrom->to[j].weight;
+
+                        XMVECTOR* accPtr = rowActive[v].scanline.get();
+                        if (!accPtr)
+                            return E_POINTER;
+
+                        for (size_t k = 0; k < xFrom->count; ++k)
+                        {
+                            size_t u = xFrom->to[k].u;
+                            assert(u < nwidth);
+
+                            const XMVECTOR weight = XMVectorReplicate(yweight * xFrom->to[k].weight);
+
+                            assert(x < width);
+                            accPtr[u] = XMVectorMultiplyAdd(row[x], weight, accPtr[u]);
+                        }
+                    }
+
+                    xFrom = reinterpret_cast<FilterFrom*>(reinterpret_cast<uint8_t*>(xFrom) + xFrom->sizeInBytes);
+                }
+
+                // Write completed accumulation rows
+                for (size_t j = 0; j < yFrom->count; ++j)
+                {
+                    size_t v = yFrom->to[j].u;
+                    assert(v < nheight);
+                    TriangleRow* rowAcc = &rowActive[v];
+
+                    assert(rowAcc->remaining > 0);
+                    --rowAcc->remaining;
+
+                    if (!rowAcc->remaining)
+                    {
+                        XMVECTOR* pAccSrc = rowAcc->scanline.get();
+                        if (!pAccSrc)
+                            return E_POINTER;
+
+                        switch (dest->format)
+                        {
+                        case DXGI_FORMAT_R10G10B10A2_UNORM:
+                        case DXGI_FORMAT_R10G10B10A2_UINT:
+                            {
+                                // Need to slightly bias results for floating-point error accumulation which can
+                                // be visible with harshly quantized values
+                                static const XMVECTORF32 Bias = { { { 0.f, 0.f, 0.f, 0.1f } } };
+
+                                XMVECTOR* ptr = pAccSrc;
+                                for (size_t i = 0; i < dest->width; ++i, ++ptr)
+                                {
+                                    *ptr = XMVectorAdd(*ptr, Bias);
+                                }
+                            }
+                            break;
+
+                        default:
+                            break;
+                        }
+
+                        // This performs any required clamping
+                        if (!StoreScanlineLinear(pDest + (dest->rowPitch * v), dest->rowPitch, dest->format, pAccSrc, dest->width, filter))
+                            return E_FAIL;
+
+                        // Put row on freelist to reuse it's allocated scanline
+                        rowAcc->next = rowFree;
+                        rowFree = rowAcc;
+                    }
+                }
+
+                yFrom = reinterpret_cast<FilterFrom*>(reinterpret_cast<uint8_t*>(yFrom) + yFrom->sizeInBytes);
+            }
+
+            if (height > 1)
+                height >>= 1;
+
+            if (width > 1)
+                width >>= 1;
+        }
+
+        return S_OK;
+    }
+
+
+    //-------------------------------------------------------------------------------------
+    // Generate volume mip-map helpers
+    //-------------------------------------------------------------------------------------
+    HRESULT Setup3DMips(
+        _In_reads_(depth) const Image* baseImages,
+        size_t depth,
+        size_t levels,
+        _Out_ ScratchImage& mipChain) noexcept
+    {
+        if (!baseImages || !depth)
+            return E_INVALIDARG;
+
+        if (depth > INT16_MAX)
+            return E_INVALIDARG;
+
+        assert(levels > 1);
+
+        const size_t width = baseImages[0].width;
+        const size_t height = baseImages[0].height;
+
+        HRESULT hr = mipChain.Initialize3D(baseImages[0].format, width, height, depth, levels);
+        if (FAILED(hr))
+            return hr;
+
+        // Copy base images to top slice
+        for (size_t slice = 0; slice < depth; ++slice)
+        {
+            const Image& src = baseImages[slice];
+
+            const Image *dest = mipChain.GetImage(0, 0, slice);
+            if (!dest)
+            {
+                mipChain.Release();
+                return E_POINTER;
+            }
+
+            assert(src.format == dest->format);
+
+            uint8_t* pDest = dest->pixels;
+            if (!pDest)
+            {
+                mipChain.Release();
+                return E_POINTER;
+            }
+
+            const uint8_t *pSrc = src.pixels;
+            const size_t rowPitch = src.rowPitch;
+            for (size_t h = 0; h < height; ++h)
+            {
+                const size_t msize = std::min<size_t>(dest->rowPitch, rowPitch);
+                memcpy(pDest, pSrc, msize);
+                pSrc += rowPitch;
+                pDest += dest->rowPitch;
+            }
+        }
+
+        return S_OK;
+    }
+
+
+    //--- 3D Point Filter ---
+    HRESULT Generate3DMipsPointFilter(size_t depth, size_t levels, const ScratchImage& mipChain) noexcept
+    {
+        if (!depth || !mipChain.GetImages())
+            return E_INVALIDARG;
+
+        if (depth > INT16_MAX)
+            return E_INVALIDARG;
+
+        // This assumes that the base images are already placed into the mipChain at the top level... (see _Setup3DMips)
+
+        assert(levels > 1);
+
+        size_t width = mipChain.GetMetadata().width;
+        size_t height = mipChain.GetMetadata().height;
+
+        // Allocate temporary space (2 scanlines)
+        auto scanline = make_AlignedArrayXMVECTOR(uint64_t(width) * 2);
+        if (!scanline)
+            return E_OUTOFMEMORY;
+
+        XMVECTOR* target = scanline.get();
+
+        XMVECTOR* row = target + width;
+
+        // Resize base image to each target mip level
+        for (size_t level = 1; level < levels; ++level)
+        {
+        #ifdef _DEBUG
+            memset(row, 0xCD, sizeof(XMVECTOR)*width);
+        #endif
+
+            if (depth > 1)
+            {
+                // 3D point filter
+                const size_t ndepth = depth >> 1;
+
+                const size_t zinc = (depth << 16) / ndepth;
+
+                size_t sz = 0;
+                for (size_t slice = 0; slice < ndepth; ++slice)
+                {
+                    const Image* src = mipChain.GetImage(level - 1, 0, (sz >> 16));
+                    const Image* dest = mipChain.GetImage(level, 0, slice);
+
+                    if (!src || !dest)
+                        return E_POINTER;
+
+                    const uint8_t* pSrc = src->pixels;
+                    uint8_t* pDest = dest->pixels;
+
+                    const size_t rowPitch = src->rowPitch;
+
+                    const size_t nwidth = (width > 1) ? (width >> 1) : 1;
+                    const size_t nheight = (height > 1) ? (height >> 1) : 1;
+
+                    const size_t xinc = (width << 16) / nwidth;
+                    const size_t yinc = (height << 16) / nheight;
+
+                    size_t lasty = size_t(-1);
+
+                    size_t sy = 0;
+                    for (size_t y = 0; y < nheight; ++y)
+                    {
+                        if ((lasty ^ sy) >> 16)
+                        {
+                            if (!LoadScanline(row, width, pSrc + (rowPitch * (sy >> 16)), rowPitch, src->format))
+                                return E_FAIL;
+                            lasty = sy;
+                        }
+
+                        size_t sx = 0;
+                        for (size_t x = 0; x < nwidth; ++x)
+                        {
+                            target[x] = row[sx >> 16];
+                            sx += xinc;
+                        }
+
+                        if (!StoreScanline(pDest, dest->rowPitch, dest->format, target, nwidth))
+                            return E_FAIL;
+                        pDest += dest->rowPitch;
+
+                        sy += yinc;
+                    }
+
+                    sz += zinc;
+                }
+            }
+            else
+            {
+                // 2D point filter
+                const Image* src = mipChain.GetImage(level - 1, 0, 0);
+                const Image* dest = mipChain.GetImage(level, 0, 0);
+
+                if (!src || !dest)
+                    return E_POINTER;
+
+                const uint8_t* pSrc = src->pixels;
+                uint8_t* pDest = dest->pixels;
+
+                const size_t rowPitch = src->rowPitch;
+
+                const size_t nwidth = (width > 1) ? (width >> 1) : 1;
+                const size_t nheight = (height > 1) ? (height >> 1) : 1;
+
+                const size_t xinc = (width << 16) / nwidth;
+                const size_t yinc = (height << 16) / nheight;
+
+                size_t lasty = size_t(-1);
+
+                size_t sy = 0;
+                for (size_t y = 0; y < nheight; ++y)
+                {
+                    if ((lasty ^ sy) >> 16)
+                    {
+                        if (!LoadScanline(row, width, pSrc + (rowPitch * (sy >> 16)), rowPitch, src->format))
+                            return E_FAIL;
+                        lasty = sy;
+                    }
+
+                    size_t sx = 0;
+                    for (size_t x = 0; x < nwidth; ++x)
+                    {
+                        target[x] = row[sx >> 16];
+                        sx += xinc;
+                    }
+
+                    if (!StoreScanline(pDest, dest->rowPitch, dest->format, target, nwidth))
+                        return E_FAIL;
+                    pDest += dest->rowPitch;
+
+                    sy += yinc;
+                }
+            }
+
+            if (height > 1)
+                height >>= 1;
+
+            if (width > 1)
+                width >>= 1;
+
+            if (depth > 1)
+                depth >>= 1;
+        }
+
+        return S_OK;
+    }
+
+
+    //--- 3D Box Filter ---
+    HRESULT Generate3DMipsBoxFilter(size_t depth, size_t levels, TEX_FILTER_FLAGS filter, const ScratchImage& mipChain) noexcept
+    {
+        using namespace DirectX::Filters;
+
+        if (!depth || !mipChain.GetImages())
+            return E_INVALIDARG;
+
+        if (depth > INT16_MAX)
+            return E_INVALIDARG;
+
+        // This assumes that the base images are already placed into the mipChain at the top level... (see _Setup3DMips)
+
+        assert(levels > 1);
+
+        size_t width = mipChain.GetMetadata().width;
+        size_t height = mipChain.GetMetadata().height;
+
+        if (!ispow2(width) || !ispow2(height) || !ispow2(depth))
+            return E_FAIL;
+
+        // Allocate temporary space (5 scanlines)
+        auto scanline = make_AlignedArrayXMVECTOR(uint64_t(width) * 5);
+        if (!scanline)
+            return E_OUTOFMEMORY;
+
+        XMVECTOR* target = scanline.get();
+
+        XMVECTOR* urow0 = target + width;
+        XMVECTOR* urow1 = target + width * 2;
+        XMVECTOR* vrow0 = target + width * 3;
+        XMVECTOR* vrow1 = target + width * 4;
+
+        const XMVECTOR* urow2 = urow0 + 1;
+        const XMVECTOR* urow3 = urow1 + 1;
+        const XMVECTOR* vrow2 = vrow0 + 1;
+        const XMVECTOR* vrow3 = vrow1 + 1;
+
+        // Resize base image to each target mip level
+        for (size_t level = 1; level < levels; ++level)
+        {
+            if (height <= 1)
+            {
+                urow1 = urow0;
+                vrow1 = vrow0;
+            }
+
+            if (width <= 1)
+            {
+                urow2 = urow0;
+                urow3 = urow1;
+                vrow2 = vrow0;
+                vrow3 = vrow1;
+            }
+
+            if (depth > 1)
+            {
+                // 3D box filter
+                const size_t ndepth = depth >> 1;
+
+                for (size_t slice = 0; slice < ndepth; ++slice)
+                {
+                    const size_t slicea = std::min<size_t>(slice * 2, depth - 1);
+                    const size_t sliceb = std::min<size_t>(slicea + 1, depth - 1);
+
+                    const Image* srca = mipChain.GetImage(level - 1, 0, slicea);
+                    const Image* srcb = mipChain.GetImage(level - 1, 0, sliceb);
+                    const Image* dest = mipChain.GetImage(level, 0, slice);
+
+                    if (!srca || !srcb || !dest)
+                        return E_POINTER;
+
+                    const uint8_t* pSrc1 = srca->pixels;
+                    const uint8_t* pSrc2 = srcb->pixels;
+                    uint8_t* pDest = dest->pixels;
+
+                    const size_t aRowPitch = srca->rowPitch;
+                    const size_t bRowPitch = srcb->rowPitch;
+
+                    const size_t nwidth = (width > 1) ? (width >> 1) : 1;
+                    const size_t nheight = (height > 1) ? (height >> 1) : 1;
+
+                    for (size_t y = 0; y < nheight; ++y)
+                    {
+                        if (!LoadScanlineLinear(urow0, width, pSrc1, aRowPitch, srca->format, filter))
+                            return E_FAIL;
+                        pSrc1 += aRowPitch;
+
+                        if (urow0 != urow1)
+                        {
+                            if (!LoadScanlineLinear(urow1, width, pSrc1, aRowPitch, srca->format, filter))
+                                return E_FAIL;
+                            pSrc1 += aRowPitch;
+                        }
+
+                        if (!LoadScanlineLinear(vrow0, width, pSrc2, bRowPitch, srcb->format, filter))
+                            return E_FAIL;
+                        pSrc2 += bRowPitch;
+
+                        if (vrow0 != vrow1)
+                        {
+                            if (!LoadScanlineLinear(vrow1, width, pSrc2, bRowPitch, srcb->format, filter))
+                                return E_FAIL;
+                            pSrc2 += bRowPitch;
+                        }
+
+                        for (size_t x = 0; x < nwidth; ++x)
+                        {
+                            const size_t x2 = x << 1;
+
+                            AVERAGE8(target[x], urow0[x2], urow1[x2], urow2[x2], urow3[x2],
+                                vrow0[x2], vrow1[x2], vrow2[x2], vrow3[x2])
+                        }
+
+                        if (!StoreScanlineLinear(pDest, dest->rowPitch, dest->format, target, nwidth, filter))
+                            return E_FAIL;
+                        pDest += dest->rowPitch;
+                    }
+                }
+            }
+            else
+            {
+                // 2D box filter
+                const Image* src = mipChain.GetImage(level - 1, 0, 0);
+                const Image* dest = mipChain.GetImage(level, 0, 0);
+
+                if (!src || !dest)
+                    return E_POINTER;
+
+                const uint8_t* pSrc = src->pixels;
+                uint8_t* pDest = dest->pixels;
+
+                const size_t rowPitch = src->rowPitch;
+
+                const size_t nwidth = (width > 1) ? (width >> 1) : 1;
+                const size_t nheight = (height > 1) ? (height >> 1) : 1;
+
+                for (size_t y = 0; y < nheight; ++y)
+                {
+                    if (!LoadScanlineLinear(urow0, width, pSrc, rowPitch, src->format, filter))
+                        return E_FAIL;
+                    pSrc += rowPitch;
+
+                    if (urow0 != urow1)
+                    {
+                        if (!LoadScanlineLinear(urow1, width, pSrc, rowPitch, src->format, filter))
+                            return E_FAIL;
+                        pSrc += rowPitch;
+                    }
+
+                    for (size_t x = 0; x < nwidth; ++x)
+                    {
+                        const size_t x2 = x << 1;
+
+                        AVERAGE4(target[x], urow0[x2], urow1[x2], urow2[x2], urow3[x2])
+                    }
+
+                    if (!StoreScanlineLinear(pDest, dest->rowPitch, dest->format, target, nwidth, filter))
+                        return E_FAIL;
+                    pDest += dest->rowPitch;
+                }
+            }
+
+            if (height > 1)
+                height >>= 1;
+
+            if (width > 1)
+                width >>= 1;
+
+            if (depth > 1)
+                depth >>= 1;
+        }
+
+        return S_OK;
+    }
+
+
+    //--- 3D Linear Filter ---
+    HRESULT Generate3DMipsLinearFilter(size_t depth, size_t levels, TEX_FILTER_FLAGS filter, const ScratchImage& mipChain) noexcept
+    {
+        using namespace DirectX::Filters;
+
+        if (!depth || !mipChain.GetImages())
+            return E_INVALIDARG;
+
+        if (depth > INT16_MAX)
+            return E_INVALIDARG;
+
+        // This assumes that the base images are already placed into the mipChain at the top level... (see _Setup3DMips)
+
+        assert(levels > 1);
+
+        size_t width = mipChain.GetMetadata().width;
+        size_t height = mipChain.GetMetadata().height;
+
+        // Allocate temporary space (5 scanlines, plus X/Y/Z filters)
+        auto scanline = make_AlignedArrayXMVECTOR(uint64_t(width) * 5);
+        if (!scanline)
+            return E_OUTOFMEMORY;
+
+        std::unique_ptr<LinearFilter[]> lf(new (std::nothrow) LinearFilter[width + height + depth]);
+        if (!lf)
+            return E_OUTOFMEMORY;
+
+        LinearFilter* lfX = lf.get();
+        LinearFilter* lfY = lf.get() + width;
+        LinearFilter* lfZ = lf.get() + width + height;
+
+        XMVECTOR* target = scanline.get();
+
+        XMVECTOR* urow0 = target + width;
+        XMVECTOR* urow1 = target + width * 2;
+        XMVECTOR* vrow0 = target + width * 3;
+        XMVECTOR* vrow1 = target + width * 4;
+
+        // Resize base image to each target mip level
+        for (size_t level = 1; level < levels; ++level)
+        {
+            const size_t nwidth = (width > 1) ? (width >> 1) : 1;
+            CreateLinearFilter(width, nwidth, (filter & TEX_FILTER_WRAP_U) != 0, lfX);
+
+            const size_t nheight = (height > 1) ? (height >> 1) : 1;
+            CreateLinearFilter(height, nheight, (filter & TEX_FILTER_WRAP_V) != 0, lfY);
+
+        #ifdef _DEBUG
+            memset(urow0, 0xCD, sizeof(XMVECTOR)*width);
+            memset(urow1, 0xDD, sizeof(XMVECTOR)*width);
+            memset(vrow0, 0xED, sizeof(XMVECTOR)*width);
+            memset(vrow1, 0xFD, sizeof(XMVECTOR)*width);
+        #endif
+
+            if (depth > 1)
+            {
+                // 3D linear filter
+                const size_t ndepth = depth >> 1;
+                CreateLinearFilter(depth, ndepth, (filter & TEX_FILTER_WRAP_W) != 0, lfZ);
+
+                for (size_t slice = 0; slice < ndepth; ++slice)
+                {
+                    auto const& toZ = lfZ[slice];
+
+                    const Image* srca = mipChain.GetImage(level - 1, 0, toZ.u0);
+                    const Image* srcb = mipChain.GetImage(level - 1, 0, toZ.u1);
+                    if (!srca || !srcb)
+                        return E_POINTER;
+
+                    size_t u0 = size_t(-1);
+                    size_t u1 = size_t(-1);
+
+                    const Image* dest = mipChain.GetImage(level, 0, slice);
+                    if (!dest)
+                        return E_POINTER;
+
+                    uint8_t* pDest = dest->pixels;
+
+                    for (size_t y = 0; y < nheight; ++y)
+                    {
+                        auto const& toY = lfY[y];
+
+                        if (toY.u0 != u0)
+                        {
+                            if (toY.u0 != u1)
+                            {
+                                u0 = toY.u0;
+
+                                if (!LoadScanlineLinear(urow0, width, srca->pixels + (srca->rowPitch * u0), srca->rowPitch, srca->format, filter)
+                                    || !LoadScanlineLinear(vrow0, width, srcb->pixels + (srcb->rowPitch * u0), srcb->rowPitch, srcb->format, filter))
+                                    return E_FAIL;
+                            }
+                            else
+                            {
+                                u0 = u1;
+                                u1 = size_t(-1);
+
+                                std::swap(urow0, urow1);
+                                std::swap(vrow0, vrow1);
+                            }
+                        }
+
+                        if (toY.u1 != u1)
+                        {
+                            u1 = toY.u1;
+
+                            if (!LoadScanlineLinear(urow1, width, srca->pixels + (srca->rowPitch * u1), srca->rowPitch, srca->format, filter)
+                                || !LoadScanlineLinear(vrow1, width, srcb->pixels + (srcb->rowPitch * u1), srcb->rowPitch, srcb->format, filter))
+                                return E_FAIL;
+                        }
+
+                        for (size_t x = 0; x < nwidth; ++x)
+                        {
+                            auto const& toX = lfX[x];
+
+                            TRILINEAR_INTERPOLATE(target[x], toX, toY, toZ, urow0, urow1, vrow0, vrow1)
+                        }
+
+                        if (!StoreScanlineLinear(pDest, dest->rowPitch, dest->format, target, nwidth, filter))
+                            return E_FAIL;
+                        pDest += dest->rowPitch;
+                    }
+                }
+            }
+            else
+            {
+                // 2D linear filter
+                const Image* src = mipChain.GetImage(level - 1, 0, 0);
+                const Image* dest = mipChain.GetImage(level, 0, 0);
+
+                if (!src || !dest)
+                    return E_POINTER;
+
+                const uint8_t* pSrc = src->pixels;
+                uint8_t* pDest = dest->pixels;
+
+                const size_t rowPitch = src->rowPitch;
+
+                size_t u0 = size_t(-1);
+                size_t u1 = size_t(-1);
+
+                for (size_t y = 0; y < nheight; ++y)
+                {
+                    auto const& toY = lfY[y];
+
+                    if (toY.u0 != u0)
+                    {
+                        if (toY.u0 != u1)
+                        {
+                            u0 = toY.u0;
+
+                            if (!LoadScanlineLinear(urow0, width, pSrc + (rowPitch * u0), rowPitch, src->format, filter))
+                                return E_FAIL;
+                        }
+                        else
+                        {
+                            u0 = u1;
+                            u1 = size_t(-1);
+
+                            std::swap(urow0, urow1);
+                        }
+                    }
+
+                    if (toY.u1 != u1)
+                    {
+                        u1 = toY.u1;
+
+                        if (!LoadScanlineLinear(urow1, width, pSrc + (rowPitch * u1), rowPitch, src->format, filter))
+                            return E_FAIL;
+                    }
+
+                    for (size_t x = 0; x < nwidth; ++x)
+                    {
+                        auto const& toX = lfX[x];
+
+                        BILINEAR_INTERPOLATE(target[x], toX, toY, urow0, urow1)
+                    }
+
+                    if (!StoreScanlineLinear(pDest, dest->rowPitch, dest->format, target, nwidth, filter))
+                        return E_FAIL;
+                    pDest += dest->rowPitch;
+                }
+            }
+
+            if (height > 1)
+                height >>= 1;
+
+            if (width > 1)
+                width >>= 1;
+
+            if (depth > 1)
+                depth >>= 1;
+        }
+
+        return S_OK;
+    }
+
+
+    //--- 3D Cubic Filter ---
+    HRESULT Generate3DMipsCubicFilter(size_t depth, size_t levels, TEX_FILTER_FLAGS filter, const ScratchImage& mipChain) noexcept
+    {
+        using namespace DirectX::Filters;
+
+        if (!depth || !mipChain.GetImages())
+            return E_INVALIDARG;
+
+        if (depth > INT16_MAX)
+            return E_INVALIDARG;
+
+        // This assumes that the base images are already placed into the mipChain at the top level... (see _Setup3DMips)
+
+        assert(levels > 1);
+
+        size_t width = mipChain.GetMetadata().width;
+        size_t height = mipChain.GetMetadata().height;
+
+        // Allocate temporary space (17 scanlines, plus X/Y/Z filters)
+        auto scanline = make_AlignedArrayXMVECTOR(uint64_t(width) * 17);
+        if (!scanline)
+            return E_OUTOFMEMORY;
+
+        std::unique_ptr<CubicFilter[]> cf(new (std::nothrow) CubicFilter[width + height + depth]);
+        if (!cf)
+            return E_OUTOFMEMORY;
+
+        CubicFilter* cfX = cf.get();
+        CubicFilter* cfY = cf.get() + width;
+        CubicFilter* cfZ = cf.get() + width + height;
+
+        XMVECTOR* target = scanline.get();
+
+        XMVECTOR* urow[4];
+        XMVECTOR* vrow[4];
+        XMVECTOR* srow[4];
+        XMVECTOR* trow[4];
+
+        XMVECTOR *ptr = scanline.get() + width;
+        for (size_t j = 0; j < 4; ++j)
+        {
+            urow[j] = ptr;  ptr += width;
+            vrow[j] = ptr;  ptr += width;
+            srow[j] = ptr;  ptr += width;
+            trow[j] = ptr;  ptr += width;
+        }
+
+        // Resize base image to each target mip level
+        for (size_t level = 1; level < levels; ++level)
+        {
+            const size_t nwidth = (width > 1) ? (width >> 1) : 1;
+            CreateCubicFilter(width, nwidth, (filter & TEX_FILTER_WRAP_U) != 0, (filter & TEX_FILTER_MIRROR_U) != 0, cfX);
+
+            const size_t nheight = (height > 1) ? (height >> 1) : 1;
+            CreateCubicFilter(height, nheight, (filter & TEX_FILTER_WRAP_V) != 0, (filter & TEX_FILTER_MIRROR_V) != 0, cfY);
+
+        #ifdef _DEBUG
+            for (size_t j = 0; j < 4; ++j)
+            {
+                memset(urow[j], 0xCD, sizeof(XMVECTOR)*width);
+                memset(vrow[j], 0xDD, sizeof(XMVECTOR)*width);
+                memset(srow[j], 0xED, sizeof(XMVECTOR)*width);
+                memset(trow[j], 0xFD, sizeof(XMVECTOR)*width);
+            }
+        #endif
+
+            if (depth > 1)
+            {
+                // 3D cubic filter
+                const size_t ndepth = depth >> 1;
+                CreateCubicFilter(depth, ndepth, (filter & TEX_FILTER_WRAP_W) != 0, (filter & TEX_FILTER_MIRROR_W) != 0, cfZ);
+
+                for (size_t slice = 0; slice < ndepth; ++slice)
+                {
+                    auto const& toZ = cfZ[slice];
+
+                    const Image* srca = mipChain.GetImage(level - 1, 0, toZ.u0);
+                    const Image* srcb = mipChain.GetImage(level - 1, 0, toZ.u1);
+                    const Image* srcc = mipChain.GetImage(level - 1, 0, toZ.u2);
+                    const Image* srcd = mipChain.GetImage(level - 1, 0, toZ.u3);
+                    if (!srca || !srcb || !srcc || !srcd)
+                        return E_POINTER;
+
+                    size_t u0 = size_t(-1);
+                    size_t u1 = size_t(-1);
+                    size_t u2 = size_t(-1);
+                    size_t u3 = size_t(-1);
+
+                    const Image* dest = mipChain.GetImage(level, 0, slice);
+                    if (!dest)
+                        return E_POINTER;
+
+                    uint8_t* pDest = dest->pixels;
+
+                    for (size_t y = 0; y < nheight; ++y)
+                    {
+                        auto const& toY = cfY[y];
+
+                        // Scanline 1
+                        if (toY.u0 != u0)
+                        {
+                            if (toY.u0 != u1 && toY.u0 != u2 && toY.u0 != u3)
+                            {
+                                u0 = toY.u0;
+
+                                if (!LoadScanlineLinear(urow[0], width, srca->pixels + (srca->rowPitch * u0), srca->rowPitch, srca->format, filter)
+                                    || !LoadScanlineLinear(urow[1], width, srcb->pixels + (srcb->rowPitch * u0), srcb->rowPitch, srcb->format, filter)
+                                    || !LoadScanlineLinear(urow[2], width, srcc->pixels + (srcc->rowPitch * u0), srcc->rowPitch, srcc->format, filter)
+                                    || !LoadScanlineLinear(urow[3], width, srcd->pixels + (srcd->rowPitch * u0), srcd->rowPitch, srcd->format, filter))
+                                    return E_FAIL;
+                            }
+                            else if (toY.u0 == u1)
+                            {
+                                u0 = u1;
+                                u1 = size_t(-1);
+
+                                std::swap(urow[0], vrow[0]);
+                                std::swap(urow[1], vrow[1]);
+                                std::swap(urow[2], vrow[2]);
+                                std::swap(urow[3], vrow[3]);
+                            }
+                            else if (toY.u0 == u2)
+                            {
+                                u0 = u2;
+                                u2 = size_t(-1);
+
+                                std::swap(urow[0], srow[0]);
+                                std::swap(urow[1], srow[1]);
+                                std::swap(urow[2], srow[2]);
+                                std::swap(urow[3], srow[3]);
+                            }
+                            else if (toY.u0 == u3)
+                            {
+                                u0 = u3;
+                                u3 = size_t(-1);
+
+                                std::swap(urow[0], trow[0]);
+                                std::swap(urow[1], trow[1]);
+                                std::swap(urow[2], trow[2]);
+                                std::swap(urow[3], trow[3]);
+                            }
+                        }
+
+                        // Scanline 2
+                        if (toY.u1 != u1)
+                        {
+                            if (toY.u1 != u2 && toY.u1 != u3)
+                            {
+                                u1 = toY.u1;
+
+                                if (!LoadScanlineLinear(vrow[0], width, srca->pixels + (srca->rowPitch * u1), srca->rowPitch, srca->format, filter)
+                                    || !LoadScanlineLinear(vrow[1], width, srcb->pixels + (srcb->rowPitch * u1), srcb->rowPitch, srcb->format, filter)
+                                    || !LoadScanlineLinear(vrow[2], width, srcc->pixels + (srcc->rowPitch * u1), srcc->rowPitch, srcc->format, filter)
+                                    || !LoadScanlineLinear(vrow[3], width, srcd->pixels + (srcd->rowPitch * u1), srcd->rowPitch, srcd->format, filter))
+                                    return E_FAIL;
+                            }
+                            else if (toY.u1 == u2)
+                            {
+                                u1 = u2;
+                                u2 = size_t(-1);
+
+                                std::swap(vrow[0], srow[0]);
+                                std::swap(vrow[1], srow[1]);
+                                std::swap(vrow[2], srow[2]);
+                                std::swap(vrow[3], srow[3]);
+                            }
+                            else if (toY.u1 == u3)
+                            {
+                                u1 = u3;
+                                u3 = size_t(-1);
+
+                                std::swap(vrow[0], trow[0]);
+                                std::swap(vrow[1], trow[1]);
+                                std::swap(vrow[2], trow[2]);
+                                std::swap(vrow[3], trow[3]);
+                            }
+                        }
+
+                        // Scanline 3
+                        if (toY.u2 != u2)
+                        {
+                            if (toY.u2 != u3)
+                            {
+                                u2 = toY.u2;
+
+                                if (!LoadScanlineLinear(srow[0], width, srca->pixels + (srca->rowPitch * u2), srca->rowPitch, srca->format, filter)
+                                    || !LoadScanlineLinear(srow[1], width, srcb->pixels + (srcb->rowPitch * u2), srcb->rowPitch, srcb->format, filter)
+                                    || !LoadScanlineLinear(srow[2], width, srcc->pixels + (srcc->rowPitch * u2), srcc->rowPitch, srcc->format, filter)
+                                    || !LoadScanlineLinear(srow[3], width, srcd->pixels + (srcd->rowPitch * u2), srcd->rowPitch, srcd->format, filter))
+                                    return E_FAIL;
+                            }
+                            else
+                            {
+                                u2 = u3;
+                                u3 = size_t(-1);
+
+                                std::swap(srow[0], trow[0]);
+                                std::swap(srow[1], trow[1]);
+                                std::swap(srow[2], trow[2]);
+                                std::swap(srow[3], trow[3]);
+                            }
+                        }
+
+                        // Scanline 4
+                        if (toY.u3 != u3)
+                        {
+                            u3 = toY.u3;
+
+                            if (!LoadScanlineLinear(trow[0], width, srca->pixels + (srca->rowPitch * u3), srca->rowPitch, srca->format, filter)
+                                || !LoadScanlineLinear(trow[1], width, srcb->pixels + (srcb->rowPitch * u3), srcb->rowPitch, srcb->format, filter)
+                                || !LoadScanlineLinear(trow[2], width, srcc->pixels + (srcc->rowPitch * u3), srcc->rowPitch, srcc->format, filter)
+                                || !LoadScanlineLinear(trow[3], width, srcd->pixels + (srcd->rowPitch * u3), srcd->rowPitch, srcd->format, filter))
+                                return E_FAIL;
+                        }
+
+                        for (size_t x = 0; x < nwidth; ++x)
+                        {
+                            auto const& toX = cfX[x];
+
+                            XMVECTOR D[4];
+
+                            for (size_t j = 0; j < 4; ++j)
+                            {
+                                XMVECTOR C0, C1, C2, C3;
+                                CUBIC_INTERPOLATE(C0, toX.x, urow[j][toX.u0], urow[j][toX.u1], urow[j][toX.u2], urow[j][toX.u3]);
+                                CUBIC_INTERPOLATE(C1, toX.x, vrow[j][toX.u0], vrow[j][toX.u1], vrow[j][toX.u2], vrow[j][toX.u3]);
+                                CUBIC_INTERPOLATE(C2, toX.x, srow[j][toX.u0], srow[j][toX.u1], srow[j][toX.u2], srow[j][toX.u3]);
+                                CUBIC_INTERPOLATE(C3, toX.x, trow[j][toX.u0], trow[j][toX.u1], trow[j][toX.u2], trow[j][toX.u3]);
+
+                                CUBIC_INTERPOLATE(D[j], toY.x, C0, C1, C2, C3);
+                            }
+
+                            CUBIC_INTERPOLATE(target[x], toZ.x, D[0], D[1], D[2], D[3]);
+                        }
+
+                        if (!StoreScanlineLinear(pDest, dest->rowPitch, dest->format, target, nwidth, filter))
+                            return E_FAIL;
+                        pDest += dest->rowPitch;
+                    }
+                }
+            }
+            else
+            {
+                // 2D cubic filter
+                const Image* src = mipChain.GetImage(level - 1, 0, 0);
+                const Image* dest = mipChain.GetImage(level, 0, 0);
+
+                if (!src || !dest)
+                    return E_POINTER;
+
+                const uint8_t* pSrc = src->pixels;
+                uint8_t* pDest = dest->pixels;
+
+                const size_t rowPitch = src->rowPitch;
+
+                size_t u0 = size_t(-1);
+                size_t u1 = size_t(-1);
+                size_t u2 = size_t(-1);
+                size_t u3 = size_t(-1);
+
+                for (size_t y = 0; y < nheight; ++y)
+                {
+                    auto const& toY = cfY[y];
+
+                    // Scanline 1
+                    if (toY.u0 != u0)
+                    {
+                        if (toY.u0 != u1 && toY.u0 != u2 && toY.u0 != u3)
+                        {
+                            u0 = toY.u0;
+
+                            if (!LoadScanlineLinear(urow[0], width, pSrc + (rowPitch * u0), rowPitch, src->format, filter))
+                                return E_FAIL;
+                        }
+                        else if (toY.u0 == u1)
+                        {
+                            u0 = u1;
+                            u1 = size_t(-1);
+
+                            std::swap(urow[0], vrow[0]);
+                        }
+                        else if (toY.u0 == u2)
+                        {
+                            u0 = u2;
+                            u2 = size_t(-1);
+
+                            std::swap(urow[0], srow[0]);
+                        }
+                        else if (toY.u0 == u3)
+                        {
+                            u0 = u3;
+                            u3 = size_t(-1);
+
+                            std::swap(urow[0], trow[0]);
+                        }
+                    }
+
+                    // Scanline 2
+                    if (toY.u1 != u1)
+                    {
+                        if (toY.u1 != u2 && toY.u1 != u3)
+                        {
+                            u1 = toY.u1;
+
+                            if (!LoadScanlineLinear(vrow[0], width, pSrc + (rowPitch * u1), rowPitch, src->format, filter))
+                                return E_FAIL;
+                        }
+                        else if (toY.u1 == u2)
+                        {
+                            u1 = u2;
+                            u2 = size_t(-1);
+
+                            std::swap(vrow[0], srow[0]);
+                        }
+                        else if (toY.u1 == u3)
+                        {
+                            u1 = u3;
+                            u3 = size_t(-1);
+
+                            std::swap(vrow[0], trow[0]);
+                        }
+                    }
+
+                    // Scanline 3
+                    if (toY.u2 != u2)
+                    {
+                        if (toY.u2 != u3)
+                        {
+                            u2 = toY.u2;
+
+                            if (!LoadScanlineLinear(srow[0], width, pSrc + (rowPitch * u2), rowPitch, src->format, filter))
+                                return E_FAIL;
+                        }
+                        else
+                        {
+                            u2 = u3;
+                            u3 = size_t(-1);
+
+                            std::swap(srow[0], trow[0]);
+                        }
+                    }
+
+                    // Scanline 4
+                    if (toY.u3 != u3)
+                    {
+                        u3 = toY.u3;
+
+                        if (!LoadScanlineLinear(trow[0], width, pSrc + (rowPitch * u3), rowPitch, src->format, filter))
+                            return E_FAIL;
+                    }
+
+                    for (size_t x = 0; x < nwidth; ++x)
+                    {
+                        auto const& toX = cfX[x];
+
+                        XMVECTOR C0, C1, C2, C3;
+                        CUBIC_INTERPOLATE(C0, toX.x, urow[0][toX.u0], urow[0][toX.u1], urow[0][toX.u2], urow[0][toX.u3]);
+                        CUBIC_INTERPOLATE(C1, toX.x, vrow[0][toX.u0], vrow[0][toX.u1], vrow[0][toX.u2], vrow[0][toX.u3]);
+                        CUBIC_INTERPOLATE(C2, toX.x, srow[0][toX.u0], srow[0][toX.u1], srow[0][toX.u2], srow[0][toX.u3]);
+                        CUBIC_INTERPOLATE(C3, toX.x, trow[0][toX.u0], trow[0][toX.u1], trow[0][toX.u2], trow[0][toX.u3]);
+
+                        CUBIC_INTERPOLATE(target[x], toY.x, C0, C1, C2, C3);
+                    }
+
+                    if (!StoreScanlineLinear(pDest, dest->rowPitch, dest->format, target, nwidth, filter))
+                        return E_FAIL;
+                    pDest += dest->rowPitch;
+                }
+            }
+
+            if (height > 1)
+                height >>= 1;
+
+            if (width > 1)
+                width >>= 1;
+
+            if (depth > 1)
+                depth >>= 1;
+        }
+
+        return S_OK;
+    }
+
+
+    //--- 3D Triangle Filter ---
+    HRESULT Generate3DMipsTriangleFilter(size_t depth, size_t levels, TEX_FILTER_FLAGS filter, const ScratchImage& mipChain) noexcept
+    {
+        using namespace DirectX::Filters;
+
+        if (!depth || !mipChain.GetImages())
+            return E_INVALIDARG;
+
+        if (depth > INT16_MAX)
+            return E_INVALIDARG;
+
+        // This assumes that the base images are already placed into the mipChain at the top level... (see _Setup3DMips)
+
+        assert(levels > 1);
+
+        size_t width = mipChain.GetMetadata().width;
+        size_t height = mipChain.GetMetadata().height;
+
+        // Allocate initial temporary space (1 scanline, accumulation rows, plus X/Y/Z filters)
+        auto scanline = make_AlignedArrayXMVECTOR(width);
+        if (!scanline)
+            return E_OUTOFMEMORY;
+
+        std::unique_ptr<TriangleRow[]> sliceActive(new (std::nothrow) TriangleRow[depth]);
+        if (!sliceActive)
+            return E_OUTOFMEMORY;
+
+        TriangleRow * sliceFree = nullptr;
+
+        std::unique_ptr<Filter> tfX, tfY, tfZ;
+
+        XMVECTOR* row = scanline.get();
+
+        // Resize base image to each target mip level
+        for (size_t level = 1; level < levels; ++level)
+        {
+            const size_t nwidth = (width > 1) ? (width >> 1) : 1;
+            HRESULT hr = CreateTriangleFilter(width, nwidth, (filter & TEX_FILTER_WRAP_U) != 0, tfX);
+            if (FAILED(hr))
+                return hr;
+
+            const size_t nheight = (height > 1) ? (height >> 1) : 1;
+            hr = CreateTriangleFilter(height, nheight, (filter & TEX_FILTER_WRAP_V) != 0, tfY);
+            if (FAILED(hr))
+                return hr;
+
+            const size_t ndepth = (depth > 1) ? (depth >> 1) : 1;
+            hr = CreateTriangleFilter(depth, ndepth, (filter & TEX_FILTER_WRAP_W) != 0, tfZ);
+            if (FAILED(hr))
+                return hr;
+
+        #ifdef _DEBUG
+            memset(row, 0xCD, sizeof(XMVECTOR)*width);
+        #endif
+
+            auto xFromEnd = reinterpret_cast<const FilterFrom*>(reinterpret_cast<const uint8_t*>(tfX.get()) + tfX->sizeInBytes);
+            auto yFromEnd = reinterpret_cast<const FilterFrom*>(reinterpret_cast<const uint8_t*>(tfY.get()) + tfY->sizeInBytes);
+            auto zFromEnd = reinterpret_cast<const FilterFrom*>(reinterpret_cast<const uint8_t*>(tfZ.get()) + tfZ->sizeInBytes);
+
+            // Count times slices get written (and clear out any leftover accumulation slices from last miplevel)
+            for (FilterFrom* zFrom = tfZ->from; zFrom < zFromEnd; )
+            {
+                for (size_t j = 0; j < zFrom->count; ++j)
+                {
+                    const size_t w = zFrom->to[j].u;
+                    assert(w < ndepth);
+                    TriangleRow* sliceAcc = &sliceActive[w];
+
+                    ++sliceAcc->remaining;
+
+                    if (sliceAcc->scanline)
+                    {
+                        memset(sliceAcc->scanline.get(), 0, sizeof(XMVECTOR) * nwidth * nheight);
+                    }
+                }
+
+                zFrom = reinterpret_cast<FilterFrom*>(reinterpret_cast<uint8_t*>(zFrom) + zFrom->sizeInBytes);
+            }
+
+            // Filter image
+            size_t z = 0;
+            for (FilterFrom* zFrom = tfZ->from; zFrom < zFromEnd; ++z)
+            {
+                // Create accumulation slices as needed
+                for (size_t j = 0; j < zFrom->count; ++j)
+                {
+                    const size_t w = zFrom->to[j].u;
+                    assert(w < ndepth);
+                    TriangleRow* sliceAcc = &sliceActive[w];
+
+                    if (!sliceAcc->scanline)
+                    {
+                        if (sliceFree)
+                        {
+                            // Steal and reuse scanline from 'free slice' list
+                            // (it will always be at least as large as nwidth*nheight due to loop decending order)
+                            assert(sliceFree->scanline != nullptr);
+                            sliceAcc->scanline.reset(sliceFree->scanline.release());
+                            sliceFree = sliceFree->next;
+                        }
+                        else
+                        {
+                            auto nscanline = make_AlignedArrayXMVECTOR(uint64_t(nwidth) * uint64_t(nheight));
+                            if (!nscanline)
+                                return E_OUTOFMEMORY;
+                            sliceAcc->scanline.swap(nscanline);
+                        }
+
+                        memset(sliceAcc->scanline.get(), 0, sizeof(XMVECTOR) * nwidth * nheight);
+                    }
+                }
+
+                assert(z < depth);
+                const Image* src = mipChain.GetImage(level - 1, 0, z);
+                if (!src)
+                    return E_POINTER;
+
+                const uint8_t* pSrc = src->pixels;
+                const size_t rowPitch = src->rowPitch;
+                const uint8_t* pEndSrc = pSrc + rowPitch * height;
+
+                for (FilterFrom* yFrom = tfY->from; yFrom < yFromEnd; )
+                {
+                    // Load source scanline
+                    if ((pSrc + rowPitch) > pEndSrc)
+                        return E_FAIL;
+
+                    if (!LoadScanlineLinear(row, width, pSrc, rowPitch, src->format, filter))
+                        return E_FAIL;
+
+                    pSrc += rowPitch;
+
+                    // Process row
+                    size_t x = 0;
+                    for (FilterFrom* xFrom = tfX->from; xFrom < xFromEnd; ++x)
+                    {
+                        for (size_t j = 0; j < zFrom->count; ++j)
+                        {
+                            const size_t w = zFrom->to[j].u;
+                            assert(w < ndepth);
+                            const float zweight = zFrom->to[j].weight;
+
+                            XMVECTOR* accSlice = sliceActive[w].scanline.get();
+                            if (!accSlice)
+                                return E_POINTER;
+
+                            for (size_t k = 0; k < yFrom->count; ++k)
+                            {
+                                size_t v = yFrom->to[k].u;
+                                assert(v < nheight);
+                                const float yweight = yFrom->to[k].weight;
+
+                                XMVECTOR * accPtr = accSlice + v * nwidth;
+
+                                for (size_t l = 0; l < xFrom->count; ++l)
+                                {
+                                    size_t u = xFrom->to[l].u;
+                                    assert(u < nwidth);
+
+                                    const XMVECTOR weight = XMVectorReplicate(zweight * yweight * xFrom->to[l].weight);
+
+                                    assert(x < width);
+                                    accPtr[u] = XMVectorMultiplyAdd(row[x], weight, accPtr[u]);
+                                }
+                            }
+                        }
+
+                        xFrom = reinterpret_cast<FilterFrom*>(reinterpret_cast<uint8_t*>(xFrom) + xFrom->sizeInBytes);
+                    }
+
+                    yFrom = reinterpret_cast<FilterFrom*>(reinterpret_cast<uint8_t*>(yFrom) + yFrom->sizeInBytes);
+                }
+
+                // Write completed accumulation slices
+                for (size_t j = 0; j < zFrom->count; ++j)
+                {
+                    const size_t w = zFrom->to[j].u;
+                    assert(w < ndepth);
+                    TriangleRow* sliceAcc = &sliceActive[w];
+
+                    assert(sliceAcc->remaining > 0);
+                    --sliceAcc->remaining;
+
+                    if (!sliceAcc->remaining)
+                    {
+                        const Image* dest = mipChain.GetImage(level, 0, w);
+                        XMVECTOR* pAccSrc = sliceAcc->scanline.get();
+                        if (!dest || !pAccSrc)
+                            return E_POINTER;
+
+                        uint8_t* pDest = dest->pixels;
+
+                        for (size_t h = 0; h < nheight; ++h)
+                        {
+                            switch (dest->format)
+                            {
+                            case DXGI_FORMAT_R10G10B10A2_UNORM:
+                            case DXGI_FORMAT_R10G10B10A2_UINT:
+                                {
+                                    // Need to slightly bias results for floating-point error accumulation which can
+                                    // be visible with harshly quantized values
+                                    static const XMVECTORF32 Bias = { { { 0.f, 0.f, 0.f, 0.1f } } };
+
+                                    XMVECTOR* ptr = pAccSrc;
+                                    for (size_t i = 0; i < dest->width; ++i, ++ptr)
+                                    {
+                                        *ptr = XMVectorAdd(*ptr, Bias);
+                                    }
+                                }
+                                break;
+
+                            default:
+                                break;
+                            }
+
+                            // This performs any required clamping
+                            if (!StoreScanlineLinear(pDest, dest->rowPitch, dest->format, pAccSrc, dest->width, filter))
+                                return E_FAIL;
+
+                            pDest += dest->rowPitch;
+                            pAccSrc += nwidth;
+                        }
+
+                        // Put slice on freelist to reuse it's allocated scanline
+                        sliceAcc->next = sliceFree;
+                        sliceFree = sliceAcc;
+                    }
+                }
+
+                zFrom = reinterpret_cast<FilterFrom*>(reinterpret_cast<uint8_t*>(zFrom) + zFrom->sizeInBytes);
+            }
+
+            if (height > 1)
+                height >>= 1;
+
+            if (width > 1)
+                width >>= 1;
+
+            if (depth > 1)
+                depth >>= 1;
+        }
+
+        return S_OK;
+    }
+}
+
+
+//=====================================================================================
+// Entry-points
+//=====================================================================================
+
+//-------------------------------------------------------------------------------------
+// Generate mipmap chain
+//-------------------------------------------------------------------------------------
+_Use_decl_annotations_
+HRESULT DirectX::GenerateMipMaps(
+    const Image& baseImage,
+    TEX_FILTER_FLAGS filter,
+    size_t levels,
+    ScratchImage& mipChain,
+    bool allow1D) noexcept
+{
+    if (!IsValid(baseImage.format))
+        return E_INVALIDARG;
+
+    if (!baseImage.pixels)
+        return E_POINTER;
+
+    if (!CalculateMipLevels(baseImage.width, baseImage.height, levels))
+        return E_INVALIDARG;
+
+    if (levels <= 1)
+        return E_INVALIDARG;
+
+    if (IsCompressed(baseImage.format) || IsTypeless(baseImage.format) || IsPlanar(baseImage.format) || IsPalettized(baseImage.format))
+    {
+        return HRESULT_E_NOT_SUPPORTED;
+    }
+
+    HRESULT hr = E_UNEXPECTED;
+
+    static_assert(TEX_FILTER_POINT == 0x100000, "TEX_FILTER_ flag values don't match TEX_FILTER_MODE_MASK");
+
+#ifdef _WIN32
+    bool usewic = UseWICFiltering(baseImage.format, filter);
+
+    WICPixelFormatGUID pfGUID = {};
+    const bool wicpf = (usewic) ? DXGIToWIC(baseImage.format, pfGUID, true) : false;
+
+    if (usewic && !wicpf)
+    {
+        // Check to see if the source and/or result size is too big for WIC
+        const uint64_t expandedSize = uint64_t(std::max<size_t>(1, baseImage.width >> 1)) * uint64_t(std::max<size_t>(1, baseImage.height >> 1)) * sizeof(float) * 4;
+        const uint64_t expandedSize2 = uint64_t(baseImage.width) * uint64_t(baseImage.height) * sizeof(float) * 4;
+        if (expandedSize > UINT32_MAX || expandedSize2 > UINT32_MAX)
+        {
+            if (filter & TEX_FILTER_FORCE_WIC)
+                return HRESULT_E_ARITHMETIC_OVERFLOW;
+
+            usewic = false;
+        }
+    }
+
+    if (usewic)
+    {
+        //--- Use WIC filtering to generate mipmaps -----------------------------------
+        switch (filter & TEX_FILTER_MODE_MASK)
+        {
+        case 0:
+        case TEX_FILTER_POINT:
+        case TEX_FILTER_FANT: // Equivalent to Box filter
+        case TEX_FILTER_LINEAR:
+        case TEX_FILTER_CUBIC:
+            {
+                static_assert(TEX_FILTER_FANT == TEX_FILTER_BOX, "TEX_FILTER_ flag alias mismatch");
+
+                if (wicpf)
+                {
+                    // Case 1: Base image format is supported by Windows Imaging Component
+                    hr = (baseImage.height > 1 || !allow1D)
+                        ? mipChain.Initialize2D(baseImage.format, baseImage.width, baseImage.height, 1, levels)
+                        : mipChain.Initialize1D(baseImage.format, baseImage.width, 1, levels);
+                    if (FAILED(hr))
+                        return hr;
+
+                    return GenerateMipMapsUsingWIC(baseImage, filter, levels, pfGUID, mipChain, 0);
+                }
+                else
+                {
+                    // Case 2: Base image format is not supported by WIC, so we have to convert, generate, and convert back
+                    assert(baseImage.format != DXGI_FORMAT_R32G32B32A32_FLOAT);
+                    ScratchImage temp;
+                    hr = ConvertToR32G32B32A32(baseImage, temp);
+                    if (FAILED(hr))
+                        return hr;
+
+                    const Image *timg = temp.GetImage(0, 0, 0);
+                    if (!timg)
+                        return E_POINTER;
+
+                    ScratchImage tMipChain;
+                    hr = (baseImage.height > 1 || !allow1D)
+                        ? tMipChain.Initialize2D(DXGI_FORMAT_R32G32B32A32_FLOAT, baseImage.width, baseImage.height, 1, levels)
+                        : tMipChain.Initialize1D(DXGI_FORMAT_R32G32B32A32_FLOAT, baseImage.width, 1, levels);
+                    if (FAILED(hr))
+                        return hr;
+
+                    hr = GenerateMipMapsUsingWIC(*timg, filter, levels, GUID_WICPixelFormat128bppRGBAFloat, tMipChain, 0);
+                    if (FAILED(hr))
+                        return hr;
+
+                    temp.Release();
+
+                    return ConvertFromR32G32B32A32(tMipChain.GetImages(), tMipChain.GetImageCount(), tMipChain.GetMetadata(), baseImage.format, mipChain);
+                }
+            }
+
+        default:
+            return HRESULT_E_NOT_SUPPORTED;
+        }
+    }
+    else
+    #endif // WIN32
+    {
+        //--- Use custom filters to generate mipmaps ----------------------------------
+        TexMetadata mdata = {};
+        mdata.width = baseImage.width;
+        if (baseImage.height > 1 || !allow1D)
+        {
+            mdata.height = baseImage.height;
+            mdata.dimension = TEX_DIMENSION_TEXTURE2D;
+        }
+        else
+        {
+            mdata.height = 1;
+            mdata.dimension = TEX_DIMENSION_TEXTURE1D;
+        }
+        mdata.depth = mdata.arraySize = 1;
+        mdata.mipLevels = levels;
+        mdata.format = baseImage.format;
+
+        unsigned long filter_select = (filter & TEX_FILTER_MODE_MASK);
+        if (!filter_select)
+        {
+            // Default filter choice
+            filter_select = (ispow2(baseImage.width) && ispow2(baseImage.height)) ? TEX_FILTER_BOX : TEX_FILTER_LINEAR;
+        }
+
+        switch (filter_select)
+        {
+        case TEX_FILTER_BOX:
+            hr = Setup2DMips(&baseImage, 1, mdata, mipChain);
+            if (FAILED(hr))
+                return hr;
+
+            hr = Generate2DMipsBoxFilter(levels, filter, mipChain, 0);
+            if (FAILED(hr))
+                mipChain.Release();
+            return hr;
+
+        case TEX_FILTER_POINT:
+            hr = Setup2DMips(&baseImage, 1, mdata, mipChain);
+            if (FAILED(hr))
+                return hr;
+
+            hr = Generate2DMipsPointFilter(levels, mipChain, 0);
+            if (FAILED(hr))
+                mipChain.Release();
+            return hr;
+
+        case TEX_FILTER_LINEAR:
+            hr = Setup2DMips(&baseImage, 1, mdata, mipChain);
+            if (FAILED(hr))
+                return hr;
+
+            hr = Generate2DMipsLinearFilter(levels, filter, mipChain, 0);
+            if (FAILED(hr))
+                mipChain.Release();
+            return hr;
+
+        case TEX_FILTER_CUBIC:
+            hr = Setup2DMips(&baseImage, 1, mdata, mipChain);
+            if (FAILED(hr))
+                return hr;
+
+            hr = Generate2DMipsCubicFilter(levels, filter, mipChain, 0);
+            if (FAILED(hr))
+                mipChain.Release();
+            return hr;
+
+        case TEX_FILTER_TRIANGLE:
+            hr = Setup2DMips(&baseImage, 1, mdata, mipChain);
+            if (FAILED(hr))
+                return hr;
+
+            hr = Generate2DMipsTriangleFilter(levels, filter, mipChain, 0);
+            if (FAILED(hr))
+                mipChain.Release();
+            return hr;
+
+        default:
+            return HRESULT_E_NOT_SUPPORTED;
+        }
+    }
+}
+
+_Use_decl_annotations_
+HRESULT DirectX::GenerateMipMaps(
+    const Image* srcImages,
+    size_t nimages,
+    const TexMetadata& metadata,
+    TEX_FILTER_FLAGS filter,
+    size_t levels,
+    ScratchImage& mipChain)
+{
+    if (!srcImages || !nimages || !IsValid(metadata.format))
+        return E_INVALIDARG;
+
+    if (metadata.IsVolumemap()
+        || IsCompressed(metadata.format) || IsTypeless(metadata.format) || IsPlanar(metadata.format) || IsPalettized(metadata.format))
+        return HRESULT_E_NOT_SUPPORTED;
+
+    if (!CalculateMipLevels(metadata.width, metadata.height, levels))
+        return E_INVALIDARG;
+
+    if (levels <= 1)
+        return E_INVALIDARG;
+
+    std::vector<Image> baseImages;
+    baseImages.reserve(metadata.arraySize);
+    for (size_t item = 0; item < metadata.arraySize; ++item)
+    {
+        const size_t index = metadata.ComputeIndex(0, item, 0);
+        if (index >= nimages)
+            return E_FAIL;
+
+        const Image& src = srcImages[index];
+        if (!src.pixels)
+            return E_POINTER;
+
+        if (src.format != metadata.format || src.width != metadata.width || src.height != metadata.height)
+        {
+            // All base images must be the same format, width, and height
+            return E_FAIL;
+        }
+
+        baseImages.push_back(src);
+    }
+
+    assert(baseImages.size() == metadata.arraySize);
+
+    HRESULT hr = E_UNEXPECTED;
+
+    if (baseImages.empty())
+        return hr;
+
+    static_assert(TEX_FILTER_POINT == 0x100000, "TEX_FILTER_ flag values don't match TEX_FILTER_MODE_MASK");
+
+#ifdef _WIN32
+    bool usewic = !metadata.IsPMAlpha() && UseWICFiltering(metadata.format, filter);
+
+    WICPixelFormatGUID pfGUID = {};
+    const bool wicpf = (usewic) ? DXGIToWIC(metadata.format, pfGUID, true) : false;
+
+    if (usewic && !wicpf)
+    {
+        // Check to see if the source and/or result size is too big for WIC
+        const uint64_t expandedSize = uint64_t(std::max<size_t>(1, metadata.width >> 1)) * uint64_t(std::max<size_t>(1, metadata.height >> 1)) * sizeof(float) * 4;
+        const uint64_t expandedSize2 = uint64_t(metadata.width) * uint64_t(metadata.height) * sizeof(float) * 4;
+        if (expandedSize > UINT32_MAX || expandedSize2 > UINT32_MAX)
+        {
+            if (filter & TEX_FILTER_FORCE_WIC)
+                return HRESULT_E_ARITHMETIC_OVERFLOW;
+
+            usewic = false;
+        }
+    }
+
+    if (usewic)
+    {
+        //--- Use WIC filtering to generate mipmaps -----------------------------------
+        switch (filter & TEX_FILTER_MODE_MASK)
+        {
+        case 0:
+        case TEX_FILTER_POINT:
+        case TEX_FILTER_FANT: // Equivalent to Box filter
+        case TEX_FILTER_LINEAR:
+        case TEX_FILTER_CUBIC:
+            {
+                static_assert(TEX_FILTER_FANT == TEX_FILTER_BOX, "TEX_FILTER_ flag alias mismatch");
+
+                if (wicpf)
+                {
+                    // Case 1: Base image format is supported by Windows Imaging Component
+                    TexMetadata mdata2 = metadata;
+                    mdata2.mipLevels = levels;
+                    hr = mipChain.Initialize(mdata2);
+                    if (FAILED(hr))
+                        return hr;
+
+                    for (size_t item = 0; item < metadata.arraySize; ++item)
+                    {
+                        hr = GenerateMipMapsUsingWIC(baseImages[item], filter, levels, pfGUID, mipChain, item);
+                        if (FAILED(hr))
+                        {
+                            mipChain.Release();
+                            return hr;
+                        }
+                    }
+
+                    return S_OK;
+                }
+                else
+                {
+                    // Case 2: Base image format is not supported by WIC, so we have to convert, generate, and convert back
+                    assert(metadata.format != DXGI_FORMAT_R32G32B32A32_FLOAT);
+
+                    TexMetadata mdata2 = metadata;
+                    mdata2.mipLevels = levels;
+                    mdata2.format = DXGI_FORMAT_R32G32B32A32_FLOAT;
+                    ScratchImage tMipChain;
+                    hr = tMipChain.Initialize(mdata2);
+                    if (FAILED(hr))
+                        return hr;
+
+                    for (size_t item = 0; item < metadata.arraySize; ++item)
+                    {
+                        ScratchImage temp;
+                        hr = ConvertToR32G32B32A32(baseImages[item], temp);
+                        if (FAILED(hr))
+                            return hr;
+
+                        const Image *timg = temp.GetImage(0, 0, 0);
+                        if (!timg)
+                            return E_POINTER;
+
+                        hr = GenerateMipMapsUsingWIC(*timg, filter, levels, GUID_WICPixelFormat128bppRGBAFloat, tMipChain, item);
+                        if (FAILED(hr))
+                            return hr;
+                    }
+
+                    return ConvertFromR32G32B32A32(tMipChain.GetImages(), tMipChain.GetImageCount(), tMipChain.GetMetadata(), metadata.format, mipChain);
+                }
+            }
+
+        default:
+            return HRESULT_E_NOT_SUPPORTED;
+        }
+    }
+    else
+    #endif // WIN32
+    {
+        //--- Use custom filters to generate mipmaps ----------------------------------
+        TexMetadata mdata2 = metadata;
+        mdata2.mipLevels = levels;
+
+        unsigned long filter_select = (filter & TEX_FILTER_MODE_MASK);
+        if (!filter_select)
+        {
+            // Default filter choice
+            filter_select = (ispow2(metadata.width) && ispow2(metadata.height)) ? TEX_FILTER_BOX : TEX_FILTER_LINEAR;
+        }
+
+        switch (filter_select)
+        {
+        case TEX_FILTER_BOX:
+            hr = Setup2DMips(&baseImages[0], metadata.arraySize, mdata2, mipChain);
+            if (FAILED(hr))
+                return hr;
+
+            for (size_t item = 0; item < metadata.arraySize; ++item)
+            {
+                hr = Generate2DMipsBoxFilter(levels, filter, mipChain, item);
+                if (FAILED(hr))
+                    mipChain.Release();
+            }
+            return hr;
+
+        case TEX_FILTER_POINT:
+            hr = Setup2DMips(&baseImages[0], metadata.arraySize, mdata2, mipChain);
+            if (FAILED(hr))
+                return hr;
+
+            for (size_t item = 0; item < metadata.arraySize; ++item)
+            {
+                hr = Generate2DMipsPointFilter(levels, mipChain, item);
+                if (FAILED(hr))
+                    mipChain.Release();
+            }
+            return hr;
+
+        case TEX_FILTER_LINEAR:
+            hr = Setup2DMips(&baseImages[0], metadata.arraySize, mdata2, mipChain);
+            if (FAILED(hr))
+                return hr;
+
+            for (size_t item = 0; item < metadata.arraySize; ++item)
+            {
+                hr = Generate2DMipsLinearFilter(levels, filter, mipChain, item);
+                if (FAILED(hr))
+                    mipChain.Release();
+            }
+            return hr;
+
+        case TEX_FILTER_CUBIC:
+            hr = Setup2DMips(&baseImages[0], metadata.arraySize, mdata2, mipChain);
+            if (FAILED(hr))
+                return hr;
+
+            for (size_t item = 0; item < metadata.arraySize; ++item)
+            {
+                hr = Generate2DMipsCubicFilter(levels, filter, mipChain, item);
+                if (FAILED(hr))
+                    mipChain.Release();
+            }
+            return hr;
+
+        case TEX_FILTER_TRIANGLE:
+            hr = Setup2DMips(&baseImages[0], metadata.arraySize, mdata2, mipChain);
+            if (FAILED(hr))
+                return hr;
+
+            for (size_t item = 0; item < metadata.arraySize; ++item)
+            {
+                hr = Generate2DMipsTriangleFilter(levels, filter, mipChain, item);
+                if (FAILED(hr))
+                    mipChain.Release();
+            }
+            return hr;
+
+        default:
+            return HRESULT_E_NOT_SUPPORTED;
+        }
+    }
+}
+
+
+//-------------------------------------------------------------------------------------
+// Generate mipmap chain for volume texture
+//-------------------------------------------------------------------------------------
+_Use_decl_annotations_
+HRESULT DirectX::GenerateMipMaps3D(
+    const Image* baseImages,
+    size_t depth,
+    TEX_FILTER_FLAGS filter,
+    size_t levels,
+    ScratchImage& mipChain) noexcept
+{
+    if (!baseImages || !depth)
+        return E_INVALIDARG;
+
+    if (depth > INT16_MAX)
+        return E_INVALIDARG;
+
+    if (filter & TEX_FILTER_FORCE_WIC)
+        return HRESULT_E_NOT_SUPPORTED;
+
+    const DXGI_FORMAT format = baseImages[0].format;
+    const size_t width = baseImages[0].width;
+    const size_t height = baseImages[0].height;
+
+    if (!CalculateMipLevels3D(width, height, depth, levels))
+        return E_INVALIDARG;
+
+    if (levels <= 1)
+        return E_INVALIDARG;
+
+    for (size_t slice = 0; slice < depth; ++slice)
+    {
+        if (!baseImages[slice].pixels)
+            return E_POINTER;
+
+        if (baseImages[slice].format != format || baseImages[slice].width != width || baseImages[slice].height != height)
+        {
+            // All base images must be the same format, width, and height
+            return E_FAIL;
+        }
+    }
+
+    if (IsCompressed(format) || IsTypeless(format) || IsPlanar(format) || IsPalettized(format))
+        return HRESULT_E_NOT_SUPPORTED;
+
+    static_assert(TEX_FILTER_POINT == 0x100000, "TEX_FILTER_ flag values don't match TEX_FILTER_MODE_MASK");
+
+    HRESULT hr = E_UNEXPECTED;
+
+    unsigned long filter_select = (filter & TEX_FILTER_MODE_MASK);
+    if (!filter_select)
+    {
+        // Default filter choice
+        filter_select = (ispow2(width) && ispow2(height) && ispow2(depth)) ? TEX_FILTER_BOX : TEX_FILTER_TRIANGLE;
+    }
+
+    switch (filter_select)
+    {
+    case TEX_FILTER_BOX:
+        hr = Setup3DMips(baseImages, depth, levels, mipChain);
+        if (FAILED(hr))
+            return hr;
+
+        hr = Generate3DMipsBoxFilter(depth, levels, filter, mipChain);
+        if (FAILED(hr))
+            mipChain.Release();
+        return hr;
+
+    case TEX_FILTER_POINT:
+        hr = Setup3DMips(baseImages, depth, levels, mipChain);
+        if (FAILED(hr))
+            return hr;
+
+        hr = Generate3DMipsPointFilter(depth, levels, mipChain);
+        if (FAILED(hr))
+            mipChain.Release();
+        return hr;
+
+    case TEX_FILTER_LINEAR:
+        hr = Setup3DMips(baseImages, depth, levels, mipChain);
+        if (FAILED(hr))
+            return hr;
+
+        hr = Generate3DMipsLinearFilter(depth, levels, filter, mipChain);
+        if (FAILED(hr))
+            mipChain.Release();
+        return hr;
+
+    case TEX_FILTER_CUBIC:
+        hr = Setup3DMips(baseImages, depth, levels, mipChain);
+        if (FAILED(hr))
+            return hr;
+
+        hr = Generate3DMipsCubicFilter(depth, levels, filter, mipChain);
+        if (FAILED(hr))
+            mipChain.Release();
+        return hr;
+
+    case TEX_FILTER_TRIANGLE:
+        hr = Setup3DMips(baseImages, depth, levels, mipChain);
+        if (FAILED(hr))
+            return hr;
+
+        hr = Generate3DMipsTriangleFilter(depth, levels, filter, mipChain);
+        if (FAILED(hr))
+            mipChain.Release();
+        return hr;
+
+    default:
+        return HRESULT_E_NOT_SUPPORTED;
+    }
+}
+
+_Use_decl_annotations_
+HRESULT DirectX::GenerateMipMaps3D(
+    const Image* srcImages,
+    size_t nimages,
+    const TexMetadata& metadata,
+    TEX_FILTER_FLAGS filter,
+    size_t levels,
+    ScratchImage& mipChain)
+{
+    if (!srcImages || !nimages || !IsValid(metadata.format))
+        return E_INVALIDARG;
+
+    if (levels > INT16_MAX)
+        return E_INVALIDARG;
+
+    if (filter & TEX_FILTER_FORCE_WIC)
+        return HRESULT_E_NOT_SUPPORTED;
+
+    if (!metadata.IsVolumemap()
+        || IsCompressed(metadata.format) || IsTypeless(metadata.format) || IsPlanar(metadata.format) || IsPalettized(metadata.format))
+        return HRESULT_E_NOT_SUPPORTED;
+
+    if (!CalculateMipLevels3D(metadata.width, metadata.height, metadata.depth, levels))
+        return E_INVALIDARG;
+
+    if (levels <= 1)
+        return E_INVALIDARG;
+
+    std::vector<Image> baseImages;
+    baseImages.reserve(metadata.depth);
+    for (size_t slice = 0; slice < metadata.depth; ++slice)
+    {
+        const size_t index = metadata.ComputeIndex(0, 0, slice);
+        if (index >= nimages)
+            return E_FAIL;
+
+        const Image& src = srcImages[index];
+        if (!src.pixels)
+            return E_POINTER;
+
+        if (src.format != metadata.format || src.width != metadata.width || src.height != metadata.height)
+        {
+            // All base images must be the same format, width, and height
+            return E_FAIL;
+        }
+
+        baseImages.push_back(src);
+    }
+
+    assert(baseImages.size() == metadata.depth);
+
+    HRESULT hr = E_UNEXPECTED;
+
+    static_assert(TEX_FILTER_POINT == 0x100000, "TEX_FILTER_ flag values don't match TEX_FILTER_MODE_MASK");
+
+    unsigned long filter_select = (filter & TEX_FILTER_MODE_MASK);
+    if (!filter_select)
+    {
+        // Default filter choice
+        filter_select = (ispow2(metadata.width) && ispow2(metadata.height) && ispow2(metadata.depth)) ? TEX_FILTER_BOX : TEX_FILTER_TRIANGLE;
+    }
+
+    switch (filter_select)
+    {
+    case TEX_FILTER_BOX:
+        hr = Setup3DMips(&baseImages[0], metadata.depth, levels, mipChain);
+        if (FAILED(hr))
+            return hr;
+
+        hr = Generate3DMipsBoxFilter(metadata.depth, levels, filter, mipChain);
+        if (FAILED(hr))
+            mipChain.Release();
+        return hr;
+
+    case TEX_FILTER_POINT:
+        hr = Setup3DMips(&baseImages[0], metadata.depth, levels, mipChain);
+        if (FAILED(hr))
+            return hr;
+
+        hr = Generate3DMipsPointFilter(metadata.depth, levels, mipChain);
+        if (FAILED(hr))
+            mipChain.Release();
+        return hr;
+
+    case TEX_FILTER_LINEAR:
+        hr = Setup3DMips(&baseImages[0], metadata.depth, levels, mipChain);
+        if (FAILED(hr))
+            return hr;
+
+        hr = Generate3DMipsLinearFilter(metadata.depth, levels, filter, mipChain);
+        if (FAILED(hr))
+            mipChain.Release();
+        return hr;
+
+    case TEX_FILTER_CUBIC:
+        hr = Setup3DMips(&baseImages[0], metadata.depth, levels, mipChain);
+        if (FAILED(hr))
+            return hr;
+
+        hr = Generate3DMipsCubicFilter(metadata.depth, levels, filter, mipChain);
+        if (FAILED(hr))
+            mipChain.Release();
+        return hr;
+
+    case TEX_FILTER_TRIANGLE:
+        hr = Setup3DMips(&baseImages[0], metadata.depth, levels, mipChain);
+        if (FAILED(hr))
+            return hr;
+
+        hr = Generate3DMipsTriangleFilter(metadata.depth, levels, filter, mipChain);
+        if (FAILED(hr))
+            mipChain.Release();
+        return hr;
+
+    default:
+        return HRESULT_E_NOT_SUPPORTED;
+    }
+}
+
+_Use_decl_annotations_
+HRESULT DirectX::ScaleMipMapsAlphaForCoverage(
+    const Image* srcImages,
+    size_t nimages,
+    const TexMetadata& metadata,
+    size_t item,
+    float alphaReference,
+    ScratchImage& mipChain) noexcept
+{
+    if (!srcImages || !nimages || !IsValid(metadata.format) || nimages > metadata.mipLevels || !mipChain.GetImages())
+        return E_INVALIDARG;
+
+    if (metadata.IsVolumemap()
+        || IsCompressed(metadata.format) || IsTypeless(metadata.format) || IsPlanar(metadata.format) || IsPalettized(metadata.format))
+        return HRESULT_E_NOT_SUPPORTED;
+
+    if (srcImages[0].format != metadata.format || srcImages[0].width != metadata.width || srcImages[0].height != metadata.height)
+    {
+        // Base image must be the same format, width, and height
+        return E_FAIL;
+    }
+
+    float targetCoverage = 0.0f;
+    HRESULT hr = CalculateAlphaCoverage(srcImages[0], alphaReference, 1.0f, targetCoverage);
+    if (FAILED(hr))
+        return hr;
+
+    // Copy base image
+    {
+        const Image& src = srcImages[0];
+
+        const Image *dest = mipChain.GetImage(0, item, 0);
+        if (!dest)
+            return E_POINTER;
+
+        uint8_t* pDest = dest->pixels;
+        if (!pDest)
+            return E_POINTER;
+
+        const uint8_t *pSrc = src.pixels;
+        const size_t rowPitch = src.rowPitch;
+        for (size_t h = 0; h < metadata.height; ++h)
+        {
+            const size_t msize = std::min<size_t>(dest->rowPitch, rowPitch);
+            memcpy(pDest, pSrc, msize);
+            pSrc += rowPitch;
+            pDest += dest->rowPitch;
+        }
+    }
+
+    for (size_t level = 1; level < metadata.mipLevels; ++level)
+    {
+        if (level >= nimages)
+            return E_FAIL;
+
+        float alphaScale = 0.0f;
+        hr = EstimateAlphaScaleForCoverage(srcImages[level], alphaReference, targetCoverage, alphaScale);
+        if (FAILED(hr))
+            return hr;
+
+        const Image* mipImage = mipChain.GetImage(level, item, 0);
+        if (!mipImage)
+            return E_POINTER;
+
+        hr = ScaleAlpha(srcImages[level], alphaScale, *mipImage);
+        if (FAILED(hr))
+            return hr;
+    }
+
+    return S_OK;
+}

--- a/DirectXTex/DirectXTex/DirectXTexMisc.cpp
+++ b/DirectXTex/DirectXTex/DirectXTexMisc.cpp
@@ -1,0 +1,767 @@
+//-------------------------------------------------------------------------------------
+// DirectXTexMisc.cpp
+//
+// DirectX Texture Library - Misc image operations
+//
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+//
+// http://go.microsoft.com/fwlink/?LinkId=248926
+//-------------------------------------------------------------------------------------
+
+#include "DirectXTexP.h"
+
+using namespace DirectX;
+using namespace DirectX::Internal;
+
+#ifdef __GNUC__
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wignored-attributes"
+#endif
+
+namespace
+{
+    const XMVECTORF32 g_Gamma22 = { { { 2.2f, 2.2f, 2.2f, 1.f } } };
+
+    //-------------------------------------------------------------------------------------
+    HRESULT ComputeMSE_(
+        const Image& image1,
+        const Image& image2,
+        float& mse,
+        _Out_writes_opt_(4) float* mseV,
+        CMSE_FLAGS flags) noexcept
+    {
+        if (!image1.pixels || !image2.pixels)
+            return E_POINTER;
+
+        assert(image1.width == image2.width && image1.height == image2.height);
+        assert(!IsCompressed(image1.format) && !IsCompressed(image2.format));
+
+        const size_t width = image1.width;
+
+        auto scanline = make_AlignedArrayXMVECTOR(uint64_t(width) * 2);
+        if (!scanline)
+            return E_OUTOFMEMORY;
+
+        // Flags implied from image formats
+        switch (image1.format)
+        {
+        case DXGI_FORMAT_B8G8R8X8_UNORM:
+            flags |= CMSE_IGNORE_ALPHA;
+            break;
+
+        case DXGI_FORMAT_B8G8R8X8_UNORM_SRGB:
+            flags |= CMSE_IMAGE1_SRGB | CMSE_IGNORE_ALPHA;
+            break;
+
+        case DXGI_FORMAT_R8G8B8A8_UNORM_SRGB:
+        case DXGI_FORMAT_BC1_UNORM_SRGB:
+        case DXGI_FORMAT_BC2_UNORM_SRGB:
+        case DXGI_FORMAT_BC3_UNORM_SRGB:
+        case DXGI_FORMAT_B8G8R8A8_UNORM_SRGB:
+        case DXGI_FORMAT_BC7_UNORM_SRGB:
+            flags |= CMSE_IMAGE1_SRGB;
+            break;
+
+        default:
+            break;
+        }
+
+        switch (image2.format)
+        {
+        case DXGI_FORMAT_B8G8R8X8_UNORM:
+            flags |= CMSE_IGNORE_ALPHA;
+            break;
+
+        case DXGI_FORMAT_B8G8R8X8_UNORM_SRGB:
+            flags |= CMSE_IMAGE2_SRGB | CMSE_IGNORE_ALPHA;
+            break;
+
+        case DXGI_FORMAT_R8G8B8A8_UNORM_SRGB:
+        case DXGI_FORMAT_BC1_UNORM_SRGB:
+        case DXGI_FORMAT_BC2_UNORM_SRGB:
+        case DXGI_FORMAT_BC3_UNORM_SRGB:
+        case DXGI_FORMAT_B8G8R8A8_UNORM_SRGB:
+        case DXGI_FORMAT_BC7_UNORM_SRGB:
+            flags |= CMSE_IMAGE2_SRGB;
+            break;
+
+        default:
+            break;
+        }
+
+        const uint8_t *pSrc1 = image1.pixels;
+        const size_t rowPitch1 = image1.rowPitch;
+
+        const uint8_t *pSrc2 = image2.pixels;
+        const size_t rowPitch2 = image2.rowPitch;
+
+        XMVECTOR acc = g_XMZero;
+        static XMVECTORF32 two = { { { 2.0f, 2.0f, 2.0f, 2.0f } } };
+
+        for (size_t h = 0; h < image1.height; ++h)
+        {
+            XMVECTOR* ptr1 = scanline.get();
+            if (!LoadScanline(ptr1, width, pSrc1, rowPitch1, image1.format))
+                return E_FAIL;
+
+            XMVECTOR* ptr2 = scanline.get() + width;
+            if (!LoadScanline(ptr2, width, pSrc2, rowPitch2, image2.format))
+                return E_FAIL;
+
+            for (size_t i = 0; i < width; ++i)
+            {
+                XMVECTOR v1 = *(ptr1++);
+                if (flags & CMSE_IMAGE1_SRGB)
+                {
+                    v1 = XMVectorPow(v1, g_Gamma22);
+                }
+                if (flags & CMSE_IMAGE1_X2_BIAS)
+                {
+                    v1 = XMVectorMultiplyAdd(v1, two, g_XMNegativeOne);
+                }
+
+                XMVECTOR v2 = *(ptr2++);
+                if (flags & CMSE_IMAGE2_SRGB)
+                {
+                    v2 = XMVectorPow(v2, g_Gamma22);
+                }
+                if (flags & CMSE_IMAGE2_X2_BIAS)
+                {
+                    v2 = XMVectorMultiplyAdd(v2, two, g_XMNegativeOne);
+                }
+
+                // sum[ (I1 - I2)^2 ]
+                XMVECTOR v = XMVectorSubtract(v1, v2);
+                if (flags & CMSE_IGNORE_RED)
+                {
+                    v = XMVectorSelect(v, g_XMZero, g_XMMaskX);
+                }
+                if (flags & CMSE_IGNORE_GREEN)
+                {
+                    v = XMVectorSelect(v, g_XMZero, g_XMMaskY);
+                }
+                if (flags & CMSE_IGNORE_BLUE)
+                {
+                    v = XMVectorSelect(v, g_XMZero, g_XMMaskZ);
+                }
+                if (flags & CMSE_IGNORE_ALPHA)
+                {
+                    v = XMVectorSelect(v, g_XMZero, g_XMMaskW);
+                }
+
+                acc = XMVectorMultiplyAdd(v, v, acc);
+            }
+
+            pSrc1 += rowPitch1;
+            pSrc2 += rowPitch2;
+        }
+
+        // MSE = sum[ (I1 - I2)^2 ] / w*h
+        const XMVECTOR d = XMVectorReplicate(float(image1.width * image1.height));
+        const XMVECTOR v = XMVectorDivide(acc, d);
+        if (mseV)
+        {
+            XMStoreFloat4(reinterpret_cast<XMFLOAT4*>(mseV), v);
+            mse = mseV[0] + mseV[1] + mseV[2] + mseV[3];
+        }
+        else
+        {
+            XMFLOAT4 _mseV;
+            XMStoreFloat4(&_mseV, v);
+            mse = _mseV.x + _mseV.y + _mseV.z + _mseV.w;
+        }
+
+        return S_OK;
+    }
+
+    //-------------------------------------------------------------------------------------
+    HRESULT EvaluateImage_(
+        const Image& image,
+        const std::function<void __cdecl(_In_reads_(width) const XMVECTOR* pixels, size_t width, size_t y)>& pixelFunc)
+    {
+        if (!pixelFunc)
+            return E_INVALIDARG;
+
+        if (!image.pixels)
+            return E_POINTER;
+
+        assert(!IsCompressed(image.format));
+
+        const size_t width = image.width;
+
+        auto scanline = make_AlignedArrayXMVECTOR(width);
+        if (!scanline)
+            return E_OUTOFMEMORY;
+
+        const uint8_t *pSrc = image.pixels;
+        const size_t rowPitch = image.rowPitch;
+
+        for (size_t h = 0; h < image.height; ++h)
+        {
+            if (!LoadScanline(scanline.get(), width, pSrc, rowPitch, image.format))
+                return E_FAIL;
+
+            pixelFunc(scanline.get(), width, h);
+
+            pSrc += rowPitch;
+        }
+
+        return S_OK;
+    }
+
+
+    //-------------------------------------------------------------------------------------
+    HRESULT TransformImage_(
+        const Image& srcImage,
+        const std::function<void __cdecl(_Out_writes_(width) XMVECTOR* outPixels, _In_reads_(width) const XMVECTOR* inPixels, size_t width, size_t y)>& pixelFunc,
+        const Image& destImage)
+    {
+        if (!pixelFunc)
+            return E_INVALIDARG;
+
+        if (!srcImage.pixels || !destImage.pixels)
+            return E_POINTER;
+
+        if (srcImage.width != destImage.width || srcImage.height != destImage.height || srcImage.format != destImage.format)
+            return E_FAIL;
+
+        const size_t width = srcImage.width;
+
+        auto scanlines = make_AlignedArrayXMVECTOR(uint64_t(width) * 2);
+        if (!scanlines)
+            return E_OUTOFMEMORY;
+
+        XMVECTOR* sScanline = scanlines.get();
+        XMVECTOR* dScanline = scanlines.get() + width;
+
+        const uint8_t *pSrc = srcImage.pixels;
+        const size_t spitch = srcImage.rowPitch;
+
+        uint8_t *pDest = destImage.pixels;
+        const size_t dpitch = destImage.rowPitch;
+
+        for (size_t h = 0; h < srcImage.height; ++h)
+        {
+            if (!LoadScanline(sScanline, width, pSrc, spitch, srcImage.format))
+                return E_FAIL;
+
+        #ifdef _DEBUG
+            memset(dScanline, 0xCD, sizeof(XMVECTOR)*width);
+        #endif
+
+            pixelFunc(dScanline, sScanline, width, h);
+
+            if (!StoreScanline(pDest, destImage.rowPitch, destImage.format, dScanline, width))
+                return E_FAIL;
+
+            pSrc += spitch;
+            pDest += dpitch;
+        }
+
+        return S_OK;
+    }
+};
+
+
+//=====================================================================================
+// Entry points
+//=====================================================================================
+
+//-------------------------------------------------------------------------------------
+// Copies a rectangle from one image into another
+//-------------------------------------------------------------------------------------
+_Use_decl_annotations_
+HRESULT DirectX::CopyRectangle(
+    const Image& srcImage,
+    const Rect& srcRect,
+    const Image& dstImage,
+    TEX_FILTER_FLAGS filter,
+    size_t xOffset,
+    size_t yOffset) noexcept
+{
+    if (!srcImage.pixels || !dstImage.pixels)
+        return E_POINTER;
+
+    if (IsCompressed(srcImage.format) || IsCompressed(dstImage.format)
+        || IsPlanar(srcImage.format) || IsPlanar(dstImage.format)
+        || IsPalettized(srcImage.format) || IsPalettized(dstImage.format))
+        return HRESULT_E_NOT_SUPPORTED;
+
+    // Validate rectangle/offset
+    if (!srcRect.w || !srcRect.h || ((srcRect.x + srcRect.w) > srcImage.width) || ((srcRect.y + srcRect.h) > srcImage.height))
+    {
+        return E_INVALIDARG;
+    }
+
+    if (((xOffset + srcRect.w) > dstImage.width) || ((yOffset + srcRect.h) > dstImage.height))
+    {
+        return E_INVALIDARG;
+    }
+
+    // Compute source bytes-per-pixel
+    size_t sbpp = BitsPerPixel(srcImage.format);
+    if (!sbpp)
+        return E_FAIL;
+
+    if (sbpp < 8)
+    {
+        // We don't support monochrome (DXGI_FORMAT_R1_UNORM)
+        return HRESULT_E_NOT_SUPPORTED;
+    }
+
+    const uint8_t* pEndSrc = srcImage.pixels + srcImage.rowPitch*srcImage.height;
+    const uint8_t* pEndDest = dstImage.pixels + dstImage.rowPitch*dstImage.height;
+
+    // Round to bytes
+    sbpp = (sbpp + 7) / 8;
+
+    const uint8_t* pSrc = srcImage.pixels + (srcRect.y * srcImage.rowPitch) + (srcRect.x * sbpp);
+
+    if (srcImage.format == dstImage.format)
+    {
+        // Direct copy case (avoid intermediate conversions)
+        uint8_t* pDest = dstImage.pixels + (yOffset * dstImage.rowPitch) + (xOffset * sbpp);
+        const size_t copyW = srcRect.w * sbpp;
+        for (size_t h = 0; h < srcRect.h; ++h)
+        {
+            if (((pSrc + copyW) > pEndSrc) || (pDest > pEndDest))
+                return E_FAIL;
+
+            memcpy(pDest, pSrc, copyW);
+
+            pSrc += srcImage.rowPitch;
+            pDest += dstImage.rowPitch;
+        }
+
+        return S_OK;
+    }
+
+    // Compute destination bytes-per-pixel (not the same format as source)
+    size_t dbpp = BitsPerPixel(dstImage.format);
+    if (!dbpp)
+        return E_FAIL;
+
+    if (dbpp < 8)
+    {
+        // We don't support monochrome (DXGI_FORMAT_R1_UNORM)
+        return HRESULT_E_NOT_SUPPORTED;
+    }
+
+    // Round to bytes
+    dbpp = (dbpp + 7) / 8;
+
+    uint8_t* pDest = dstImage.pixels + (yOffset * dstImage.rowPitch) + (xOffset * dbpp);
+
+    auto scanline = make_AlignedArrayXMVECTOR(srcRect.w);
+    if (!scanline)
+        return E_OUTOFMEMORY;
+
+    const size_t copyS = srcRect.w * sbpp;
+    const size_t copyD = srcRect.w * dbpp;
+
+    for (size_t h = 0; h < srcRect.h; ++h)
+    {
+        if (((pSrc + copyS) > pEndSrc) || ((pDest + copyD) > pEndDest))
+            return E_FAIL;
+
+        if (!LoadScanline(scanline.get(), srcRect.w, pSrc, copyS, srcImage.format))
+            return E_FAIL;
+
+        ConvertScanline(scanline.get(), srcRect.w, dstImage.format, srcImage.format, filter);
+
+        if (!StoreScanline(pDest, copyD, dstImage.format, scanline.get(), srcRect.w))
+            return E_FAIL;
+
+        pSrc += srcImage.rowPitch;
+        pDest += dstImage.rowPitch;
+    }
+
+    return S_OK;
+}
+
+
+//-------------------------------------------------------------------------------------
+// Computes the Mean-Squared-Error (MSE) between two images
+//-------------------------------------------------------------------------------------
+_Use_decl_annotations_
+HRESULT DirectX::ComputeMSE(
+    const Image& image1,
+    const Image& image2,
+    float& mse,
+    float* mseV,
+    CMSE_FLAGS flags) noexcept
+{
+    if (!image1.pixels || !image2.pixels)
+        return E_POINTER;
+
+    if (image1.width != image2.width || image1.height != image2.height)
+        return E_INVALIDARG;
+
+    if (!IsValid(image1.format) || !IsValid(image2.format))
+        return E_INVALIDARG;
+
+    if (IsPlanar(image1.format) || IsPlanar(image2.format)
+        || IsPalettized(image1.format) || IsPalettized(image2.format)
+        || IsTypeless(image1.format) || IsTypeless(image2.format))
+        return HRESULT_E_NOT_SUPPORTED;
+
+    if (IsCompressed(image1.format))
+    {
+        if (IsCompressed(image2.format))
+        {
+            // Case 1: both images are compressed, expand to RGBA32F
+            ScratchImage temp1;
+            HRESULT hr = Decompress(image1, DXGI_FORMAT_R32G32B32A32_FLOAT, temp1);
+            if (FAILED(hr))
+                return hr;
+
+            ScratchImage temp2;
+            hr = Decompress(image2, DXGI_FORMAT_R32G32B32A32_FLOAT, temp2);
+            if (FAILED(hr))
+                return hr;
+
+            const Image* img1 = temp1.GetImage(0, 0, 0);
+            const Image* img2 = temp2.GetImage(0, 0, 0);
+            if (!img1 || !img2)
+                return E_POINTER;
+
+            return ComputeMSE_(*img1, *img2, mse, mseV, flags);
+        }
+        else
+        {
+            // Case 2: image1 is compressed, expand to RGBA32F
+            ScratchImage temp;
+            HRESULT hr = Decompress(image1, DXGI_FORMAT_R32G32B32A32_FLOAT, temp);
+            if (FAILED(hr))
+                return hr;
+
+            const Image* img = temp.GetImage(0, 0, 0);
+            if (!img)
+                return E_POINTER;
+
+            return ComputeMSE_(*img, image2, mse, mseV, flags);
+        }
+    }
+    else
+    {
+        if (IsCompressed(image2.format))
+        {
+            // Case 3: image2 is compressed, expand to RGBA32F
+            ScratchImage temp;
+            HRESULT hr = Decompress(image2, DXGI_FORMAT_R32G32B32A32_FLOAT, temp);
+            if (FAILED(hr))
+                return hr;
+
+            const Image* img = temp.GetImage(0, 0, 0);
+            if (!img)
+                return E_POINTER;
+
+            return ComputeMSE_(image1, *img, mse, mseV, flags);
+        }
+        else
+        {
+            // Case 4: neither image is compressed
+            return ComputeMSE_(image1, image2, mse, mseV, flags);
+        }
+    }
+}
+
+
+//-------------------------------------------------------------------------------------
+// Evaluates a user-supplied function for all the pixels in the image
+//-------------------------------------------------------------------------------------
+_Use_decl_annotations_
+HRESULT DirectX::EvaluateImage(
+    const Image& image,
+    std::function<void __cdecl(_In_reads_(width) const XMVECTOR* pixels, size_t width, size_t y)> pixelFunc)
+{
+    if (image.width > UINT32_MAX
+        || image.height > UINT32_MAX)
+        return E_INVALIDARG;
+
+    if (!IsValid(image.format))
+        return E_INVALIDARG;
+
+    if (IsPlanar(image.format) || IsPalettized(image.format) || IsTypeless(image.format))
+        return HRESULT_E_NOT_SUPPORTED;
+
+    if (IsCompressed(image.format))
+    {
+        ScratchImage temp;
+        HRESULT hr = Decompress(image, DXGI_FORMAT_R32G32B32A32_FLOAT, temp);
+        if (FAILED(hr))
+            return hr;
+
+        const Image* img = temp.GetImage(0, 0, 0);
+        if (!img)
+            return E_POINTER;
+
+        return EvaluateImage_(*img, pixelFunc);
+    }
+    else
+    {
+        return EvaluateImage_(image, pixelFunc);
+    }
+}
+
+_Use_decl_annotations_
+HRESULT DirectX::EvaluateImage(
+    const Image* images,
+    size_t nimages,
+    const TexMetadata& metadata,
+    std::function<void __cdecl(_In_reads_(width) const XMVECTOR* pixels, size_t width, size_t y)> pixelFunc)
+{
+    if (!images || !nimages)
+        return E_INVALIDARG;
+
+    if (!IsValid(metadata.format))
+        return E_INVALIDARG;
+
+    if (IsPlanar(metadata.format) || IsPalettized(metadata.format) || IsTypeless(metadata.format))
+        return HRESULT_E_NOT_SUPPORTED;
+
+    if (metadata.width > UINT32_MAX
+        || metadata.height > UINT32_MAX)
+        return E_INVALIDARG;
+
+    if (metadata.IsVolumemap() && metadata.depth > UINT16_MAX)
+        return E_INVALIDARG;
+
+    ScratchImage temp;
+    DXGI_FORMAT format = metadata.format;
+    if (IsCompressed(format))
+    {
+        HRESULT hr = Decompress(images, nimages, metadata, DXGI_FORMAT_R32G32B32A32_FLOAT, temp);
+        if (FAILED(hr))
+            return hr;
+
+        if (nimages != temp.GetImageCount())
+            return E_UNEXPECTED;
+
+        images = temp.GetImages();
+        format = DXGI_FORMAT_R32G32B32A32_FLOAT;
+    }
+
+    switch (metadata.dimension)
+    {
+    case TEX_DIMENSION_TEXTURE1D:
+    case TEX_DIMENSION_TEXTURE2D:
+        for (size_t index = 0; index < nimages; ++index)
+        {
+            const Image& img = images[index];
+            if (img.format != format)
+                return E_FAIL;
+
+            if ((img.width > UINT32_MAX) || (img.height > UINT32_MAX))
+                return E_FAIL;
+
+            HRESULT hr = EvaluateImage_(img, pixelFunc);
+            if (FAILED(hr))
+                return hr;
+        }
+        break;
+
+    case TEX_DIMENSION_TEXTURE3D:
+        {
+            size_t index = 0;
+            size_t d = metadata.depth;
+            for (size_t level = 0; level < metadata.mipLevels; ++level)
+            {
+                for (size_t slice = 0; slice < d; ++slice, ++index)
+                {
+                    if (index >= nimages)
+                        return E_FAIL;
+
+                    const Image& img = images[index];
+                    if (img.format != format)
+                        return E_FAIL;
+
+                    if ((img.width > UINT32_MAX) || (img.height > UINT32_MAX))
+                        return E_FAIL;
+
+                    HRESULT hr = EvaluateImage_(img, pixelFunc);
+                    if (FAILED(hr))
+                        return hr;
+                }
+
+                if (d > 1)
+                    d >>= 1;
+            }
+        }
+        break;
+
+    default:
+        return E_FAIL;
+    }
+
+    return S_OK;
+}
+
+
+//-------------------------------------------------------------------------------------
+// Use a user-supplied function to compute a new image from an input image
+//-------------------------------------------------------------------------------------
+_Use_decl_annotations_
+HRESULT DirectX::TransformImage(
+    const Image& image,
+    std::function<void __cdecl(_Out_writes_(width) XMVECTOR* outPixels, _In_reads_(width) const XMVECTOR* inPixels, size_t width, size_t y)> pixelFunc,
+    ScratchImage& result)
+{
+    if (image.width > UINT32_MAX
+        || image.height > UINT32_MAX)
+        return E_INVALIDARG;
+
+    if (IsPlanar(image.format) || IsPalettized(image.format) || IsCompressed(image.format) || IsTypeless(image.format))
+        return HRESULT_E_NOT_SUPPORTED;
+
+    HRESULT hr = result.Initialize2D(image.format, image.width, image.height, 1, 1);
+    if (FAILED(hr))
+        return hr;
+
+    const Image* dimg = result.GetImage(0, 0, 0);
+    if (!dimg)
+    {
+        result.Release();
+        return E_POINTER;
+    }
+
+    hr = TransformImage_(image, pixelFunc, *dimg);
+    if (FAILED(hr))
+    {
+        result.Release();
+        return hr;
+    }
+
+    return S_OK;
+}
+
+_Use_decl_annotations_
+HRESULT DirectX::TransformImage(
+    const Image* srcImages,
+    size_t nimages, const TexMetadata& metadata,
+    std::function<void __cdecl(_Out_writes_(width) XMVECTOR* outPixels, _In_reads_(width) const XMVECTOR* inPixels, size_t width, size_t y)> pixelFunc,
+    ScratchImage& result)
+{
+    if (!srcImages || !nimages)
+        return E_INVALIDARG;
+
+    if (IsPlanar(metadata.format) || IsPalettized(metadata.format) || IsCompressed(metadata.format) || IsTypeless(metadata.format))
+        return HRESULT_E_NOT_SUPPORTED;
+
+    if (metadata.width > UINT32_MAX
+        || metadata.height > UINT32_MAX)
+        return E_INVALIDARG;
+
+    if (metadata.IsVolumemap() && metadata.depth > UINT16_MAX)
+        return E_INVALIDARG;
+
+    HRESULT hr = result.Initialize(metadata);
+    if (FAILED(hr))
+        return hr;
+
+    if (nimages != result.GetImageCount())
+    {
+        result.Release();
+        return E_FAIL;
+    }
+
+    const Image* dest = result.GetImages();
+    if (!dest)
+    {
+        result.Release();
+        return E_POINTER;
+    }
+
+    switch (metadata.dimension)
+    {
+    case TEX_DIMENSION_TEXTURE1D:
+    case TEX_DIMENSION_TEXTURE2D:
+        for (size_t index = 0; index < nimages; ++index)
+        {
+            const Image& src = srcImages[index];
+            if (src.format != metadata.format)
+            {
+                result.Release();
+                return E_FAIL;
+            }
+
+            if ((src.width > UINT32_MAX) || (src.height > UINT32_MAX))
+            {
+                result.Release();
+                return E_FAIL;
+            }
+
+            const Image& dst = dest[index];
+
+            if (src.width != dst.width || src.height != dst.height)
+            {
+                result.Release();
+                return E_FAIL;
+            }
+
+            hr = TransformImage_(src, pixelFunc, dst);
+            if (FAILED(hr))
+            {
+                result.Release();
+                return hr;
+            }
+        }
+        break;
+
+    case TEX_DIMENSION_TEXTURE3D:
+        {
+            size_t index = 0;
+            size_t d = metadata.depth;
+            for (size_t level = 0; level < metadata.mipLevels; ++level)
+            {
+                for (size_t slice = 0; slice < d; ++slice, ++index)
+                {
+                    if (index >= nimages)
+                    {
+                        result.Release();
+                        return E_FAIL;
+                    }
+
+                    const Image& src = srcImages[index];
+                    if (src.format != metadata.format)
+                    {
+                        result.Release();
+                        return E_FAIL;
+                    }
+
+                    if ((src.width > UINT32_MAX) || (src.height > UINT32_MAX))
+                    {
+                        result.Release();
+                        return E_FAIL;
+                    }
+
+                    const Image& dst = dest[index];
+
+                    if (src.width != dst.width || src.height != dst.height)
+                    {
+                        result.Release();
+                        return E_FAIL;
+                    }
+
+                    hr = TransformImage_(src, pixelFunc, dst);
+                    if (FAILED(hr))
+                    {
+                        result.Release();
+                        return hr;
+                    }
+                }
+
+                if (d > 1)
+                    d >>= 1;
+            }
+        }
+        break;
+
+    default:
+        result.Release();
+        return E_FAIL;
+    }
+
+    return S_OK;
+}

--- a/DirectXTex/DirectXTex/DirectXTexP.h
+++ b/DirectXTex/DirectXTex/DirectXTexP.h
@@ -1,0 +1,457 @@
+//-------------------------------------------------------------------------------------
+// DirectXTexP.h
+//
+// DirectX Texture Library - Private header
+//
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+//
+// http://go.microsoft.com/fwlink/?LinkId=248926
+//-------------------------------------------------------------------------------------
+
+#pragma once
+
+#ifdef _MSC_VER
+// Off by default warnings
+#pragma warning(disable : 4619 4616 4061 4265 4365 4571 4623 4625 4626 4628 4668 4710 4711 4746 4774 4820 4987 5026 5027 5031 5032 5039 5045 5219 5246 5264 26812)
+// C4619/4616 #pragma warning warnings
+// C4061 enumerator 'X' in switch of enum 'X' is not explicitly handled by a case label
+// C4265 class has virtual functions, but destructor is not virtual
+// C4365 signed/unsigned mismatch
+// C4571 behavior change
+// C4623 default constructor was implicitly defined as deleted
+// C4625 copy constructor was implicitly defined as deleted
+// C4626 assignment operator was implicitly defined as deleted
+// C4628 digraphs not supported
+// C4668 not defined as a preprocessor macro
+// C4710 function not inlined
+// C4711 selected for automatic inline expansion
+// C4746 volatile access of '<expression>' is subject to /volatile:<iso|ms> setting
+// C4774 format string expected in argument 3 is not a string literal
+// C4820 padding added after data member
+// C4987 nonstandard extension used
+// C5026 move constructor was implicitly defined as deleted
+// C5027 move assignment operator was implicitly defined as deleted
+// C5031/5032 push/pop mismatches in windows headers
+// C5039 pointer or reference to potentially throwing function passed to extern C function under - EHc
+// C5045 Spectre mitigation warning
+// C5219 implicit conversion from 'int' to 'float', possible loss of data
+// C5246 the initialization of a subobject should be wrapped in braces
+// C5264 'const' variable is not used
+// 26812: The enum type 'x' is unscoped. Prefer 'enum class' over 'enum' (Enum.3).
+
+#if defined(_XBOX_ONE) && defined(_TITLE)
+// Xbox One XDK related Off by default warnings
+#pragma warning(disable : 4471 4643 4917 4986 5029 5038 5040 5043 5204 5246 5256 5262 5267)
+// C4471 forward declaration of an unscoped enumeration must have an underlying type
+// C4643 Forward declaring in namespace std is not permitted by the C++ Standard
+// C4917 a GUID can only be associated with a class, interface or namespace
+// C4986 exception specification does not match previous declaration
+// C5029 nonstandard extension used
+// C5038 data member 'X' will be initialized after data member 'Y'
+// C5040 dynamic exception specifications are valid only in C++14 and earlier; treating as noexcept(false)
+// C5043 exception specification does not match previous declaration
+// C5204 class has virtual functions, but its trivial destructor is not virtual; instances of objects derived from this class may not be destructed correctly
+// C5246 'anonymous struct or union': the initialization of a subobject should be wrapped in braces
+// C5256 a non-defining declaration of an enumeration with a fixed underlying type is only permitted as a standalone declaration
+// C5262 implicit fall-through occurs here; are you missing a break statement?
+// C5267 definition of implicit copy constructor for 'X' is deprecated because it has a user-provided assignment operator
+#endif // _XBOX_ONE && _TITLE
+#endif // _MSC_VER
+
+#ifdef __INTEL_COMPILER
+#pragma warning(disable : 161)
+// warning #161: unrecognized #pragma
+#endif
+
+#ifdef __clang__
+#pragma clang diagnostic ignored "-Wc++98-compat"
+#pragma clang diagnostic ignored "-Wc++98-compat-pedantic"
+#pragma clang diagnostic ignored "-Wc++98-compat-local-type-template-args"
+#pragma clang diagnostic ignored "-Wcovered-switch-default"
+#pragma clang diagnostic ignored "-Wfloat-equal"
+#pragma clang diagnostic ignored "-Wglobal-constructors"
+#pragma clang diagnostic ignored "-Wgnu-anonymous-struct"
+#pragma clang diagnostic ignored "-Wlanguage-extension-token"
+#pragma clang diagnostic ignored "-Wmissing-variable-declarations"
+#pragma clang diagnostic ignored "-Wnested-anon-types"
+#pragma clang diagnostic ignored "-Wreserved-id-macro"
+#pragma clang diagnostic ignored "-Wswitch-enum"
+#pragma clang diagnostic ignored "-Wtautological-type-limit-compare"
+#pragma clang diagnostic ignored "-Wunknown-pragmas"
+#pragma clang diagnostic ignored "-Wundef"
+#pragma clang diagnostic ignored "-Wunknown-warning-option"
+#pragma clang diagnostic ignored "-Wunsafe-buffer-usage"
+#endif
+
+#ifdef _WIN32
+#ifndef WIN32_LEAN_AND_MEAN
+#define WIN32_LEAN_AND_MEAN
+#endif
+
+#pragma warning(push)
+#pragma warning(disable : 4005)
+#define NOMINMAX 1
+#define NODRAWTEXT
+#define NOGDI
+#define NOBITMAP
+#define NOMCX
+#define NOSERVICE
+#define NOHELP
+#pragma warning(pop)
+
+#include <Windows.h>
+
+#ifdef __MINGW32__
+#include <unknwn.h>
+#endif
+
+#ifndef _WIN32_WINNT_WIN10
+#define _WIN32_WINNT_WIN10 0x0A00
+#endif
+
+#ifdef _GAMING_XBOX_SCARLETT
+#pragma warning(push)
+#pragma warning(disable: 5204 5249)
+#include <d3d12_xs.h>
+#pragma warning(pop)
+#elif defined(_GAMING_XBOX)
+#pragma warning(push)
+#pragma warning(disable: 5204)
+#include <d3d12_x.h>
+#pragma warning(pop)
+#elif defined(_XBOX_ONE) && defined(_TITLE)
+#include <d3d12_x.h>
+#include <d3d11_x.h>
+#elif (_WIN32_WINNT >= _WIN32_WINNT_WIN10)
+#ifdef USING_DIRECTX_HEADERS
+#include <directx/dxgiformat.h>
+#include <directx/d3d12.h>
+#else
+#include <d3d12.h>
+#endif
+#include <d3d11_4.h>
+#else
+#include <d3d11_1.h>
+#endif
+#else // !WIN32
+#include <wsl/winadapter.h>
+#include <wsl/wrladapter.h>
+#include <directx/d3d12.h>
+#endif
+
+#include <algorithm>
+#include <cassert>
+#include <cctype>
+#include <cstdlib>
+#include <ctime>
+#include <cstring>
+#include <iterator>
+#include <memory>
+#include <new>
+#include <tuple>
+
+#ifndef _WIN32
+#include <fstream>
+#include <filesystem>
+#include <thread>
+#endif
+
+#define _XM_NO_XMVECTOR_OVERLOADS_
+
+#include <DirectXPackedVector.h>
+
+#if (DIRECTX_MATH_VERSION < 315)
+#define XM_ALIGNED_DATA(x) __declspec(align(x))
+#endif
+
+#include "DirectXTex.h"
+
+#ifdef _WIN32
+#include <malloc.h>
+
+#if defined(NTDDI_WIN10_FE) || defined(__MINGW32__)
+#include <ole2.h>
+#else
+#include <Ole2.h>
+#endif
+#include <wincodec.h>
+#include <wrl\client.h>
+#else
+using WICPixelFormatGUID = GUID;
+#endif
+
+#include "scoped.h"
+
+#define XBOX_DXGI_FORMAT_R10G10B10_7E3_A2_FLOAT DXGI_FORMAT(116)
+#define XBOX_DXGI_FORMAT_R10G10B10_6E4_A2_FLOAT DXGI_FORMAT(117)
+#define XBOX_DXGI_FORMAT_D16_UNORM_S8_UINT DXGI_FORMAT(118)
+#define XBOX_DXGI_FORMAT_R16_UNORM_X8_TYPELESS DXGI_FORMAT(119)
+#define XBOX_DXGI_FORMAT_X16_TYPELESS_G8_UINT DXGI_FORMAT(120)
+
+#define WIN10_DXGI_FORMAT_P208 DXGI_FORMAT(130)
+#define WIN10_DXGI_FORMAT_V208 DXGI_FORMAT(131)
+#define WIN10_DXGI_FORMAT_V408 DXGI_FORMAT(132)
+
+#ifndef XBOX_DXGI_FORMAT_R10G10B10_SNORM_A2_UNORM
+#define XBOX_DXGI_FORMAT_R10G10B10_SNORM_A2_UNORM DXGI_FORMAT(189)
+#endif
+
+#define XBOX_DXGI_FORMAT_R4G4_UNORM DXGI_FORMAT(190)
+
+#define WIN11_DXGI_FORMAT_A4B4G4R4_UNORM DXGI_FORMAT(191)
+
+#if defined(__MINGW32__) && !defined(E_BOUNDS)
+#define E_BOUNDS static_cast<HRESULT>(0x8000000BL)
+#endif
+
+// HRESULT_FROM_WIN32(ERROR_FILE_NOT_FOUND)
+#define HRESULT_ERROR_FILE_NOT_FOUND static_cast<HRESULT>(0x80070002)
+
+// HRESULT_FROM_WIN32(ERROR_ARITHMETIC_OVERFLOW)
+#define HRESULT_E_ARITHMETIC_OVERFLOW static_cast<HRESULT>(0x80070216L)
+
+// HRESULT_FROM_WIN32(ERROR_NOT_SUPPORTED)
+#define HRESULT_E_NOT_SUPPORTED static_cast<HRESULT>(0x80070032L)
+
+// HRESULT_FROM_WIN32(ERROR_HANDLE_EOF)
+#define HRESULT_E_HANDLE_EOF static_cast<HRESULT>(0x80070026L)
+
+// HRESULT_FROM_WIN32(ERROR_INVALID_DATA)
+#define HRESULT_E_INVALID_DATA static_cast<HRESULT>(0x8007000DL)
+
+// HRESULT_FROM_WIN32(ERROR_FILE_TOO_LARGE)
+#define HRESULT_E_FILE_TOO_LARGE static_cast<HRESULT>(0x800700DFL)
+
+// HRESULT_FROM_WIN32(ERROR_CANNOT_MAKE)
+#define HRESULT_E_CANNOT_MAKE static_cast<HRESULT>(0x80070052L)
+
+// HRESULT_FROM_WIN32(ERROR_INSUFFICIENT_BUFFER)
+#ifndef E_NOT_SUFFICIENT_BUFFER
+#define E_NOT_SUFFICIENT_BUFFER static_cast<HRESULT>(0x8007007AL)
+#endif
+
+//-------------------------------------------------------------------------------------
+namespace DirectX
+{
+    namespace Internal
+    {
+        //-----------------------------------------------------------------------------
+        // WIC helper functions
+    #ifdef _WIN32
+        DXGI_FORMAT __cdecl WICToDXGI(_In_ const GUID& guid) noexcept;
+        bool __cdecl DXGIToWIC(_In_ DXGI_FORMAT format, _Out_ GUID& guid, _In_ bool ignoreRGBvsBGR = false) noexcept;
+
+        TEX_FILTER_FLAGS __cdecl CheckWICColorSpace(_In_ const GUID& sourceGUID, _In_ const GUID& targetGUID) noexcept;
+
+        inline WICBitmapDitherType __cdecl GetWICDither(_In_ TEX_FILTER_FLAGS flags) noexcept
+        {
+            static_assert(TEX_FILTER_DITHER == 0x10000, "TEX_FILTER_DITHER* flag values don't match mask");
+
+            static_assert(static_cast<int>(TEX_FILTER_DITHER) == static_cast<int>(WIC_FLAGS_DITHER), "TEX_FILTER_DITHER* should match WIC_FLAGS_DITHER*");
+            static_assert(static_cast<int>(TEX_FILTER_DITHER_DIFFUSION) == static_cast<int>(WIC_FLAGS_DITHER_DIFFUSION), "TEX_FILTER_DITHER* should match WIC_FLAGS_DITHER*");
+
+            switch (flags & TEX_FILTER_DITHER_MASK)
+            {
+            case TEX_FILTER_DITHER:
+                return WICBitmapDitherTypeOrdered4x4;
+
+            case TEX_FILTER_DITHER_DIFFUSION:
+                return WICBitmapDitherTypeErrorDiffusion;
+
+            default:
+                return WICBitmapDitherTypeNone;
+            }
+        }
+
+        inline WICBitmapDitherType __cdecl GetWICDither(_In_ WIC_FLAGS flags) noexcept
+        {
+            switch (flags & TEX_FILTER_DITHER_MASK)
+            {
+            case WIC_FLAGS_DITHER:
+                return WICBitmapDitherTypeOrdered4x4;
+
+            case WIC_FLAGS_DITHER_DIFFUSION:
+                return WICBitmapDitherTypeErrorDiffusion;
+
+            default:
+                return WICBitmapDitherTypeNone;
+            }
+        }
+
+        inline WICBitmapInterpolationMode __cdecl GetWICInterp(_In_ WIC_FLAGS flags) noexcept
+        {
+            static_assert(TEX_FILTER_POINT == 0x100000, "TEX_FILTER_ flag values don't match TEX_FILTER_MASK");
+
+            static_assert(static_cast<int>(TEX_FILTER_POINT) == static_cast<int>(WIC_FLAGS_FILTER_POINT), "TEX_FILTER_* flags should match WIC_FLAGS_FILTER_*");
+            static_assert(static_cast<int>(TEX_FILTER_LINEAR) == static_cast<int>(WIC_FLAGS_FILTER_LINEAR), "TEX_FILTER_* flags should match WIC_FLAGS_FILTER_*");
+            static_assert(static_cast<int>(TEX_FILTER_CUBIC) == static_cast<int>(WIC_FLAGS_FILTER_CUBIC), "TEX_FILTER_* flags should match WIC_FLAGS_FILTER_*");
+            static_assert(static_cast<int>(TEX_FILTER_FANT) == static_cast<int>(WIC_FLAGS_FILTER_FANT), "TEX_FILTER_* flags should match WIC_FLAGS_FILTER_*");
+
+            switch (flags & TEX_FILTER_MODE_MASK)
+            {
+            case TEX_FILTER_POINT:
+                return WICBitmapInterpolationModeNearestNeighbor;
+
+            case TEX_FILTER_LINEAR:
+                return WICBitmapInterpolationModeLinear;
+
+            case TEX_FILTER_CUBIC:
+                return WICBitmapInterpolationModeCubic;
+
+            case TEX_FILTER_FANT:
+            default:
+                return WICBitmapInterpolationModeFant;
+            }
+        }
+
+        inline WICBitmapInterpolationMode __cdecl GetWICInterp(_In_ TEX_FILTER_FLAGS flags) noexcept
+        {
+            switch (flags & TEX_FILTER_MODE_MASK)
+            {
+            case TEX_FILTER_POINT:
+                return WICBitmapInterpolationModeNearestNeighbor;
+
+            case TEX_FILTER_LINEAR:
+                return WICBitmapInterpolationModeLinear;
+
+            case TEX_FILTER_CUBIC:
+                return WICBitmapInterpolationModeCubic;
+
+            case TEX_FILTER_FANT:
+            default:
+                return WICBitmapInterpolationModeFant;
+            }
+        }
+    #endif // WIN32
+
+        //---------------------------------------------------------------------------------
+        // Image helper functions
+        HRESULT __cdecl DetermineImageArray(
+            _In_ const TexMetadata& metadata, _In_ CP_FLAGS cpFlags,
+            _Out_ size_t& nImages, _Out_ size_t& pixelSize) noexcept;
+
+        _Success_(return) bool __cdecl SetupImageArray(
+            _In_reads_bytes_(pixelSize) uint8_t* pMemory, _In_ size_t pixelSize,
+            _In_ const TexMetadata& metadata, _In_ CP_FLAGS cpFlags,
+            _Out_writes_(nImages) Image* images, _In_ size_t nImages) noexcept;
+
+        //---------------------------------------------------------------------------------
+        // Conversion helper functions
+
+        enum TEXP_SCANLINE_FLAGS : uint32_t
+        {
+            TEXP_SCANLINE_NONE = 0,
+
+            TEXP_SCANLINE_SETALPHA = 0x1,
+            // Set alpha channel to known opaque value
+
+            TEXP_SCANLINE_LEGACY = 0x2,
+            // Enables specific legacy format conversion cases
+        };
+
+        enum CONVERT_FLAGS : uint32_t
+        {
+            CONVF_FLOAT = 0x1,
+            CONVF_UNORM = 0x2,
+            CONVF_UINT = 0x4,
+            CONVF_SNORM = 0x8,
+            CONVF_SINT = 0x10,
+            CONVF_DEPTH = 0x20,
+            CONVF_STENCIL = 0x40,
+            CONVF_SHAREDEXP = 0x80,
+            CONVF_BGR = 0x100,
+            CONVF_XR = 0x200,
+            CONVF_PACKED = 0x400,
+            CONVF_BC = 0x800,
+            CONVF_YUV = 0x1000,
+            CONVF_POS_ONLY = 0x2000,
+            CONVF_R = 0x10000,
+            CONVF_G = 0x20000,
+            CONVF_B = 0x40000,
+            CONVF_A = 0x80000,
+            CONVF_RGB_MASK = 0x70000,
+            CONVF_RGBA_MASK = 0xF0000,
+        };
+
+        uint32_t __cdecl GetConvertFlags(_In_ DXGI_FORMAT format) noexcept;
+
+        void __cdecl CopyScanline(
+            _When_(pDestination == pSource, _Inout_updates_bytes_(outSize))
+            _When_(pDestination != pSource, _Out_writes_bytes_(outSize))
+            void* pDestination, _In_ size_t outSize,
+            _In_reads_bytes_(inSize) const void* pSource, _In_ size_t inSize,
+            _In_ DXGI_FORMAT format, _In_ uint32_t tflags) noexcept;
+
+        void __cdecl SwizzleScanline(
+            _When_(pDestination == pSource, _In_)
+            _When_(pDestination != pSource, _Out_writes_bytes_(outSize))
+            void* pDestination, _In_ size_t outSize,
+            _In_reads_bytes_(inSize) const void* pSource, _In_ size_t inSize,
+            _In_ DXGI_FORMAT format, _In_ uint32_t tflags) noexcept;
+
+        _Success_(return) bool __cdecl ExpandScanline(
+            _Out_writes_bytes_(outSize) void* pDestination, _In_ size_t outSize,
+            _In_ DXGI_FORMAT outFormat,
+            _In_reads_bytes_(inSize) const void* pSource, _In_ size_t inSize,
+            _In_ DXGI_FORMAT inFormat, _In_ uint32_t tflags) noexcept;
+
+        _Success_(return) bool __cdecl LoadScanline(
+            _Out_writes_(count) XMVECTOR* pDestination, _In_ size_t count,
+            _In_reads_bytes_(size) const void* pSource, _In_ size_t size,
+            _In_ DXGI_FORMAT format) noexcept;
+
+        _Success_(return) bool __cdecl LoadScanlineLinear(
+            _Out_writes_(count) XMVECTOR* pDestination, _In_ size_t count,
+            _In_reads_bytes_(size) const void* pSource, _In_ size_t size,
+            _In_ DXGI_FORMAT format, _In_ TEX_FILTER_FLAGS flags) noexcept;
+
+        _Success_(return) bool __cdecl StoreScanline(
+            _Out_writes_bytes_(size) void* pDestination, _In_ size_t size, _In_ DXGI_FORMAT format,
+            _In_reads_(count) const XMVECTOR* pSource, _In_ size_t count, _In_ float threshold = 0) noexcept;
+
+        _Success_(return) bool __cdecl StoreScanlineLinear(
+            _Out_writes_bytes_(size) void* pDestination, _In_ size_t size, _In_ DXGI_FORMAT format,
+            _Inout_updates_all_(count) XMVECTOR* pSource, _In_ size_t count,
+            _In_ TEX_FILTER_FLAGS flags, _In_ float threshold = 0) noexcept;
+
+        _Success_(return) bool __cdecl StoreScanlineDither(
+            _Out_writes_bytes_(size) void* pDestination, _In_ size_t size, _In_ DXGI_FORMAT format,
+            _Inout_updates_all_(count) XMVECTOR* pSource, _In_ size_t count,
+            _In_ float threshold, size_t y, size_t z,
+            _Inout_updates_all_opt_(count + 2) XMVECTOR* pDiffusionErrors) noexcept;
+
+        HRESULT __cdecl ConvertToR32G32B32A32(_In_ const Image& srcImage, _Inout_ ScratchImage& image) noexcept;
+
+        HRESULT __cdecl ConvertFromR32G32B32A32(_In_ const Image& srcImage, _In_ const Image& destImage) noexcept;
+        HRESULT __cdecl ConvertFromR32G32B32A32(
+            _In_ const Image& srcImage, _In_ DXGI_FORMAT format, _Inout_ ScratchImage& image) noexcept;
+        HRESULT __cdecl ConvertFromR32G32B32A32(
+            _In_reads_(nimages) const Image* srcImages, _In_ size_t nimages, _In_ const TexMetadata& metadata,
+            _In_ DXGI_FORMAT format, _Out_ ScratchImage& result) noexcept;
+
+        HRESULT __cdecl ConvertToR16G16B16A16(_In_ const Image& srcImage, _Inout_ ScratchImage& image) noexcept;
+
+        HRESULT __cdecl ConvertFromR16G16B16A16(_In_ const Image& srcImage, _In_ const Image& destImage) noexcept;
+
+        void __cdecl ConvertScanline(
+            _Inout_updates_all_(count) XMVECTOR* pBuffer, _In_ size_t count,
+            _In_ DXGI_FORMAT outFormat, _In_ DXGI_FORMAT inFormat, _In_ TEX_FILTER_FLAGS flags) noexcept;
+
+        //---------------------------------------------------------------------------------
+        // Misc helper functions
+        bool __cdecl IsAlphaAllOpaqueBC(_In_ const Image& cImage) noexcept;
+        bool __cdecl CalculateMipLevels(_In_ size_t width, _In_ size_t height, _Inout_ size_t& mipLevels) noexcept;
+        bool __cdecl CalculateMipLevels3D(_In_ size_t width, _In_ size_t height, _In_ size_t depth,
+            _Inout_ size_t& mipLevels) noexcept;
+
+    #ifdef _WIN32
+        HRESULT __cdecl ResizeSeparateColorAndAlpha(_In_ IWICImagingFactory* pWIC,
+            _In_ bool iswic2,
+            _In_ IWICBitmap* original,
+            _In_ size_t newWidth, _In_ size_t newHeight, _In_ TEX_FILTER_FLAGS filter,
+            _Inout_ const Image* img) noexcept;
+    #endif
+
+    } // namespace Internal
+} // namespace DirectX

--- a/DirectXTex/DirectXTex/DirectXTexUtil.cpp
+++ b/DirectXTex/DirectXTex/DirectXTexUtil.cpp
@@ -1,0 +1,1696 @@
+//-------------------------------------------------------------------------------------
+// DirectXTexUtil.cpp
+//
+// DirectX Texture Library - Utilities
+//
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+//
+// http://go.microsoft.com/fwlink/?LinkId=248926
+//-------------------------------------------------------------------------------------
+
+#include "DirectXTexP.h"
+
+#if (defined(_XBOX_ONE) && defined(_TITLE)) || defined(_GAMING_XBOX)
+static_assert(XBOX_DXGI_FORMAT_R10G10B10_7E3_A2_FLOAT == DXGI_FORMAT_R10G10B10_7E3_A2_FLOAT, "Xbox mismatch detected");
+static_assert(XBOX_DXGI_FORMAT_R10G10B10_6E4_A2_FLOAT == DXGI_FORMAT_R10G10B10_6E4_A2_FLOAT, "Xbox mismatch detected");
+static_assert(XBOX_DXGI_FORMAT_D16_UNORM_S8_UINT == DXGI_FORMAT_D16_UNORM_S8_UINT, "Xbox mismatch detected");
+static_assert(XBOX_DXGI_FORMAT_R16_UNORM_X8_TYPELESS == DXGI_FORMAT_R16_UNORM_X8_TYPELESS, "Xbox mismatch detected");
+static_assert(XBOX_DXGI_FORMAT_X16_TYPELESS_G8_UINT == DXGI_FORMAT_X16_TYPELESS_G8_UINT, "Xbox mismatch detected");
+static_assert(XBOX_DXGI_FORMAT_R10G10B10_SNORM_A2_UNORM == DXGI_FORMAT_R10G10B10_SNORM_A2_UNORM, "Xbox mismatch detected");
+static_assert(XBOX_DXGI_FORMAT_R4G4_UNORM == DXGI_FORMAT_R4G4_UNORM, "Xbox mismatch detected");
+#endif
+
+#if (_WIN32_WINNT >= _WIN32_WINNT_WIN10)
+static_assert(WIN10_DXGI_FORMAT_P208 == DXGI_FORMAT_P208, "Windows SDK mismatch detected");
+static_assert(WIN10_DXGI_FORMAT_V208 == DXGI_FORMAT_V208, "Windows SDK mismatch detected");
+static_assert(WIN10_DXGI_FORMAT_V408 == DXGI_FORMAT_V408, "Windows SDK mismatch detected");
+#endif
+
+using namespace DirectX;
+using Microsoft::WRL::ComPtr;
+
+namespace
+{
+#ifdef _WIN32
+    //-------------------------------------------------------------------------------------
+    // WIC Pixel Format Translation Data
+    //-------------------------------------------------------------------------------------
+    struct WICTranslate
+    {
+        const GUID& wic;
+        DXGI_FORMAT format;
+        bool        srgb;
+
+        constexpr WICTranslate(const GUID& wg, DXGI_FORMAT fmt, bool isrgb) noexcept :
+            wic(wg),
+            format(fmt),
+            srgb(isrgb) {}
+    };
+
+    constexpr WICTranslate g_WICFormats[] =
+    {
+        { GUID_WICPixelFormat128bppRGBAFloat,       DXGI_FORMAT_R32G32B32A32_FLOAT,         false },
+
+        { GUID_WICPixelFormat64bppRGBAHalf,         DXGI_FORMAT_R16G16B16A16_FLOAT,         false },
+        { GUID_WICPixelFormat64bppRGBA,             DXGI_FORMAT_R16G16B16A16_UNORM,         true },
+
+        { GUID_WICPixelFormat32bppRGBA,             DXGI_FORMAT_R8G8B8A8_UNORM,             true },
+        { GUID_WICPixelFormat32bppBGRA,             DXGI_FORMAT_B8G8R8A8_UNORM,             true }, // DXGI 1.1
+        { GUID_WICPixelFormat32bppBGR,              DXGI_FORMAT_B8G8R8X8_UNORM,             true }, // DXGI 1.1
+
+        { GUID_WICPixelFormat32bppRGBA1010102XR,    DXGI_FORMAT_R10G10B10_XR_BIAS_A2_UNORM, true }, // DXGI 1.1
+        { GUID_WICPixelFormat32bppRGBA1010102,      DXGI_FORMAT_R10G10B10A2_UNORM,          true },
+
+        { GUID_WICPixelFormat16bppBGRA5551,         DXGI_FORMAT_B5G5R5A1_UNORM,             true },
+        { GUID_WICPixelFormat16bppBGR565,           DXGI_FORMAT_B5G6R5_UNORM,               true },
+
+        { GUID_WICPixelFormat32bppGrayFloat,        DXGI_FORMAT_R32_FLOAT,                  false },
+        { GUID_WICPixelFormat16bppGrayHalf,         DXGI_FORMAT_R16_FLOAT,                  false },
+        { GUID_WICPixelFormat16bppGray,             DXGI_FORMAT_R16_UNORM,                  true },
+        { GUID_WICPixelFormat8bppGray,              DXGI_FORMAT_R8_UNORM,                   true },
+
+        { GUID_WICPixelFormat8bppAlpha,             DXGI_FORMAT_A8_UNORM,                   false },
+
+        { GUID_WICPixelFormatBlackWhite,            DXGI_FORMAT_R1_UNORM,                   false },
+    };
+
+    bool g_WIC2 = false;
+    IWICImagingFactory* g_Factory = nullptr;
+
+    BOOL WINAPI InitializeWICFactory(PINIT_ONCE, PVOID, PVOID *ifactory) noexcept
+    {
+    #if (_WIN32_WINNT >= _WIN32_WINNT_WIN8) || defined(_WIN7_PLATFORM_UPDATE)
+        HRESULT hr = CoCreateInstance(
+            CLSID_WICImagingFactory2,
+            nullptr,
+            CLSCTX_INPROC_SERVER,
+            __uuidof(IWICImagingFactory2),
+            ifactory
+        );
+
+        if (SUCCEEDED(hr))
+        {
+            // WIC2 is available on Windows 10, Windows 8.x, and Windows 7 SP1 with KB 2670838 installed
+            g_WIC2 = true;
+            return TRUE;
+        }
+        else
+        {
+            g_WIC2 = false;
+
+            hr = CoCreateInstance(
+                CLSID_WICImagingFactory1,
+                nullptr,
+                CLSCTX_INPROC_SERVER,
+                __uuidof(IWICImagingFactory),
+                ifactory
+            );
+            return SUCCEEDED(hr) ? TRUE : FALSE;
+        }
+    #else
+        g_WIC2 = false;
+
+        return SUCCEEDED(CoCreateInstance(
+            CLSID_WICImagingFactory,
+            nullptr,
+            CLSCTX_INPROC_SERVER,
+            __uuidof(IWICImagingFactory),
+            ifactory)) ? TRUE : FALSE;
+    #endif
+    }
+
+#else // !WIN32
+    inline void * _aligned_malloc(size_t size, size_t alignment)
+    {
+        size = (size + alignment - 1) & ~(alignment - 1);
+        return std::aligned_alloc(alignment, size);
+    }
+
+#define _aligned_free free
+#endif
+}
+
+
+#ifdef _WIN32
+//=====================================================================================
+// WIC Utilities
+//=====================================================================================
+
+_Use_decl_annotations_
+DXGI_FORMAT DirectX::Internal::WICToDXGI(const GUID& guid) noexcept
+{
+    for (size_t i = 0; i < std::size(g_WICFormats); ++i)
+    {
+        if (memcmp(&g_WICFormats[i].wic, &guid, sizeof(GUID)) == 0)
+            return g_WICFormats[i].format;
+    }
+
+#if (_WIN32_WINNT >= _WIN32_WINNT_WIN8) || defined(_WIN7_PLATFORM_UPDATE)
+    if (g_WIC2)
+    {
+        if (memcmp(&GUID_WICPixelFormat96bppRGBFloat, &guid, sizeof(GUID)) == 0)
+            return DXGI_FORMAT_R32G32B32_FLOAT;
+    }
+#endif
+
+    return DXGI_FORMAT_UNKNOWN;
+}
+
+_Use_decl_annotations_
+bool DirectX::Internal::DXGIToWIC(DXGI_FORMAT format, GUID& guid, bool ignoreRGBvsBGR) noexcept
+{
+    switch (format)
+    {
+    case DXGI_FORMAT_R8G8B8A8_UNORM:
+    case DXGI_FORMAT_R8G8B8A8_UNORM_SRGB:
+        if (ignoreRGBvsBGR)
+        {
+            // If we are not doing conversion so don't really care about BGR vs RGB color-order,
+            // we can use the canonical WIC 32bppBGRA format which avoids an extra format conversion when using the WIC scaler
+            memcpy(&guid, &GUID_WICPixelFormat32bppBGRA, sizeof(GUID));
+        }
+        else
+        {
+            memcpy(&guid, &GUID_WICPixelFormat32bppRGBA, sizeof(GUID));
+        }
+        return true;
+
+    case DXGI_FORMAT_D32_FLOAT:
+        memcpy(&guid, &GUID_WICPixelFormat32bppGrayFloat, sizeof(GUID));
+        return true;
+
+    case DXGI_FORMAT_D16_UNORM:
+        memcpy(&guid, &GUID_WICPixelFormat16bppGray, sizeof(GUID));
+        return true;
+
+    case DXGI_FORMAT_B8G8R8A8_UNORM_SRGB:
+        memcpy(&guid, &GUID_WICPixelFormat32bppBGRA, sizeof(GUID));
+        return true;
+
+    case DXGI_FORMAT_B8G8R8X8_UNORM_SRGB:
+        memcpy(&guid, &GUID_WICPixelFormat32bppBGR, sizeof(GUID));
+        return true;
+
+    #if (_WIN32_WINNT >= _WIN32_WINNT_WIN8) || defined(_WIN7_PLATFORM_UPDATE)
+    case DXGI_FORMAT_R32G32B32_FLOAT:
+        if (g_WIC2)
+        {
+            memcpy(&guid, &GUID_WICPixelFormat96bppRGBFloat, sizeof(GUID));
+            return true;
+        }
+        break;
+    #endif
+
+    default:
+        for (size_t i = 0; i < std::size(g_WICFormats); ++i)
+        {
+            if (g_WICFormats[i].format == format)
+            {
+                memcpy(&guid, &g_WICFormats[i].wic, sizeof(GUID));
+                return true;
+            }
+        }
+        break;
+    }
+
+    memset(&guid, 0, sizeof(GUID));
+    return false;
+}
+
+TEX_FILTER_FLAGS DirectX::Internal::CheckWICColorSpace(_In_ const GUID& sourceGUID, _In_ const GUID& targetGUID) noexcept
+{
+    TEX_FILTER_FLAGS srgb = TEX_FILTER_DEFAULT;
+
+    for (size_t i = 0; i < std::size(g_WICFormats); ++i)
+    {
+        if (memcmp(&g_WICFormats[i].wic, &sourceGUID, sizeof(GUID)) == 0)
+        {
+            if (g_WICFormats[i].srgb)
+                srgb |= TEX_FILTER_SRGB_IN;
+        }
+
+        if (memcmp(&g_WICFormats[i].wic, &targetGUID, sizeof(GUID)) == 0)
+        {
+            if (g_WICFormats[i].srgb)
+                srgb |= TEX_FILTER_SRGB_OUT;
+        }
+    }
+
+    if ((srgb & (TEX_FILTER_SRGB_IN | TEX_FILTER_SRGB_OUT)) == (TEX_FILTER_SRGB_IN | TEX_FILTER_SRGB_OUT))
+    {
+        srgb &= ~(TEX_FILTER_SRGB_IN | TEX_FILTER_SRGB_OUT);
+    }
+
+    return srgb;
+}
+
+
+//-------------------------------------------------------------------------------------
+// Public helper function to get common WIC codec GUIDs
+//-------------------------------------------------------------------------------------
+_Use_decl_annotations_
+REFGUID DirectX::GetWICCodec(WICCodecs codec) noexcept
+{
+    switch (codec)
+    {
+    case WIC_CODEC_BMP:
+        return GUID_ContainerFormatBmp;
+
+    case WIC_CODEC_JPEG:
+        return GUID_ContainerFormatJpeg;
+
+    case WIC_CODEC_PNG:
+        return GUID_ContainerFormatPng;
+
+    case WIC_CODEC_TIFF:
+        return GUID_ContainerFormatTiff;
+
+    case WIC_CODEC_GIF:
+        return GUID_ContainerFormatGif;
+
+    case WIC_CODEC_WMP:
+        return GUID_ContainerFormatWmp;
+
+    case WIC_CODEC_ICO:
+        return GUID_ContainerFormatIco;
+
+#ifdef NTDDI_WIN10_RS4
+    case WIC_CODEC_HEIF:
+        // This requires installing https://aka.ms/heif
+        return GUID_ContainerFormatHeif;
+#endif
+
+    default:
+        return GUID_NULL;
+    }
+}
+
+
+//-------------------------------------------------------------------------------------
+// Singleton function for WIC factory
+//-------------------------------------------------------------------------------------
+IWICImagingFactory* DirectX::GetWICFactory(bool& iswic2) noexcept
+{
+    if (g_Factory)
+    {
+        iswic2 = g_WIC2;
+        return g_Factory;
+    }
+
+    static INIT_ONCE s_initOnce = INIT_ONCE_STATIC_INIT;
+
+    if (!InitOnceExecuteOnce(&s_initOnce,
+        InitializeWICFactory,
+        nullptr,
+        reinterpret_cast<LPVOID*>(&g_Factory)))
+    {
+        return nullptr;
+    }
+
+    iswic2 = g_WIC2;
+    return g_Factory;
+}
+
+
+//-------------------------------------------------------------------------------------
+// Optional initializer for WIC factory
+//-------------------------------------------------------------------------------------
+void DirectX::SetWICFactory(_In_opt_ IWICImagingFactory* pWIC) noexcept
+{
+    if (pWIC == g_Factory)
+        return;
+
+    bool iswic2 = false;
+    if (pWIC)
+    {
+    #if(_WIN32_WINNT >= _WIN32_WINNT_WIN8) || defined(_WIN7_PLATFORM_UPDATE)
+        ComPtr<IWICImagingFactory2> wic2;
+        HRESULT hr = pWIC->QueryInterface(IID_PPV_ARGS(wic2.GetAddressOf()));
+        if (SUCCEEDED(hr))
+        {
+            iswic2 = true;
+        }
+    #endif
+        pWIC->AddRef();
+    }
+
+    g_WIC2 = iswic2;
+    std::swap(pWIC, g_Factory);
+    if (pWIC)
+        pWIC->Release();
+}
+#endif // WIN32
+
+
+//=====================================================================================
+// DXGI Format Utilities
+//=====================================================================================
+
+//-------------------------------------------------------------------------------------
+_Use_decl_annotations_
+bool DirectX::IsPacked(DXGI_FORMAT fmt) noexcept
+{
+    switch (static_cast<int>(fmt))
+    {
+    case DXGI_FORMAT_R8G8_B8G8_UNORM:
+    case DXGI_FORMAT_G8R8_G8B8_UNORM:
+    case DXGI_FORMAT_YUY2: // 4:2:2 8-bit
+    case DXGI_FORMAT_Y210: // 4:2:2 10-bit
+    case DXGI_FORMAT_Y216: // 4:2:2 16-bit
+        return true;
+
+    default:
+        return false;
+    }
+}
+
+
+//-------------------------------------------------------------------------------------
+_Use_decl_annotations_
+bool DirectX::IsVideo(DXGI_FORMAT fmt) noexcept
+{
+    switch (static_cast<int>(fmt))
+    {
+    case DXGI_FORMAT_AYUV:
+    case DXGI_FORMAT_Y410:
+    case DXGI_FORMAT_Y416:
+    case DXGI_FORMAT_NV12:
+    case DXGI_FORMAT_P010:
+    case DXGI_FORMAT_P016:
+    case DXGI_FORMAT_YUY2:
+    case DXGI_FORMAT_Y210:
+    case DXGI_FORMAT_Y216:
+    case DXGI_FORMAT_NV11:
+        // These video formats can be used with the 3D pipeline through special view mappings
+
+    case DXGI_FORMAT_420_OPAQUE:
+    case DXGI_FORMAT_AI44:
+    case DXGI_FORMAT_IA44:
+    case DXGI_FORMAT_P8:
+    case DXGI_FORMAT_A8P8:
+        // These are limited use video formats not usable in any way by the 3D pipeline
+
+    case WIN10_DXGI_FORMAT_P208:
+    case WIN10_DXGI_FORMAT_V208:
+    case WIN10_DXGI_FORMAT_V408:
+        // These video formats are for JPEG Hardware decode (DXGI 1.4)
+        return true;
+
+    default:
+        return false;
+    }
+}
+
+
+//-------------------------------------------------------------------------------------
+_Use_decl_annotations_
+bool DirectX::IsPlanar(DXGI_FORMAT fmt) noexcept
+{
+    switch (static_cast<int>(fmt))
+    {
+    case DXGI_FORMAT_NV12:      // 4:2:0 8-bit
+    case DXGI_FORMAT_P010:      // 4:2:0 10-bit
+    case DXGI_FORMAT_P016:      // 4:2:0 16-bit
+    case DXGI_FORMAT_420_OPAQUE:// 4:2:0 8-bit
+    case DXGI_FORMAT_NV11:      // 4:1:1 8-bit
+
+    case WIN10_DXGI_FORMAT_P208: // 4:2:2 8-bit
+    case WIN10_DXGI_FORMAT_V208: // 4:4:0 8-bit
+    case WIN10_DXGI_FORMAT_V408: // 4:4:4 8-bit
+        // These are JPEG Hardware decode formats (DXGI 1.4)
+
+    case XBOX_DXGI_FORMAT_D16_UNORM_S8_UINT:
+    case XBOX_DXGI_FORMAT_R16_UNORM_X8_TYPELESS:
+    case XBOX_DXGI_FORMAT_X16_TYPELESS_G8_UINT:
+        // These are Xbox One platform specific types
+        return true;
+
+    default:
+        return false;
+    }
+}
+
+
+//-------------------------------------------------------------------------------------
+_Use_decl_annotations_
+bool DirectX::IsDepthStencil(DXGI_FORMAT fmt) noexcept
+{
+    switch (static_cast<int>(fmt))
+    {
+    case DXGI_FORMAT_R32G8X24_TYPELESS:
+    case DXGI_FORMAT_D32_FLOAT_S8X24_UINT:
+    case DXGI_FORMAT_R32_FLOAT_X8X24_TYPELESS:
+    case DXGI_FORMAT_X32_TYPELESS_G8X24_UINT:
+    case DXGI_FORMAT_D32_FLOAT:
+    case DXGI_FORMAT_R24G8_TYPELESS:
+    case DXGI_FORMAT_D24_UNORM_S8_UINT:
+    case DXGI_FORMAT_R24_UNORM_X8_TYPELESS:
+    case DXGI_FORMAT_X24_TYPELESS_G8_UINT:
+    case DXGI_FORMAT_D16_UNORM:
+    case XBOX_DXGI_FORMAT_D16_UNORM_S8_UINT:
+    case XBOX_DXGI_FORMAT_R16_UNORM_X8_TYPELESS:
+    case XBOX_DXGI_FORMAT_X16_TYPELESS_G8_UINT:
+        return true;
+
+    default:
+        return false;
+    }
+}
+
+
+//-------------------------------------------------------------------------------------
+_Use_decl_annotations_
+bool DirectX::IsBGR(DXGI_FORMAT fmt) noexcept
+{
+    switch (static_cast<int>(fmt))
+    {
+    case DXGI_FORMAT_B5G6R5_UNORM:
+    case DXGI_FORMAT_B5G5R5A1_UNORM:
+    case DXGI_FORMAT_B8G8R8A8_UNORM:
+    case DXGI_FORMAT_B8G8R8X8_UNORM:
+    case DXGI_FORMAT_B8G8R8A8_TYPELESS:
+    case DXGI_FORMAT_B8G8R8A8_UNORM_SRGB:
+    case DXGI_FORMAT_B8G8R8X8_TYPELESS:
+    case DXGI_FORMAT_B8G8R8X8_UNORM_SRGB:
+    case DXGI_FORMAT_B4G4R4A4_UNORM:
+    case WIN11_DXGI_FORMAT_A4B4G4R4_UNORM:
+        return true;
+
+    default:
+        return false;
+    }
+}
+
+
+//-------------------------------------------------------------------------------------
+_Use_decl_annotations_
+bool DirectX::IsTypeless(DXGI_FORMAT fmt, bool partialTypeless) noexcept
+{
+    switch (static_cast<int>(fmt))
+    {
+    case DXGI_FORMAT_R32G32B32A32_TYPELESS:
+    case DXGI_FORMAT_R32G32B32_TYPELESS:
+    case DXGI_FORMAT_R16G16B16A16_TYPELESS:
+    case DXGI_FORMAT_R32G32_TYPELESS:
+    case DXGI_FORMAT_R32G8X24_TYPELESS:
+    case DXGI_FORMAT_R10G10B10A2_TYPELESS:
+    case DXGI_FORMAT_R8G8B8A8_TYPELESS:
+    case DXGI_FORMAT_R16G16_TYPELESS:
+    case DXGI_FORMAT_R32_TYPELESS:
+    case DXGI_FORMAT_R24G8_TYPELESS:
+    case DXGI_FORMAT_R8G8_TYPELESS:
+    case DXGI_FORMAT_R16_TYPELESS:
+    case DXGI_FORMAT_R8_TYPELESS:
+    case DXGI_FORMAT_BC1_TYPELESS:
+    case DXGI_FORMAT_BC2_TYPELESS:
+    case DXGI_FORMAT_BC3_TYPELESS:
+    case DXGI_FORMAT_BC4_TYPELESS:
+    case DXGI_FORMAT_BC5_TYPELESS:
+    case DXGI_FORMAT_B8G8R8A8_TYPELESS:
+    case DXGI_FORMAT_B8G8R8X8_TYPELESS:
+    case DXGI_FORMAT_BC6H_TYPELESS:
+    case DXGI_FORMAT_BC7_TYPELESS:
+        return true;
+
+    case DXGI_FORMAT_R32_FLOAT_X8X24_TYPELESS:
+    case DXGI_FORMAT_X32_TYPELESS_G8X24_UINT:
+    case DXGI_FORMAT_R24_UNORM_X8_TYPELESS:
+    case DXGI_FORMAT_X24_TYPELESS_G8_UINT:
+    case XBOX_DXGI_FORMAT_R16_UNORM_X8_TYPELESS:
+    case XBOX_DXGI_FORMAT_X16_TYPELESS_G8_UINT:
+        return partialTypeless;
+
+    default:
+        return false;
+    }
+}
+
+
+//-------------------------------------------------------------------------------------
+_Use_decl_annotations_
+bool DirectX::HasAlpha(DXGI_FORMAT fmt) noexcept
+{
+    switch (static_cast<int>(fmt))
+    {
+    case DXGI_FORMAT_R32G32B32A32_TYPELESS:
+    case DXGI_FORMAT_R32G32B32A32_FLOAT:
+    case DXGI_FORMAT_R32G32B32A32_UINT:
+    case DXGI_FORMAT_R32G32B32A32_SINT:
+    case DXGI_FORMAT_R16G16B16A16_TYPELESS:
+    case DXGI_FORMAT_R16G16B16A16_FLOAT:
+    case DXGI_FORMAT_R16G16B16A16_UNORM:
+    case DXGI_FORMAT_R16G16B16A16_UINT:
+    case DXGI_FORMAT_R16G16B16A16_SNORM:
+    case DXGI_FORMAT_R16G16B16A16_SINT:
+    case DXGI_FORMAT_R10G10B10A2_TYPELESS:
+    case DXGI_FORMAT_R10G10B10A2_UNORM:
+    case DXGI_FORMAT_R10G10B10A2_UINT:
+    case DXGI_FORMAT_R8G8B8A8_TYPELESS:
+    case DXGI_FORMAT_R8G8B8A8_UNORM:
+    case DXGI_FORMAT_R8G8B8A8_UNORM_SRGB:
+    case DXGI_FORMAT_R8G8B8A8_UINT:
+    case DXGI_FORMAT_R8G8B8A8_SNORM:
+    case DXGI_FORMAT_R8G8B8A8_SINT:
+    case DXGI_FORMAT_A8_UNORM:
+    case DXGI_FORMAT_BC1_TYPELESS:
+    case DXGI_FORMAT_BC1_UNORM:
+    case DXGI_FORMAT_BC1_UNORM_SRGB:
+    case DXGI_FORMAT_BC2_TYPELESS:
+    case DXGI_FORMAT_BC2_UNORM:
+    case DXGI_FORMAT_BC2_UNORM_SRGB:
+    case DXGI_FORMAT_BC3_TYPELESS:
+    case DXGI_FORMAT_BC3_UNORM:
+    case DXGI_FORMAT_BC3_UNORM_SRGB:
+    case DXGI_FORMAT_B5G5R5A1_UNORM:
+    case DXGI_FORMAT_B8G8R8A8_UNORM:
+    case DXGI_FORMAT_R10G10B10_XR_BIAS_A2_UNORM:
+    case DXGI_FORMAT_B8G8R8A8_TYPELESS:
+    case DXGI_FORMAT_B8G8R8A8_UNORM_SRGB:
+    case DXGI_FORMAT_BC7_TYPELESS:
+    case DXGI_FORMAT_BC7_UNORM:
+    case DXGI_FORMAT_BC7_UNORM_SRGB:
+    case DXGI_FORMAT_AYUV:
+    case DXGI_FORMAT_Y410:
+    case DXGI_FORMAT_Y416:
+    case DXGI_FORMAT_AI44:
+    case DXGI_FORMAT_IA44:
+    case DXGI_FORMAT_A8P8:
+    case DXGI_FORMAT_B4G4R4A4_UNORM:
+    case XBOX_DXGI_FORMAT_R10G10B10_7E3_A2_FLOAT:
+    case XBOX_DXGI_FORMAT_R10G10B10_6E4_A2_FLOAT:
+    case XBOX_DXGI_FORMAT_R10G10B10_SNORM_A2_UNORM:
+    case WIN11_DXGI_FORMAT_A4B4G4R4_UNORM:
+        return true;
+
+    default:
+        return false;
+    }
+}
+
+
+//-------------------------------------------------------------------------------------
+// Returns bits-per-pixel for a given DXGI format, or 0 on failure
+//-------------------------------------------------------------------------------------
+_Use_decl_annotations_
+size_t DirectX::BitsPerPixel(DXGI_FORMAT fmt) noexcept
+{
+    switch (static_cast<int>(fmt))
+    {
+    case DXGI_FORMAT_R32G32B32A32_TYPELESS:
+    case DXGI_FORMAT_R32G32B32A32_FLOAT:
+    case DXGI_FORMAT_R32G32B32A32_UINT:
+    case DXGI_FORMAT_R32G32B32A32_SINT:
+        return 128;
+
+    case DXGI_FORMAT_R32G32B32_TYPELESS:
+    case DXGI_FORMAT_R32G32B32_FLOAT:
+    case DXGI_FORMAT_R32G32B32_UINT:
+    case DXGI_FORMAT_R32G32B32_SINT:
+        return 96;
+
+    case DXGI_FORMAT_R16G16B16A16_TYPELESS:
+    case DXGI_FORMAT_R16G16B16A16_FLOAT:
+    case DXGI_FORMAT_R16G16B16A16_UNORM:
+    case DXGI_FORMAT_R16G16B16A16_UINT:
+    case DXGI_FORMAT_R16G16B16A16_SNORM:
+    case DXGI_FORMAT_R16G16B16A16_SINT:
+    case DXGI_FORMAT_R32G32_TYPELESS:
+    case DXGI_FORMAT_R32G32_FLOAT:
+    case DXGI_FORMAT_R32G32_UINT:
+    case DXGI_FORMAT_R32G32_SINT:
+    case DXGI_FORMAT_R32G8X24_TYPELESS:
+    case DXGI_FORMAT_D32_FLOAT_S8X24_UINT:
+    case DXGI_FORMAT_R32_FLOAT_X8X24_TYPELESS:
+    case DXGI_FORMAT_X32_TYPELESS_G8X24_UINT:
+    case DXGI_FORMAT_Y416:
+    case DXGI_FORMAT_Y210:
+    case DXGI_FORMAT_Y216:
+        return 64;
+
+    case DXGI_FORMAT_R10G10B10A2_TYPELESS:
+    case DXGI_FORMAT_R10G10B10A2_UNORM:
+    case DXGI_FORMAT_R10G10B10A2_UINT:
+    case DXGI_FORMAT_R11G11B10_FLOAT:
+    case DXGI_FORMAT_R8G8B8A8_TYPELESS:
+    case DXGI_FORMAT_R8G8B8A8_UNORM:
+    case DXGI_FORMAT_R8G8B8A8_UNORM_SRGB:
+    case DXGI_FORMAT_R8G8B8A8_UINT:
+    case DXGI_FORMAT_R8G8B8A8_SNORM:
+    case DXGI_FORMAT_R8G8B8A8_SINT:
+    case DXGI_FORMAT_R16G16_TYPELESS:
+    case DXGI_FORMAT_R16G16_FLOAT:
+    case DXGI_FORMAT_R16G16_UNORM:
+    case DXGI_FORMAT_R16G16_UINT:
+    case DXGI_FORMAT_R16G16_SNORM:
+    case DXGI_FORMAT_R16G16_SINT:
+    case DXGI_FORMAT_R32_TYPELESS:
+    case DXGI_FORMAT_D32_FLOAT:
+    case DXGI_FORMAT_R32_FLOAT:
+    case DXGI_FORMAT_R32_UINT:
+    case DXGI_FORMAT_R32_SINT:
+    case DXGI_FORMAT_R24G8_TYPELESS:
+    case DXGI_FORMAT_D24_UNORM_S8_UINT:
+    case DXGI_FORMAT_R24_UNORM_X8_TYPELESS:
+    case DXGI_FORMAT_X24_TYPELESS_G8_UINT:
+    case DXGI_FORMAT_R9G9B9E5_SHAREDEXP:
+    case DXGI_FORMAT_R8G8_B8G8_UNORM:
+    case DXGI_FORMAT_G8R8_G8B8_UNORM:
+    case DXGI_FORMAT_B8G8R8A8_UNORM:
+    case DXGI_FORMAT_B8G8R8X8_UNORM:
+    case DXGI_FORMAT_R10G10B10_XR_BIAS_A2_UNORM:
+    case DXGI_FORMAT_B8G8R8A8_TYPELESS:
+    case DXGI_FORMAT_B8G8R8A8_UNORM_SRGB:
+    case DXGI_FORMAT_B8G8R8X8_TYPELESS:
+    case DXGI_FORMAT_B8G8R8X8_UNORM_SRGB:
+    case DXGI_FORMAT_AYUV:
+    case DXGI_FORMAT_Y410:
+    case DXGI_FORMAT_YUY2:
+    case XBOX_DXGI_FORMAT_R10G10B10_7E3_A2_FLOAT:
+    case XBOX_DXGI_FORMAT_R10G10B10_6E4_A2_FLOAT:
+    case XBOX_DXGI_FORMAT_R10G10B10_SNORM_A2_UNORM:
+        return 32;
+
+    case DXGI_FORMAT_P010:
+    case DXGI_FORMAT_P016:
+    case XBOX_DXGI_FORMAT_D16_UNORM_S8_UINT:
+    case XBOX_DXGI_FORMAT_R16_UNORM_X8_TYPELESS:
+    case XBOX_DXGI_FORMAT_X16_TYPELESS_G8_UINT:
+    case WIN10_DXGI_FORMAT_V408:
+        return 24;
+
+    case DXGI_FORMAT_R8G8_TYPELESS:
+    case DXGI_FORMAT_R8G8_UNORM:
+    case DXGI_FORMAT_R8G8_UINT:
+    case DXGI_FORMAT_R8G8_SNORM:
+    case DXGI_FORMAT_R8G8_SINT:
+    case DXGI_FORMAT_R16_TYPELESS:
+    case DXGI_FORMAT_R16_FLOAT:
+    case DXGI_FORMAT_D16_UNORM:
+    case DXGI_FORMAT_R16_UNORM:
+    case DXGI_FORMAT_R16_UINT:
+    case DXGI_FORMAT_R16_SNORM:
+    case DXGI_FORMAT_R16_SINT:
+    case DXGI_FORMAT_B5G6R5_UNORM:
+    case DXGI_FORMAT_B5G5R5A1_UNORM:
+    case DXGI_FORMAT_A8P8:
+    case DXGI_FORMAT_B4G4R4A4_UNORM:
+    case WIN10_DXGI_FORMAT_P208:
+    case WIN10_DXGI_FORMAT_V208:
+    case WIN11_DXGI_FORMAT_A4B4G4R4_UNORM:
+        return 16;
+
+    case DXGI_FORMAT_NV12:
+    case DXGI_FORMAT_420_OPAQUE:
+    case DXGI_FORMAT_NV11:
+        return 12;
+
+    case DXGI_FORMAT_R8_TYPELESS:
+    case DXGI_FORMAT_R8_UNORM:
+    case DXGI_FORMAT_R8_UINT:
+    case DXGI_FORMAT_R8_SNORM:
+    case DXGI_FORMAT_R8_SINT:
+    case DXGI_FORMAT_A8_UNORM:
+    case DXGI_FORMAT_BC2_TYPELESS:
+    case DXGI_FORMAT_BC2_UNORM:
+    case DXGI_FORMAT_BC2_UNORM_SRGB:
+    case DXGI_FORMAT_BC3_TYPELESS:
+    case DXGI_FORMAT_BC3_UNORM:
+    case DXGI_FORMAT_BC3_UNORM_SRGB:
+    case DXGI_FORMAT_BC5_TYPELESS:
+    case DXGI_FORMAT_BC5_UNORM:
+    case DXGI_FORMAT_BC5_SNORM:
+    case DXGI_FORMAT_BC6H_TYPELESS:
+    case DXGI_FORMAT_BC6H_UF16:
+    case DXGI_FORMAT_BC6H_SF16:
+    case DXGI_FORMAT_BC7_TYPELESS:
+    case DXGI_FORMAT_BC7_UNORM:
+    case DXGI_FORMAT_BC7_UNORM_SRGB:
+    case DXGI_FORMAT_AI44:
+    case DXGI_FORMAT_IA44:
+    case DXGI_FORMAT_P8:
+    case XBOX_DXGI_FORMAT_R4G4_UNORM:
+        return 8;
+
+    case DXGI_FORMAT_R1_UNORM:
+        return 1;
+
+    case DXGI_FORMAT_BC1_TYPELESS:
+    case DXGI_FORMAT_BC1_UNORM:
+    case DXGI_FORMAT_BC1_UNORM_SRGB:
+    case DXGI_FORMAT_BC4_TYPELESS:
+    case DXGI_FORMAT_BC4_UNORM:
+    case DXGI_FORMAT_BC4_SNORM:
+        return 4;
+
+    default:
+        return 0;
+    }
+}
+
+
+//-------------------------------------------------------------------------------------
+// Returns bits-per-color-channel for a given DXGI format, or 0 on failure
+// For mixed formats, it returns the largest color-depth in the format
+//-------------------------------------------------------------------------------------
+_Use_decl_annotations_
+size_t DirectX::BitsPerColor(DXGI_FORMAT fmt) noexcept
+{
+    switch (static_cast<int>(fmt))
+    {
+    case DXGI_FORMAT_R32G32B32A32_TYPELESS:
+    case DXGI_FORMAT_R32G32B32A32_FLOAT:
+    case DXGI_FORMAT_R32G32B32A32_UINT:
+    case DXGI_FORMAT_R32G32B32A32_SINT:
+    case DXGI_FORMAT_R32G32B32_TYPELESS:
+    case DXGI_FORMAT_R32G32B32_FLOAT:
+    case DXGI_FORMAT_R32G32B32_UINT:
+    case DXGI_FORMAT_R32G32B32_SINT:
+    case DXGI_FORMAT_R32G32_TYPELESS:
+    case DXGI_FORMAT_R32G32_FLOAT:
+    case DXGI_FORMAT_R32G32_UINT:
+    case DXGI_FORMAT_R32G32_SINT:
+    case DXGI_FORMAT_R32G8X24_TYPELESS:
+    case DXGI_FORMAT_D32_FLOAT_S8X24_UINT:
+    case DXGI_FORMAT_R32_FLOAT_X8X24_TYPELESS:
+    case DXGI_FORMAT_X32_TYPELESS_G8X24_UINT:
+    case DXGI_FORMAT_R32_TYPELESS:
+    case DXGI_FORMAT_D32_FLOAT:
+    case DXGI_FORMAT_R32_FLOAT:
+    case DXGI_FORMAT_R32_UINT:
+    case DXGI_FORMAT_R32_SINT:
+        return 32;
+
+    case DXGI_FORMAT_R24G8_TYPELESS:
+    case DXGI_FORMAT_D24_UNORM_S8_UINT:
+    case DXGI_FORMAT_R24_UNORM_X8_TYPELESS:
+    case DXGI_FORMAT_X24_TYPELESS_G8_UINT:
+        return 24;
+
+    case DXGI_FORMAT_R16G16B16A16_TYPELESS:
+    case DXGI_FORMAT_R16G16B16A16_FLOAT:
+    case DXGI_FORMAT_R16G16B16A16_UNORM:
+    case DXGI_FORMAT_R16G16B16A16_UINT:
+    case DXGI_FORMAT_R16G16B16A16_SNORM:
+    case DXGI_FORMAT_R16G16B16A16_SINT:
+    case DXGI_FORMAT_R16G16_TYPELESS:
+    case DXGI_FORMAT_R16G16_FLOAT:
+    case DXGI_FORMAT_R16G16_UNORM:
+    case DXGI_FORMAT_R16G16_UINT:
+    case DXGI_FORMAT_R16G16_SNORM:
+    case DXGI_FORMAT_R16G16_SINT:
+    case DXGI_FORMAT_R16_TYPELESS:
+    case DXGI_FORMAT_R16_FLOAT:
+    case DXGI_FORMAT_D16_UNORM:
+    case DXGI_FORMAT_R16_UNORM:
+    case DXGI_FORMAT_R16_UINT:
+    case DXGI_FORMAT_R16_SNORM:
+    case DXGI_FORMAT_R16_SINT:
+    case DXGI_FORMAT_BC6H_TYPELESS:
+    case DXGI_FORMAT_BC6H_UF16:
+    case DXGI_FORMAT_BC6H_SF16:
+    case DXGI_FORMAT_Y416:
+    case DXGI_FORMAT_P016:
+    case DXGI_FORMAT_Y216:
+    case XBOX_DXGI_FORMAT_D16_UNORM_S8_UINT:
+    case XBOX_DXGI_FORMAT_R16_UNORM_X8_TYPELESS:
+    case XBOX_DXGI_FORMAT_X16_TYPELESS_G8_UINT:
+        return 16;
+
+    case DXGI_FORMAT_R9G9B9E5_SHAREDEXP:
+        return 14;
+
+    case DXGI_FORMAT_R11G11B10_FLOAT:
+        return 11;
+
+    case DXGI_FORMAT_R10G10B10A2_TYPELESS:
+    case DXGI_FORMAT_R10G10B10A2_UNORM:
+    case DXGI_FORMAT_R10G10B10A2_UINT:
+    case DXGI_FORMAT_R10G10B10_XR_BIAS_A2_UNORM:
+    case DXGI_FORMAT_Y410:
+    case DXGI_FORMAT_P010:
+    case DXGI_FORMAT_Y210:
+    case XBOX_DXGI_FORMAT_R10G10B10_7E3_A2_FLOAT:
+    case XBOX_DXGI_FORMAT_R10G10B10_6E4_A2_FLOAT:
+    case XBOX_DXGI_FORMAT_R10G10B10_SNORM_A2_UNORM:
+        return 10;
+
+    case DXGI_FORMAT_R8G8B8A8_TYPELESS:
+    case DXGI_FORMAT_R8G8B8A8_UNORM:
+    case DXGI_FORMAT_R8G8B8A8_UNORM_SRGB:
+    case DXGI_FORMAT_R8G8B8A8_UINT:
+    case DXGI_FORMAT_R8G8B8A8_SNORM:
+    case DXGI_FORMAT_R8G8B8A8_SINT:
+    case DXGI_FORMAT_R8G8_TYPELESS:
+    case DXGI_FORMAT_R8G8_UNORM:
+    case DXGI_FORMAT_R8G8_UINT:
+    case DXGI_FORMAT_R8G8_SNORM:
+    case DXGI_FORMAT_R8G8_SINT:
+    case DXGI_FORMAT_R8_TYPELESS:
+    case DXGI_FORMAT_R8_UNORM:
+    case DXGI_FORMAT_R8_UINT:
+    case DXGI_FORMAT_R8_SNORM:
+    case DXGI_FORMAT_R8_SINT:
+    case DXGI_FORMAT_A8_UNORM:
+    case DXGI_FORMAT_R8G8_B8G8_UNORM:
+    case DXGI_FORMAT_G8R8_G8B8_UNORM:
+    case DXGI_FORMAT_BC4_TYPELESS:
+    case DXGI_FORMAT_BC4_UNORM:
+    case DXGI_FORMAT_BC4_SNORM:
+    case DXGI_FORMAT_BC5_TYPELESS:
+    case DXGI_FORMAT_BC5_UNORM:
+    case DXGI_FORMAT_BC5_SNORM:
+    case DXGI_FORMAT_B8G8R8A8_UNORM:
+    case DXGI_FORMAT_B8G8R8X8_UNORM:
+    case DXGI_FORMAT_B8G8R8A8_TYPELESS:
+    case DXGI_FORMAT_B8G8R8A8_UNORM_SRGB:
+    case DXGI_FORMAT_B8G8R8X8_TYPELESS:
+    case DXGI_FORMAT_B8G8R8X8_UNORM_SRGB:
+    case DXGI_FORMAT_AYUV:
+    case DXGI_FORMAT_NV12:
+    case DXGI_FORMAT_420_OPAQUE:
+    case DXGI_FORMAT_YUY2:
+    case DXGI_FORMAT_NV11:
+    case WIN10_DXGI_FORMAT_P208:
+    case WIN10_DXGI_FORMAT_V208:
+    case WIN10_DXGI_FORMAT_V408:
+        return 8;
+
+    case DXGI_FORMAT_BC7_TYPELESS:
+    case DXGI_FORMAT_BC7_UNORM:
+    case DXGI_FORMAT_BC7_UNORM_SRGB:
+        return 7;
+
+    case DXGI_FORMAT_BC1_TYPELESS:
+    case DXGI_FORMAT_BC1_UNORM:
+    case DXGI_FORMAT_BC1_UNORM_SRGB:
+    case DXGI_FORMAT_BC2_TYPELESS:
+    case DXGI_FORMAT_BC2_UNORM:
+    case DXGI_FORMAT_BC2_UNORM_SRGB:
+    case DXGI_FORMAT_BC3_TYPELESS:
+    case DXGI_FORMAT_BC3_UNORM:
+    case DXGI_FORMAT_BC3_UNORM_SRGB:
+    case DXGI_FORMAT_B5G6R5_UNORM:
+        return 6;
+
+    case DXGI_FORMAT_B5G5R5A1_UNORM:
+        return 5;
+
+    case DXGI_FORMAT_B4G4R4A4_UNORM:
+    case XBOX_DXGI_FORMAT_R4G4_UNORM:
+    case WIN11_DXGI_FORMAT_A4B4G4R4_UNORM:
+        return 4;
+
+    case DXGI_FORMAT_R1_UNORM:
+        return 1;
+
+    case DXGI_FORMAT_AI44:
+    case DXGI_FORMAT_IA44:
+    case DXGI_FORMAT_P8:
+    case DXGI_FORMAT_A8P8:
+        // Palettized formats return 0 for this function
+
+    default:
+        return 0;
+    }
+}
+
+
+//-------------------------------------------------------------------------------------
+// Computes the image row pitch in bytes, and the slice ptich (size in bytes of the image)
+// based on DXGI format, width, and height
+//-------------------------------------------------------------------------------------
+_Use_decl_annotations_
+HRESULT DirectX::ComputePitch(DXGI_FORMAT fmt, size_t width, size_t height,
+    size_t& rowPitch, size_t& slicePitch, CP_FLAGS flags) noexcept
+{
+    uint64_t pitch = 0;
+    uint64_t slice = 0;
+
+    switch (static_cast<int>(fmt))
+    {
+    case DXGI_FORMAT_BC1_TYPELESS:
+    case DXGI_FORMAT_BC1_UNORM:
+    case DXGI_FORMAT_BC1_UNORM_SRGB:
+    case DXGI_FORMAT_BC4_TYPELESS:
+    case DXGI_FORMAT_BC4_UNORM:
+    case DXGI_FORMAT_BC4_SNORM:
+        assert(IsCompressed(fmt));
+        {
+            if (flags & CP_FLAGS_BAD_DXTN_TAILS)
+            {
+                const size_t nbw = width >> 2;
+                const size_t nbh = height >> 2;
+                pitch = std::max<uint64_t>(1u, uint64_t(nbw) * 8u);
+                slice = std::max<uint64_t>(1u, pitch * uint64_t(nbh));
+            }
+            else
+            {
+                const uint64_t nbw = std::max<uint64_t>(1u, (uint64_t(width) + 3u) / 4u);
+                const uint64_t nbh = std::max<uint64_t>(1u, (uint64_t(height) + 3u) / 4u);
+                pitch = nbw * 8u;
+                slice = pitch * nbh;
+            }
+        }
+        break;
+
+    case DXGI_FORMAT_BC2_TYPELESS:
+    case DXGI_FORMAT_BC2_UNORM:
+    case DXGI_FORMAT_BC2_UNORM_SRGB:
+    case DXGI_FORMAT_BC3_TYPELESS:
+    case DXGI_FORMAT_BC3_UNORM:
+    case DXGI_FORMAT_BC3_UNORM_SRGB:
+    case DXGI_FORMAT_BC5_TYPELESS:
+    case DXGI_FORMAT_BC5_UNORM:
+    case DXGI_FORMAT_BC5_SNORM:
+    case DXGI_FORMAT_BC6H_TYPELESS:
+    case DXGI_FORMAT_BC6H_UF16:
+    case DXGI_FORMAT_BC6H_SF16:
+    case DXGI_FORMAT_BC7_TYPELESS:
+    case DXGI_FORMAT_BC7_UNORM:
+    case DXGI_FORMAT_BC7_UNORM_SRGB:
+        assert(IsCompressed(fmt));
+        {
+            if (flags & CP_FLAGS_BAD_DXTN_TAILS)
+            {
+                const size_t nbw = width >> 2;
+                const size_t nbh = height >> 2;
+                pitch = std::max<uint64_t>(1u, uint64_t(nbw) * 16u);
+                slice = std::max<uint64_t>(1u, pitch * uint64_t(nbh));
+            }
+            else
+            {
+                const uint64_t nbw = std::max<uint64_t>(1u, (uint64_t(width) + 3u) / 4u);
+                const uint64_t nbh = std::max<uint64_t>(1u, (uint64_t(height) + 3u) / 4u);
+                pitch = nbw * 16u;
+                slice = pitch * nbh;
+            }
+        }
+        break;
+
+    case DXGI_FORMAT_R8G8_B8G8_UNORM:
+    case DXGI_FORMAT_G8R8_G8B8_UNORM:
+    case DXGI_FORMAT_YUY2:
+        assert(IsPacked(fmt));
+        pitch = ((uint64_t(width) + 1u) >> 1) * 4u;
+        slice = pitch * uint64_t(height);
+        break;
+
+    case DXGI_FORMAT_Y210:
+    case DXGI_FORMAT_Y216:
+        assert(IsPacked(fmt));
+        pitch = ((uint64_t(width) + 1u) >> 1) * 8u;
+        slice = pitch * uint64_t(height);
+        break;
+
+    case DXGI_FORMAT_NV12:
+    case DXGI_FORMAT_420_OPAQUE:
+        if ((height % 2) != 0)
+        {
+            // Requires a height alignment of 2.
+            return E_INVALIDARG;
+        }
+        assert(IsPlanar(fmt));
+        pitch = ((uint64_t(width) + 1u) >> 1) * 2u;
+        slice = pitch * (uint64_t(height) + ((uint64_t(height) + 1u) >> 1));
+        break;
+
+    case DXGI_FORMAT_P010:
+    case DXGI_FORMAT_P016:
+        if ((height % 2) != 0)
+        {
+            // Requires a height alignment of 2.
+            return E_INVALIDARG;
+        }
+
+        #if (__cplusplus >= 201703L)
+            [[fallthrough]];
+        #elif defined(__clang__)
+            [[clang::fallthrough]];
+        #elif defined(_MSC_VER)
+            __fallthrough;
+        #endif
+
+    case XBOX_DXGI_FORMAT_D16_UNORM_S8_UINT:
+    case XBOX_DXGI_FORMAT_R16_UNORM_X8_TYPELESS:
+    case XBOX_DXGI_FORMAT_X16_TYPELESS_G8_UINT:
+        assert(IsPlanar(fmt));
+        pitch = ((uint64_t(width) + 1u) >> 1) * 4u;
+        slice = pitch * (uint64_t(height) + ((uint64_t(height) + 1u) >> 1));
+        break;
+
+    case DXGI_FORMAT_NV11:
+        assert(IsPlanar(fmt));
+        pitch = ((uint64_t(width) + 3u) >> 2) * 4u;
+        slice = pitch * uint64_t(height) * 2u;
+        break;
+
+    case WIN10_DXGI_FORMAT_P208:
+        assert(IsPlanar(fmt));
+        pitch = ((uint64_t(width) + 1u) >> 1) * 2u;
+        slice = pitch * uint64_t(height) * 2u;
+        break;
+
+    case WIN10_DXGI_FORMAT_V208:
+        if ((height % 2) != 0)
+        {
+            // Requires a height alignment of 2.
+            return E_INVALIDARG;
+        }
+        assert(IsPlanar(fmt));
+        pitch = uint64_t(width);
+        slice = pitch * (uint64_t(height) + (((uint64_t(height) + 1u) >> 1) * 2u));
+        break;
+
+    case WIN10_DXGI_FORMAT_V408:
+        assert(IsPlanar(fmt));
+        pitch = uint64_t(width);
+        slice = pitch * (uint64_t(height) + (uint64_t(height >> 1) * 4u));
+        break;
+
+    default:
+        assert(!IsCompressed(fmt) && !IsPacked(fmt) && !IsPlanar(fmt));
+        {
+            size_t bpp;
+
+            if (flags & CP_FLAGS_24BPP)
+                bpp = 24;
+            else if (flags & CP_FLAGS_16BPP)
+                bpp = 16;
+            else if (flags & CP_FLAGS_8BPP)
+                bpp = 8;
+            else
+                bpp = BitsPerPixel(fmt);
+
+            if (!bpp)
+                return E_INVALIDARG;
+
+            if (flags & (CP_FLAGS_LEGACY_DWORD | CP_FLAGS_PARAGRAPH | CP_FLAGS_YMM | CP_FLAGS_ZMM | CP_FLAGS_PAGE4K))
+            {
+                if (flags & CP_FLAGS_PAGE4K)
+                {
+                    pitch = ((uint64_t(width) * bpp + 32767u) / 32768u) * 4096u;
+                    slice = pitch * uint64_t(height);
+                }
+                else if (flags & CP_FLAGS_ZMM)
+                {
+                    pitch = ((uint64_t(width) * bpp + 511u) / 512u) * 64u;
+                    slice = pitch * uint64_t(height);
+                }
+                else if (flags & CP_FLAGS_YMM)
+                {
+                    pitch = ((uint64_t(width) * bpp + 255u) / 256u) * 32u;
+                    slice = pitch * uint64_t(height);
+                }
+                else if (flags & CP_FLAGS_PARAGRAPH)
+                {
+                    pitch = ((uint64_t(width) * bpp + 127u) / 128u) * 16u;
+                    slice = pitch * uint64_t(height);
+                }
+                else // DWORD alignment
+                {
+                    // Special computation for some incorrectly created DDS files based on
+                    // legacy DirectDraw assumptions about pitch alignment
+                    pitch = ((uint64_t(width) * bpp + 31u) / 32u) * sizeof(uint32_t);
+                    slice = pitch * uint64_t(height);
+                }
+            }
+            else
+            {
+                // Default byte alignment
+                pitch = (uint64_t(width) * bpp + 7u) / 8u;
+                slice = pitch * uint64_t(height);
+            }
+        }
+        break;
+    }
+
+#if defined(_M_IX86) || defined(_M_ARM) || defined(_M_HYBRID_X86_ARM64)
+    static_assert(sizeof(size_t) == 4, "Not a 32-bit platform!");
+    if (pitch > UINT32_MAX || slice > UINT32_MAX)
+    {
+        rowPitch = slicePitch = 0;
+        return HRESULT_E_ARITHMETIC_OVERFLOW;
+    }
+#else
+    static_assert(sizeof(size_t) == 8, "Not a 64-bit platform!");
+#endif
+
+    rowPitch = static_cast<size_t>(pitch);
+    slicePitch = static_cast<size_t>(slice);
+
+    return S_OK;
+}
+
+
+//-------------------------------------------------------------------------------------
+_Use_decl_annotations_
+size_t DirectX::ComputeScanlines(DXGI_FORMAT fmt, size_t height) noexcept
+{
+    switch (static_cast<int>(fmt))
+    {
+    case DXGI_FORMAT_BC1_TYPELESS:
+    case DXGI_FORMAT_BC1_UNORM:
+    case DXGI_FORMAT_BC1_UNORM_SRGB:
+    case DXGI_FORMAT_BC2_TYPELESS:
+    case DXGI_FORMAT_BC2_UNORM:
+    case DXGI_FORMAT_BC2_UNORM_SRGB:
+    case DXGI_FORMAT_BC3_TYPELESS:
+    case DXGI_FORMAT_BC3_UNORM:
+    case DXGI_FORMAT_BC3_UNORM_SRGB:
+    case DXGI_FORMAT_BC4_TYPELESS:
+    case DXGI_FORMAT_BC4_UNORM:
+    case DXGI_FORMAT_BC4_SNORM:
+    case DXGI_FORMAT_BC5_TYPELESS:
+    case DXGI_FORMAT_BC5_UNORM:
+    case DXGI_FORMAT_BC5_SNORM:
+    case DXGI_FORMAT_BC6H_TYPELESS:
+    case DXGI_FORMAT_BC6H_UF16:
+    case DXGI_FORMAT_BC6H_SF16:
+    case DXGI_FORMAT_BC7_TYPELESS:
+    case DXGI_FORMAT_BC7_UNORM:
+    case DXGI_FORMAT_BC7_UNORM_SRGB:
+        assert(IsCompressed(fmt));
+        return std::max<size_t>(1, (height + 3) / 4);
+
+    case DXGI_FORMAT_NV11:
+    case WIN10_DXGI_FORMAT_P208:
+        assert(IsPlanar(fmt));
+        return height * 2;
+
+    case WIN10_DXGI_FORMAT_V208:
+        assert(IsPlanar(fmt));
+        return height + (((height + 1) >> 1) * 2);
+
+    case WIN10_DXGI_FORMAT_V408:
+        assert(IsPlanar(fmt));
+        return height + ((height >> 1) * 4);
+
+    case DXGI_FORMAT_NV12:
+    case DXGI_FORMAT_P010:
+    case DXGI_FORMAT_P016:
+    case DXGI_FORMAT_420_OPAQUE:
+    case XBOX_DXGI_FORMAT_D16_UNORM_S8_UINT:
+    case XBOX_DXGI_FORMAT_R16_UNORM_X8_TYPELESS:
+    case XBOX_DXGI_FORMAT_X16_TYPELESS_G8_UINT:
+        assert(IsPlanar(fmt));
+        return height + ((height + 1) >> 1);
+
+    default:
+        assert(IsValid(fmt));
+        assert(!IsCompressed(fmt) && !IsPlanar(fmt));
+        return height;
+    }
+}
+
+
+//-------------------------------------------------------------------------------------
+// Converts to an SRGB equivalent type if available
+//-------------------------------------------------------------------------------------
+_Use_decl_annotations_
+DXGI_FORMAT DirectX::MakeSRGB(DXGI_FORMAT fmt) noexcept
+{
+    switch (fmt)
+    {
+    case DXGI_FORMAT_R8G8B8A8_UNORM:
+        return DXGI_FORMAT_R8G8B8A8_UNORM_SRGB;
+
+    case DXGI_FORMAT_BC1_UNORM:
+        return DXGI_FORMAT_BC1_UNORM_SRGB;
+
+    case DXGI_FORMAT_BC2_UNORM:
+        return DXGI_FORMAT_BC2_UNORM_SRGB;
+
+    case DXGI_FORMAT_BC3_UNORM:
+        return DXGI_FORMAT_BC3_UNORM_SRGB;
+
+    case DXGI_FORMAT_B8G8R8A8_UNORM:
+        return DXGI_FORMAT_B8G8R8A8_UNORM_SRGB;
+
+    case DXGI_FORMAT_B8G8R8X8_UNORM:
+        return DXGI_FORMAT_B8G8R8X8_UNORM_SRGB;
+
+    case DXGI_FORMAT_BC7_UNORM:
+        return DXGI_FORMAT_BC7_UNORM_SRGB;
+
+    default:
+        return fmt;
+    }
+}
+
+
+//-------------------------------------------------------------------------------------
+// Converts to an non-SRGB equivalent type
+//-------------------------------------------------------------------------------------
+_Use_decl_annotations_
+DXGI_FORMAT DirectX::MakeLinear(DXGI_FORMAT fmt) noexcept
+{
+    switch (fmt)
+    {
+    case DXGI_FORMAT_R8G8B8A8_UNORM_SRGB:
+        return DXGI_FORMAT_R8G8B8A8_UNORM;
+
+    case DXGI_FORMAT_BC1_UNORM_SRGB:
+        return DXGI_FORMAT_BC1_UNORM;
+
+    case DXGI_FORMAT_BC2_UNORM_SRGB:
+        return DXGI_FORMAT_BC2_UNORM;
+
+    case DXGI_FORMAT_BC3_UNORM_SRGB:
+        return DXGI_FORMAT_BC3_UNORM;
+
+    case DXGI_FORMAT_B8G8R8A8_UNORM_SRGB:
+        return DXGI_FORMAT_B8G8R8A8_UNORM;
+
+    case DXGI_FORMAT_B8G8R8X8_UNORM_SRGB:
+        return DXGI_FORMAT_B8G8R8X8_UNORM;
+
+    case DXGI_FORMAT_BC7_UNORM_SRGB:
+        return DXGI_FORMAT_BC7_UNORM;
+
+    default:
+        return fmt;
+    }
+}
+
+
+//-------------------------------------------------------------------------------------
+// Converts to a format to an equivalent TYPELESS format if available
+//-------------------------------------------------------------------------------------
+_Use_decl_annotations_
+DXGI_FORMAT DirectX::MakeTypeless(DXGI_FORMAT fmt) noexcept
+{
+    switch (static_cast<int>(fmt))
+    {
+    case DXGI_FORMAT_R32G32B32A32_FLOAT:
+    case DXGI_FORMAT_R32G32B32A32_UINT:
+    case DXGI_FORMAT_R32G32B32A32_SINT:
+        return DXGI_FORMAT_R32G32B32A32_TYPELESS;
+
+    case DXGI_FORMAT_R32G32B32_FLOAT:
+    case DXGI_FORMAT_R32G32B32_UINT:
+    case DXGI_FORMAT_R32G32B32_SINT:
+        return DXGI_FORMAT_R32G32B32_TYPELESS;
+
+    case DXGI_FORMAT_R16G16B16A16_FLOAT:
+    case DXGI_FORMAT_R16G16B16A16_UNORM:
+    case DXGI_FORMAT_R16G16B16A16_UINT:
+    case DXGI_FORMAT_R16G16B16A16_SNORM:
+    case DXGI_FORMAT_R16G16B16A16_SINT:
+        return DXGI_FORMAT_R16G16B16A16_TYPELESS;
+
+    case DXGI_FORMAT_R32G32_FLOAT:
+    case DXGI_FORMAT_R32G32_UINT:
+    case DXGI_FORMAT_R32G32_SINT:
+        return DXGI_FORMAT_R32G32_TYPELESS;
+
+    case DXGI_FORMAT_R10G10B10A2_UNORM:
+    case DXGI_FORMAT_R10G10B10A2_UINT:
+    case XBOX_DXGI_FORMAT_R10G10B10_7E3_A2_FLOAT:
+    case XBOX_DXGI_FORMAT_R10G10B10_6E4_A2_FLOAT:
+    case XBOX_DXGI_FORMAT_R10G10B10_SNORM_A2_UNORM:
+        return DXGI_FORMAT_R10G10B10A2_TYPELESS;
+
+    case DXGI_FORMAT_R8G8B8A8_UNORM:
+    case DXGI_FORMAT_R8G8B8A8_UNORM_SRGB:
+    case DXGI_FORMAT_R8G8B8A8_UINT:
+    case DXGI_FORMAT_R8G8B8A8_SNORM:
+    case DXGI_FORMAT_R8G8B8A8_SINT:
+        return DXGI_FORMAT_R8G8B8A8_TYPELESS;
+
+    case DXGI_FORMAT_R16G16_FLOAT:
+    case DXGI_FORMAT_R16G16_UNORM:
+    case DXGI_FORMAT_R16G16_UINT:
+    case DXGI_FORMAT_R16G16_SNORM:
+    case DXGI_FORMAT_R16G16_SINT:
+        return DXGI_FORMAT_R16G16_TYPELESS;
+
+    case DXGI_FORMAT_D32_FLOAT:
+    case DXGI_FORMAT_R32_FLOAT:
+    case DXGI_FORMAT_R32_UINT:
+    case DXGI_FORMAT_R32_SINT:
+        return DXGI_FORMAT_R32_TYPELESS;
+
+    case DXGI_FORMAT_R8G8_UNORM:
+    case DXGI_FORMAT_R8G8_UINT:
+    case DXGI_FORMAT_R8G8_SNORM:
+    case DXGI_FORMAT_R8G8_SINT:
+        return DXGI_FORMAT_R8G8_TYPELESS;
+
+    case DXGI_FORMAT_R16_FLOAT:
+    case DXGI_FORMAT_D16_UNORM:
+    case DXGI_FORMAT_R16_UNORM:
+    case DXGI_FORMAT_R16_UINT:
+    case DXGI_FORMAT_R16_SNORM:
+    case DXGI_FORMAT_R16_SINT:
+        return DXGI_FORMAT_R16_TYPELESS;
+
+    case DXGI_FORMAT_R8_UNORM:
+    case DXGI_FORMAT_R8_UINT:
+    case DXGI_FORMAT_R8_SNORM:
+    case DXGI_FORMAT_R8_SINT:
+    case XBOX_DXGI_FORMAT_R4G4_UNORM:
+        return DXGI_FORMAT_R8_TYPELESS;
+
+    case DXGI_FORMAT_BC1_UNORM:
+    case DXGI_FORMAT_BC1_UNORM_SRGB:
+        return DXGI_FORMAT_BC1_TYPELESS;
+
+    case DXGI_FORMAT_BC2_UNORM:
+    case DXGI_FORMAT_BC2_UNORM_SRGB:
+        return DXGI_FORMAT_BC2_TYPELESS;
+
+    case DXGI_FORMAT_BC3_UNORM:
+    case DXGI_FORMAT_BC3_UNORM_SRGB:
+        return DXGI_FORMAT_BC3_TYPELESS;
+
+    case DXGI_FORMAT_BC4_UNORM:
+    case DXGI_FORMAT_BC4_SNORM:
+        return DXGI_FORMAT_BC4_TYPELESS;
+
+    case DXGI_FORMAT_BC5_UNORM:
+    case DXGI_FORMAT_BC5_SNORM:
+        return DXGI_FORMAT_BC5_TYPELESS;
+
+    case DXGI_FORMAT_B8G8R8A8_UNORM:
+    case DXGI_FORMAT_B8G8R8A8_UNORM_SRGB:
+        return DXGI_FORMAT_B8G8R8A8_TYPELESS;
+
+    case DXGI_FORMAT_B8G8R8X8_UNORM:
+    case DXGI_FORMAT_B8G8R8X8_UNORM_SRGB:
+        return DXGI_FORMAT_B8G8R8X8_TYPELESS;
+
+    case DXGI_FORMAT_BC6H_UF16:
+    case DXGI_FORMAT_BC6H_SF16:
+        return DXGI_FORMAT_BC6H_TYPELESS;
+
+    case DXGI_FORMAT_BC7_UNORM:
+    case DXGI_FORMAT_BC7_UNORM_SRGB:
+        return DXGI_FORMAT_BC7_TYPELESS;
+
+    default:
+        return fmt;
+    }
+}
+
+
+//-------------------------------------------------------------------------------------
+// Converts to a TYPELESS format to an equivalent UNORM format if available
+//-------------------------------------------------------------------------------------
+_Use_decl_annotations_
+DXGI_FORMAT DirectX::MakeTypelessUNORM(DXGI_FORMAT fmt) noexcept
+{
+    switch (fmt)
+    {
+    case DXGI_FORMAT_R16G16B16A16_TYPELESS:
+        return DXGI_FORMAT_R16G16B16A16_UNORM;
+
+    case DXGI_FORMAT_R10G10B10A2_TYPELESS:
+        return DXGI_FORMAT_R10G10B10A2_UNORM;
+
+    case DXGI_FORMAT_R8G8B8A8_TYPELESS:
+        return DXGI_FORMAT_R8G8B8A8_UNORM;
+
+    case DXGI_FORMAT_R16G16_TYPELESS:
+        return DXGI_FORMAT_R16G16_UNORM;
+
+    case DXGI_FORMAT_R8G8_TYPELESS:
+        return DXGI_FORMAT_R8G8_UNORM;
+
+    case DXGI_FORMAT_R16_TYPELESS:
+        return DXGI_FORMAT_R16_UNORM;
+
+    case DXGI_FORMAT_R8_TYPELESS:
+        return DXGI_FORMAT_R8_UNORM;
+
+    case DXGI_FORMAT_BC1_TYPELESS:
+        return DXGI_FORMAT_BC1_UNORM;
+
+    case DXGI_FORMAT_BC2_TYPELESS:
+        return DXGI_FORMAT_BC2_UNORM;
+
+    case DXGI_FORMAT_BC3_TYPELESS:
+        return DXGI_FORMAT_BC3_UNORM;
+
+    case DXGI_FORMAT_BC4_TYPELESS:
+        return DXGI_FORMAT_BC4_UNORM;
+
+    case DXGI_FORMAT_BC5_TYPELESS:
+        return DXGI_FORMAT_BC5_UNORM;
+
+    case DXGI_FORMAT_B8G8R8A8_TYPELESS:
+        return DXGI_FORMAT_B8G8R8A8_UNORM;
+
+    case DXGI_FORMAT_B8G8R8X8_TYPELESS:
+        return DXGI_FORMAT_B8G8R8X8_UNORM;
+
+    case DXGI_FORMAT_BC7_TYPELESS:
+        return DXGI_FORMAT_BC7_UNORM;
+
+    default:
+        return fmt;
+    }
+}
+
+
+//-------------------------------------------------------------------------------------
+// Converts to a TYPELESS format to an equivalent FLOAT format if available
+//-------------------------------------------------------------------------------------
+_Use_decl_annotations_
+DXGI_FORMAT DirectX::MakeTypelessFLOAT(DXGI_FORMAT fmt) noexcept
+{
+    switch (fmt)
+    {
+    case DXGI_FORMAT_R32G32B32A32_TYPELESS:
+        return DXGI_FORMAT_R32G32B32A32_FLOAT;
+
+    case DXGI_FORMAT_R32G32B32_TYPELESS:
+        return DXGI_FORMAT_R32G32B32_FLOAT;
+
+    case DXGI_FORMAT_R16G16B16A16_TYPELESS:
+        return DXGI_FORMAT_R16G16B16A16_FLOAT;
+
+    case DXGI_FORMAT_R32G32_TYPELESS:
+        return DXGI_FORMAT_R32G32_FLOAT;
+
+    case DXGI_FORMAT_R16G16_TYPELESS:
+        return DXGI_FORMAT_R16G16_FLOAT;
+
+    case DXGI_FORMAT_R32_TYPELESS:
+        return DXGI_FORMAT_R32_FLOAT;
+
+    case DXGI_FORMAT_R16_TYPELESS:
+        return DXGI_FORMAT_R16_FLOAT;
+
+    default:
+        return fmt;
+    }
+}
+
+
+//=====================================================================================
+// TexMetadata
+//=====================================================================================
+
+size_t TexMetadata::ComputeIndex(size_t mip, size_t item, size_t slice) const noexcept
+{
+    if (mip >= mipLevels)
+        return size_t(-1);
+
+    switch (dimension)
+    {
+    case TEX_DIMENSION_TEXTURE1D:
+    case TEX_DIMENSION_TEXTURE2D:
+        if (slice > 0)
+            return size_t(-1);
+
+        if (item >= arraySize)
+            return size_t(-1);
+
+        return (item*(mipLevels)+mip);
+
+    case TEX_DIMENSION_TEXTURE3D:
+        if (item > 0)
+        {
+            // No support for arrays of volumes
+            return size_t(-1);
+        }
+        else
+        {
+            size_t index = 0;
+            size_t d = depth;
+
+            for (size_t level = 0; level < mip; ++level)
+            {
+                index += d;
+                if (d > 1)
+                    d >>= 1;
+            }
+
+            if (slice >= d)
+                return size_t(-1);
+
+            index += slice;
+
+            return index;
+        }
+
+    default:
+        return size_t(-1);
+    }
+}
+
+// Equivalent to D3D11CacluateSubresource: MipSlice + ArraySlice * MipLevels
+uint32_t TexMetadata::CalculateSubresource(size_t mip, size_t item) const noexcept
+{
+    uint32_t result = uint32_t(-1);
+
+    if (mip < mipLevels)
+    {
+        switch (dimension)
+        {
+        case TEX_DIMENSION_TEXTURE1D:
+        case TEX_DIMENSION_TEXTURE2D:
+            if (item < arraySize)
+            {
+                return static_cast<uint32_t>(mip + item*mipLevels);
+            }
+            break;
+
+        case TEX_DIMENSION_TEXTURE3D:
+            // No support for arrays of volumes
+            if (item == 0)
+            {
+                result = static_cast<uint32_t>(mip);
+            }
+            break;
+
+        default:
+            break;
+        }
+    }
+
+    return result;
+}
+
+// Equivalent to D3D12CacluateSubresource: MipSlice + ArraySlice * MipLevels + PlaneSlice * MipLevels * ArraySize
+uint32_t TexMetadata::CalculateSubresource(size_t mip, size_t item, size_t plane) const noexcept
+{
+    uint32_t result = uint32_t(-1);
+
+    if (mip < mipLevels)
+    {
+        switch (dimension)
+        {
+        case TEX_DIMENSION_TEXTURE1D:
+        case TEX_DIMENSION_TEXTURE2D:
+            if (item < arraySize)
+            {
+                return static_cast<uint32_t>(mip + item*mipLevels + plane*mipLevels*arraySize);
+            }
+            break;
+
+        case TEX_DIMENSION_TEXTURE3D:
+            // No support for arrays of volumes
+            if (item == 0)
+            {
+                result = static_cast<uint32_t>(mip + plane*mipLevels);
+            }
+            break;
+
+        default:
+            break;
+        }
+    }
+
+    return result;
+}
+
+
+//=====================================================================================
+// Blob - Bitmap image container
+//=====================================================================================
+
+Blob& Blob::operator= (Blob&& moveFrom) noexcept
+{
+    if (this != &moveFrom)
+    {
+        Release();
+
+        m_buffer = moveFrom.m_buffer;
+        m_size = moveFrom.m_size;
+
+        moveFrom.m_buffer = nullptr;
+        moveFrom.m_size = 0;
+    }
+    return *this;
+}
+
+void Blob::Release() noexcept
+{
+    if (m_buffer)
+    {
+        _aligned_free(m_buffer);
+        m_buffer = nullptr;
+    }
+
+    m_size = 0;
+}
+
+_Use_decl_annotations_
+HRESULT Blob::Initialize(size_t size) noexcept
+{
+    if (!size)
+        return E_INVALIDARG;
+
+    Release();
+
+    m_buffer = _aligned_malloc(size, 16);
+    if (!m_buffer)
+    {
+        Release();
+        return E_OUTOFMEMORY;
+    }
+
+    m_size = size;
+
+    return S_OK;
+}
+
+HRESULT Blob::Trim(size_t size) noexcept
+{
+    if (!size)
+        return E_INVALIDARG;
+
+    if (!m_buffer)
+        return E_UNEXPECTED;
+
+    if (size > m_size)
+        return E_INVALIDARG;
+
+    m_size = size;
+
+    return S_OK;
+}
+
+HRESULT Blob::Resize(size_t size) noexcept
+{
+    if (!size)
+        return E_INVALIDARG;
+
+    if (!m_buffer || !m_size)
+        return E_UNEXPECTED;
+
+    void *tbuffer = _aligned_malloc(size, 16);
+    if (!tbuffer)
+        return E_OUTOFMEMORY;
+
+    memcpy(tbuffer, m_buffer, std::min(m_size, size));
+
+    Release();
+
+    m_buffer = tbuffer;
+    m_size = size;
+
+    return S_OK;
+}

--- a/DirectXTex/DirectXTex/DirectXTex_Desktop_2022_Win10.vcxproj
+++ b/DirectXTex/DirectXTex/DirectXTex_Desktop_2022_Win10.vcxproj
@@ -1,0 +1,139 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|Win32">
+      <Configuration>Debug</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|Win32">
+      <Configuration>Release</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <ProjectName>DirectXTex</ProjectName>
+    <ProjectGuid>{371B9FA9-4C90-4AC6-A123-ACED756D6C77}</ProjectGuid>
+    <RootNamespace>DirectXTex</RootNamespace>
+    <Keyword>Win32Proj</Keyword>
+    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
+    <PreferredToolArchitecture>x64</PreferredToolArchitecture>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
+    <ConfigurationType>StaticLibrary</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <CharacterSet>Unicode</CharacterSet>
+    <PlatformToolset>v143</PlatformToolset>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
+    <ConfigurationType>StaticLibrary</ConfigurationType>
+    <CharacterSet>Unicode</CharacterSet>
+    <PlatformToolset>v143</PlatformToolset>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings" />
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <PropertyGroup Label="UserMacros" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <OutDir>Bin\Desktop_2022_Win10\$(Platform)\$(Configuration)\</OutDir>
+    <IntDir>Bin\Desktop_2022_Win10\$(Platform)\$(Configuration)\</IntDir>
+    <TargetName>DirectXTex</TargetName>
+    <GenerateManifest>true</GenerateManifest>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <OutDir>Lib\</OutDir>
+    <IntDir>Lib\</IntDir>
+    <TargetName>DirectXTex</TargetName>
+    <GenerateManifest>true</GenerateManifest>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(SpectreMitigation)'!='' AND '$(SpectreMitigation)'!='false'">
+    <OutDir>Bin\Desktop_2022_Win10\$(Platform)\$(Configuration)Spectre\</OutDir>
+    <IntDir>Bin\Desktop_2022_Win10\$(Platform)\$(Configuration)Spectre\</IntDir>
+    <TargetName>DirectXTex_Spectre</TargetName>
+  </PropertyGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <ClCompile>
+      <WarningLevel>EnableAllWarnings</WarningLevel>
+      <Optimization>Disabled</Optimization>
+      <RuntimeLibrary>MultiThreadedDebugDLL</RuntimeLibrary>
+      <OpenMPSupport>true</OpenMPSupport>
+      <FloatingPointModel>Fast</FloatingPointModel>
+      <EnableEnhancedInstructionSet>StreamingSIMDExtensions2</EnableEnhancedInstructionSet>
+      <AdditionalOptions>/Zc:twoPhase- /Zc:__cplusplus %(AdditionalOptions)</AdditionalOptions>
+      <PreprocessorDefinitions>_UNICODE;UNICODE;WIN32;_DEBUG;_LIB;_WIN32_WINNT=0x0A00;_CRT_STDIO_ARBITRARY_WIDE_SPECIFIERS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PrecompiledHeader>Use</PrecompiledHeader>
+      <PrecompiledHeaderFile>DirectXTexP.h</PrecompiledHeaderFile>
+      <AdditionalIncludeDirectories>$(ProjectDir);$(ProjectDir)Shaders\Compiled;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <ProgramDataBaseFileName>$(IntDir)$(TargetName).pdb</ProgramDataBaseFileName>
+      <SDLCheck>true</SDLCheck>
+      <ConformanceMode>true</ConformanceMode>
+      <ExternalWarningLevel>Level4</ExternalWarningLevel>
+      <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
+      <SupportJustMyCode>false</SupportJustMyCode>
+    </ClCompile>
+    <Link>
+      <SubSystem>Windows</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+    </Link>
+    <Manifest>
+      <EnableDPIAwareness>false</EnableDPIAwareness>
+    </Manifest>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <ClCompile>
+      <WarningLevel>EnableAllWarnings</WarningLevel>
+      <Optimization>MaxSpeed</Optimization>
+      <OpenMPSupport>true</OpenMPSupport>
+      <FloatingPointModel>Fast</FloatingPointModel>
+      <EnableEnhancedInstructionSet>StreamingSIMDExtensions2</EnableEnhancedInstructionSet>
+      <AdditionalOptions>/Zc:twoPhase- /Zc:__cplusplus %(AdditionalOptions)</AdditionalOptions>
+      <PreprocessorDefinitions>_UNICODE;UNICODE;WIN32;NDEBUG;_LIB;_WIN32_WINNT=0x0A00;_CRT_STDIO_ARBITRARY_WIDE_SPECIFIERS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PrecompiledHeader>Use</PrecompiledHeader>
+      <PrecompiledHeaderFile>DirectXTexP.h</PrecompiledHeaderFile>
+      <AdditionalIncludeDirectories>$(ProjectDir);$(ProjectDir)Shaders\Compiled;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <ProgramDataBaseFileName>$(IntDir)$(TargetName).pdb</ProgramDataBaseFileName>
+      <SDLCheck>true</SDLCheck>
+      <ConformanceMode>true</ConformanceMode>
+      <ExternalWarningLevel>Level4</ExternalWarningLevel>
+      <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
+    </ClCompile>
+    <Link>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <SubSystem>Windows</SubSystem>
+      <OptimizeReferences>true</OptimizeReferences>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+    </Link>
+    <Manifest>
+      <EnableDPIAwareness>false</EnableDPIAwareness>
+    </Manifest>
+  </ItemDefinitionGroup>
+  <ItemGroup>
+    <CLInclude Include="BC.h" />
+    <ClCompile Include="BC.cpp" />
+    <CLInclude Include="DDS.h" />
+    <ClInclude Include="filters.h" />
+    <CLInclude Include="scoped.h" />
+    <CLInclude Include="DirectXTex.h" />
+    <CLInclude Include="DirectXTexP.h" />
+    <CLInclude Include="DirectXTex.inl" />
+    <ClCompile Include="BC4BC5.cpp" />
+    <ClCompile Include="BC6HBC7.cpp" />
+    <ClCompile Include="DirectXTexCompress.cpp" />
+    <ClCompile Include="DirectXTexConvert.cpp" />
+    <ClCompile Include="DirectXTexDDS.cpp" />
+    <ClCompile Include="DirectXTexImage.cpp" />
+    <ClCompile Include="DirectXTexMipMaps.cpp" />
+    <ClCompile Include="DirectXTexMisc.cpp" />
+    <ClCompile Include="DirectXTexUtil.cpp">
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">Create</PrecompiledHeader>
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">Create</PrecompiledHeader>
+    </ClCompile>
+  </ItemGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets" />
+</Project>

--- a/DirectXTex/DirectXTex/DirectXTex_Desktop_2022_Win10.vcxproj.filters
+++ b/DirectXTex/DirectXTex/DirectXTex_Desktop_2022_Win10.vcxproj.filters
@@ -1,0 +1,68 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns:atg="http://atg.xbox.com" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <Filter Include="Header Files">
+      <UniqueIdentifier>{68652706-b700-4472-9af7-a56a482bd896}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Source Files">
+      <UniqueIdentifier>{9b7fcbc5-2533-4b88-b75b-d4803e55fa7c}</UniqueIdentifier>
+    </Filter>
+  </ItemGroup>
+  <ItemGroup>
+    <CLInclude Include="DirectXTex.h">
+      <Filter>Header Files</Filter>
+    </CLInclude>
+    <CLInclude Include="DirectXTex.inl">
+      <Filter>Header Files</Filter>
+    </CLInclude>
+    <CLInclude Include="DDS.h">
+      <Filter>Source Files</Filter>
+    </CLInclude>
+    <CLInclude Include="DirectXTexP.h">
+      <Filter>Source Files</Filter>
+    </CLInclude>
+    <ClInclude Include="filters.h">
+      <Filter>Source Files</Filter>
+    </ClInclude>
+    <CLInclude Include="scoped.h">
+      <Filter>Source Files</Filter>
+    </CLInclude>
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="BC.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="DirectXTexCompress.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="DirectXTexConvert.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="DirectXTexDDS.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="DirectXTexImage.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="DirectXTexMipMaps.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="DirectXTexMisc.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="DirectXTexUtil.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="BC6HBC7.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="BC4BC5.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+  </ItemGroup>
+  <ItemGroup>
+    <CLInclude Include="BC.h">
+      <Filter>Source Files</Filter>
+    </CLInclude>
+  </ItemGroup>
+</Project>

--- a/DirectXTex/DirectXTex/DirectXTex_Desktop_2022_Win10.vcxproj.user
+++ b/DirectXTex/DirectXTex/DirectXTex_Desktop_2022_Win10.vcxproj.user
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="Current" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup />
+</Project>

--- a/DirectXTex/DirectXTex/filters.h
+++ b/DirectXTex/DirectXTex/filters.h
@@ -1,0 +1,422 @@
+//-------------------------------------------------------------------------------------
+// filters.h
+//
+// Utility header with helpers for implementing image filters
+//
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+//-------------------------------------------------------------------------------------
+
+#pragma once
+
+#include <DirectXMath.h>
+#include <DirectXPackedVector.h>
+
+#include <memory>
+
+#include "scoped.h"
+
+
+namespace DirectX
+{
+    namespace Filters
+    {
+        //-------------------------------------------------------------------------------------
+        // Box filtering helpers
+        //-------------------------------------------------------------------------------------
+
+        XMGLOBALCONST XMVECTORF32 g_boxScale = { { { 0.25f, 0.25f, 0.25f, 0.25f } } };
+        XMGLOBALCONST XMVECTORF32 g_boxScale3D = { { { 0.125f, 0.125f, 0.125f, 0.125f } } };
+
+    #define AVERAGE4( res, p0, p1, p2, p3 ) \
+{ \
+    XMVECTOR v = XMVectorAdd((p0), (p1)); \
+    v = XMVectorAdd(v, (p2)); \
+    v = XMVectorAdd(v, (p3)); \
+    res = XMVectorMultiply(v, g_boxScale); \
+}
+
+    #define AVERAGE8( res, p0, p1, p2, p3, p4, p5, p6, p7) \
+{ \
+    XMVECTOR v = XMVectorAdd((p0), (p1)); \
+    v = XMVectorAdd(v, (p2)); \
+    v = XMVectorAdd(v, (p3)); \
+    v = XMVectorAdd(v, (p4)); \
+    v = XMVectorAdd(v, (p5)); \
+    v = XMVectorAdd(v, (p6)); \
+    v = XMVectorAdd(v, (p7)); \
+    res = XMVectorMultiply(v, g_boxScale3D); \
+}
+
+
+        //-------------------------------------------------------------------------------------
+        // Linear filtering helpers
+        //-------------------------------------------------------------------------------------
+
+        struct LinearFilter
+        {
+            size_t  u0;
+            float   weight0;
+            size_t  u1;
+            float   weight1;
+        };
+
+        inline void CreateLinearFilter(_In_ size_t source, _In_ size_t dest, _In_ bool wrap, _Out_writes_(dest) LinearFilter* lf) noexcept
+        {
+            assert(source > 0);
+            assert(dest > 0);
+            assert(lf != nullptr);
+
+            const float scale = float(source) / float(dest);
+
+            // Mirror is the same case as clamp for linear
+
+            for (size_t u = 0; u < dest; ++u)
+            {
+                const float srcB = (float(u) + 0.5f) * scale + 0.5f;
+
+                ptrdiff_t isrcB = ptrdiff_t(srcB);
+                ptrdiff_t isrcA = isrcB - 1;
+
+                const float weight = 1.0f + float(isrcB) - srcB;
+
+                if (isrcA < 0)
+                {
+                    isrcA = (wrap) ? (ptrdiff_t(source) - 1) : 0;
+                }
+
+                if (size_t(isrcB) >= source)
+                {
+                    isrcB = (wrap) ? 0 : (ptrdiff_t(source) - 1);
+                }
+
+                auto& entry = lf[u];
+                entry.u0 = size_t(isrcA);
+                entry.weight0 = weight;
+
+                entry.u1 = size_t(isrcB);
+                entry.weight1 = 1.0f - weight;
+            }
+        }
+
+    #define BILINEAR_INTERPOLATE( res, x, y, r0, r1 ) \
+    res = XMVectorAdd(XMVectorScale(XMVectorAdd(XMVectorScale((r0)[ x.u0 ], x.weight0), XMVectorScale((r0)[ x.u1 ], x.weight1)), y.weight0), \
+                      XMVectorScale(XMVectorAdd(XMVectorScale((r1)[ x.u0 ], x.weight0), XMVectorScale((r1)[ x.u1 ], x.weight1)), y.weight1) );
+
+    #define TRILINEAR_INTERPOLATE( res, x, y, z, r0, r1, r2, r3 ) \
+{\
+    const XMVECTOR a0 = XMVectorScale(XMVectorAdd(XMVectorScale((r0)[ x.u0 ], x.weight0 ), XMVectorScale((r0)[ x.u1 ], x.weight1)), y.weight0); \
+    const XMVECTOR a1 = XMVectorScale(XMVectorAdd(XMVectorScale((r1)[ x.u0 ], x.weight0 ), XMVectorScale((r1)[ x.u1 ], x.weight1)), y.weight1); \
+    const XMVECTOR a2 = XMVectorScale(XMVectorAdd(XMVectorScale((r2)[ x.u0 ], x.weight0 ), XMVectorScale((r2)[ x.u1 ], x.weight1)), y.weight0); \
+    const XMVECTOR a3 = XMVectorScale(XMVectorAdd(XMVectorScale((r3)[ x.u0 ], x.weight0 ), XMVectorScale((r3)[ x.u1 ], x.weight1)), y.weight1); \
+    res = XMVectorAdd(XMVectorScale(XMVectorAdd(a0, a1), z.weight0), XMVectorScale(XMVectorAdd(a2, a3), z.weight1)); \
+}
+
+        //-------------------------------------------------------------------------------------
+        // Cubic filtering helpers
+        //-------------------------------------------------------------------------------------
+
+        XMGLOBALCONST XMVECTORF32 g_cubicThird = { { { 1.f / 3.f, 1.f / 3.f, 1.f / 3.f, 1.f / 3.f } } };
+        XMGLOBALCONST XMVECTORF32 g_cubicSixth = { { { 1.f / 6.f, 1.f / 6.f, 1.f / 6.f, 1.f / 6.f } } };
+        XMGLOBALCONST XMVECTORF32 g_cubicHalf = { { { 1.f / 2.f, 1.f / 2.f, 1.f / 2.f, 1.f / 2.f } } };
+
+        constexpr ptrdiff_t bounduvw(ptrdiff_t u, ptrdiff_t maxu, bool wrap, bool mirror) noexcept
+        {
+            if (wrap)
+            {
+                if (u < 0)
+                {
+                    u = maxu + u + 1;
+                }
+                else if (u > maxu)
+                {
+                    u = u - maxu - 1;
+                }
+            }
+            else if (mirror)
+            {
+                if (u < 0)
+                {
+                    u = (-u) - 1;
+                }
+                else if (u > maxu)
+                {
+                    u = maxu - (u - maxu - 1);
+                }
+            }
+
+            // Handles clamp, but also a safety factor for degenerate images for wrap/mirror
+            u = std::min<ptrdiff_t>(u, maxu);
+            u = std::max<ptrdiff_t>(u, 0);
+
+            return u;
+        }
+
+        struct CubicFilter
+        {
+            size_t  u0;
+            size_t  u1;
+            size_t  u2;
+            size_t  u3;
+            float   x;
+        };
+
+        inline void CreateCubicFilter(_In_ size_t source, _In_ size_t dest, _In_ bool wrap, _In_ bool mirror, _Out_writes_(dest) CubicFilter* cf) noexcept
+        {
+            assert(source > 0);
+            assert(dest > 0);
+            assert(cf != nullptr);
+
+            const float scale = float(source) / float(dest);
+
+            for (size_t u = 0; u < dest; ++u)
+            {
+                const float srcB = (float(u) + 0.5f) * scale - 0.5f;
+
+                const ptrdiff_t isrcB = bounduvw(ptrdiff_t(srcB), ptrdiff_t(source) - 1, wrap, mirror);
+                const ptrdiff_t isrcA = bounduvw(isrcB - 1, ptrdiff_t(source) - 1, wrap, mirror);
+                const ptrdiff_t isrcC = bounduvw(isrcB + 1, ptrdiff_t(source) - 1, wrap, mirror);
+                const ptrdiff_t isrcD = bounduvw(isrcB + 2, ptrdiff_t(source) - 1, wrap, mirror);
+
+                auto& entry = cf[u];
+                entry.u0 = size_t(isrcA);
+                entry.u1 = size_t(isrcB);
+                entry.u2 = size_t(isrcC);
+                entry.u3 = size_t(isrcD);
+
+                const float x = srcB - float(isrcB);
+                entry.x = x;
+            }
+        }
+
+    #define CUBIC_INTERPOLATE( res, dx, p0, p1, p2, p3 ) \
+{ \
+    const XMVECTOR a0 = (p1); \
+    const XMVECTOR d0 = XMVectorSubtract(p0, a0); \
+    const XMVECTOR d2 = XMVectorSubtract(p2, a0); \
+    const XMVECTOR d3 = XMVectorSubtract(p3, a0); \
+    XMVECTOR a1 = XMVectorSubtract(d2, XMVectorMultiply(g_cubicThird, d0)); \
+    a1 = XMVectorSubtract(a1, XMVectorMultiply(g_cubicSixth, d3)); \
+    const XMVECTOR a2 = XMVectorAdd(XMVectorMultiply(g_cubicHalf, d0), XMVectorMultiply(g_cubicHalf, d2)); \
+    XMVECTOR a3 = XMVectorSubtract(XMVectorMultiply(g_cubicSixth, d3), XMVectorMultiply(g_cubicSixth, d0)); \
+    a3 = XMVectorSubtract(a3, XMVectorMultiply(g_cubicHalf, d2)); \
+    const XMVECTOR vdx = XMVectorReplicate(dx); \
+    const XMVECTOR vdx2 = XMVectorMultiply(vdx, vdx); \
+    const XMVECTOR vdx3 = XMVectorMultiply(vdx2, vdx); \
+    res = XMVectorAdd(XMVectorAdd(XMVectorAdd(a0, XMVectorMultiply(a1, vdx)), XMVectorMultiply(a2, vdx2)), XMVectorMultiply(a3, vdx3)); \
+}
+
+
+        //-------------------------------------------------------------------------------------
+        // Triangle filtering helpers
+        //-------------------------------------------------------------------------------------
+
+        struct FilterTo
+        {
+            size_t      u;
+            float       weight;
+        };
+
+        struct FilterFrom
+        {
+            size_t      count;
+            size_t      sizeInBytes;
+            FilterTo    to[1]; // variable-sized array
+        };
+
+        struct Filter
+        {
+            size_t      sizeInBytes;
+            size_t      totalSize;
+            FilterFrom  from[1]; // variable-sized array
+        };
+
+        struct TriangleRow
+        {
+            size_t                      remaining;
+            TriangleRow* next;
+            ScopedAlignedArrayXMVECTOR  scanline;
+
+            TriangleRow() noexcept : remaining(0), next(nullptr) {}
+        };
+
+        constexpr size_t TF_FILTER_SIZE = sizeof(Filter) - sizeof(FilterFrom);
+        constexpr size_t TF_FROM_SIZE = sizeof(FilterFrom) - sizeof(FilterTo);
+        constexpr size_t TF_TO_SIZE = sizeof(FilterTo);
+
+        constexpr float TF_EPSILON = 0.00001f;
+
+        inline HRESULT CreateTriangleFilter(_In_ size_t source, _In_ size_t dest, _In_ bool wrap, _Inout_ std::unique_ptr<Filter>& tf) noexcept
+        {
+            assert(source > 0);
+            assert(dest > 0);
+
+            const float scale = float(dest) / float(source);
+            const float scaleInv = 0.5f / scale;
+
+            // Determine storage required for filter and allocate memory if needed
+            size_t totalSize = TF_FILTER_SIZE + TF_FROM_SIZE + TF_TO_SIZE;
+            const float repeat = (wrap) ? 1.f : 0.f;
+
+            for (size_t u = 0; u < source; ++u)
+            {
+                const float src = float(u) - 0.5f;
+                const float destMin = src * scale;
+                const float destMax = destMin + scale;
+                const float t = destMax - destMin + repeat + 1.f;
+                totalSize += TF_FROM_SIZE + TF_TO_SIZE + size_t(t) * TF_TO_SIZE * 2;
+            }
+
+            uint8_t* pFilter = nullptr;
+
+            if (tf)
+            {
+                // See if existing filter memory block is large enough to reuse
+                if (tf->totalSize >= totalSize)
+                {
+                    pFilter = reinterpret_cast<uint8_t*>(tf.get());
+                }
+                else
+                {
+                    // Need to reallocate filter memory block
+                    tf.reset(nullptr);
+                }
+            }
+
+            if (!tf)
+            {
+                // Allocate filter memory block
+                pFilter = new (std::nothrow) uint8_t[totalSize];
+                if (!pFilter)
+                    return E_OUTOFMEMORY;
+
+                tf.reset(reinterpret_cast<Filter*>(pFilter));
+                tf->totalSize = totalSize;
+            }
+
+            assert(pFilter != nullptr);
+            _Analysis_assume_(pFilter != nullptr);
+
+            // Filter setup
+            size_t sizeInBytes = TF_FILTER_SIZE;
+            size_t accumU = 0;
+            float accumWeight = 0.f;
+
+            for (size_t u = 0; u < source; ++u)
+            {
+                // Setup from entry
+                const size_t sizeFrom = sizeInBytes;
+                auto pFrom = reinterpret_cast<FilterFrom*>(pFilter + sizeInBytes);
+                sizeInBytes += TF_FROM_SIZE;
+
+                if (sizeInBytes > totalSize)
+                    return E_FAIL;
+
+                size_t toCount = 0;
+
+                // Perform two passes to capture the influences from both sides
+                for (size_t j = 0; j < 2; ++j)
+                {
+                    const float src = float(u + j) - 0.5f;
+
+                    float destMin = src * scale;
+                    float destMax = destMin + scale;
+
+                    if (!wrap)
+                    {
+                        // Clamp
+                        if (destMin < 0.f)
+                            destMin = 0.f;
+                        if (destMax > float(dest))
+                            destMax = float(dest);
+                    }
+
+                    for (auto k = static_cast<ptrdiff_t>(floorf(destMin)); float(k) < destMax; ++k)
+                    {
+                        float d0 = float(k);
+                        float d1 = d0 + 1.f;
+
+                        size_t u0;
+                        if (k < 0)
+                        {
+                            // Handle wrap
+                            u0 = size_t(k + ptrdiff_t(dest));
+                        }
+                        else if (k >= ptrdiff_t(dest))
+                        {
+                            // Handle wrap
+                            u0 = size_t(k - ptrdiff_t(dest));
+                        }
+                        else
+                        {
+                            u0 = size_t(k);
+                        }
+
+                        // Save previous accumulated weight (if any)
+                        if (u0 != accumU)
+                        {
+                            if (accumWeight > TF_EPSILON)
+                            {
+                                auto pTo = reinterpret_cast<FilterTo*>(pFilter + sizeInBytes);
+                                sizeInBytes += TF_TO_SIZE;
+                                ++toCount;
+
+                                if (sizeInBytes > totalSize)
+                                    return E_FAIL;
+
+                                pTo->u = accumU;
+                                pTo->weight = accumWeight;
+                            }
+
+                            accumWeight = 0.f;
+                            accumU = u0;
+                        }
+
+                        // Clip destination
+                        if (d0 < destMin)
+                            d0 = destMin;
+                        if (d1 > destMax)
+                            d1 = destMax;
+
+                        // Calculate average weight over destination pixel
+
+                        float weight;
+                        if (!wrap && src < 0.f)
+                            weight = 1.f;
+                        else if (!wrap && ((src + 1.f) >= float(source)))
+                            weight = 0.f;
+                        else
+                            weight = (d0 + d1) * scaleInv - src;
+
+                        accumWeight += (d1 - d0) * (j ? (1.f - weight) : weight);
+                    }
+                }
+
+                // Store accumulated weight
+                if (accumWeight > TF_EPSILON)
+                {
+                    auto pTo = reinterpret_cast<FilterTo*>(pFilter + sizeInBytes);
+                    sizeInBytes += TF_TO_SIZE;
+                    ++toCount;
+
+                    if (sizeInBytes > totalSize)
+                        return E_FAIL;
+
+                    pTo->u = accumU;
+                    pTo->weight = accumWeight;
+                }
+
+                accumWeight = 0.f;
+
+                // Finalize from entry
+                pFrom->count = toCount;
+                pFrom->sizeInBytes = sizeInBytes - sizeFrom;
+            }
+
+            tf->sizeInBytes = sizeInBytes;
+
+            return S_OK;
+        }
+
+    } // namespace Filters
+} // namespace DirectX

--- a/DirectXTex/DirectXTex/scoped.h
+++ b/DirectXTex/DirectXTex/scoped.h
@@ -1,0 +1,112 @@
+//-------------------------------------------------------------------------------------
+// scoped.h
+//
+// Utility header with helper classes for exception-safe handling of resources
+//
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+//-------------------------------------------------------------------------------------
+
+#pragma once
+
+#include <cassert>
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+#include <tuple>
+
+#ifndef _WIN32
+#include <cstdlib>
+
+struct aligned_deleter { void operator()(void* p) noexcept { free(p); } };
+
+using ScopedAlignedArrayFloat = std::unique_ptr<float[], aligned_deleter>;
+
+inline ScopedAlignedArrayFloat make_AlignedArrayFloat(uint64_t count)
+{
+    uint64_t size = sizeof(float) * count;
+    size = (size + 15u) & ~0xF;
+    if (size > static_cast<uint64_t>(UINT32_MAX))
+        return nullptr;
+
+    auto ptr = aligned_alloc(16, static_cast<size_t>(size));
+    return ScopedAlignedArrayFloat(static_cast<float*>(ptr));
+}
+
+using ScopedAlignedArrayXMVECTOR = std::unique_ptr<DirectX::XMVECTOR[], aligned_deleter>;
+
+inline ScopedAlignedArrayXMVECTOR make_AlignedArrayXMVECTOR(uint64_t count)
+{
+    uint64_t size = sizeof(DirectX::XMVECTOR) * count;
+    if (size > static_cast<uint64_t>(UINT32_MAX))
+        return nullptr;
+    auto ptr = aligned_alloc(16, static_cast<size_t>(size));
+    return ScopedAlignedArrayXMVECTOR(static_cast<DirectX::XMVECTOR*>(ptr));
+}
+
+#else // WIN32
+//---------------------------------------------------------------------------------
+#include <malloc.h>
+
+struct aligned_deleter { void operator()(void* p) noexcept { _aligned_free(p); } };
+
+using ScopedAlignedArrayFloat = std::unique_ptr<float[], aligned_deleter>;
+
+inline ScopedAlignedArrayFloat make_AlignedArrayFloat(uint64_t count)
+{
+    const uint64_t size = sizeof(float) * count;
+    if (size > static_cast<uint64_t>(UINT32_MAX))
+        return nullptr;
+    auto ptr = _aligned_malloc(static_cast<size_t>(size), 16);
+    return ScopedAlignedArrayFloat(static_cast<float*>(ptr));
+}
+
+using ScopedAlignedArrayXMVECTOR = std::unique_ptr<DirectX::XMVECTOR[], aligned_deleter>;
+
+inline ScopedAlignedArrayXMVECTOR make_AlignedArrayXMVECTOR(uint64_t count)
+{
+    const uint64_t size = sizeof(DirectX::XMVECTOR) * count;
+    if (size > static_cast<uint64_t>(UINT32_MAX))
+        return nullptr;
+    auto ptr = _aligned_malloc(static_cast<size_t>(size), 16);
+    return ScopedAlignedArrayXMVECTOR(static_cast<DirectX::XMVECTOR*>(ptr));
+}
+
+//---------------------------------------------------------------------------------
+struct handle_closer { void operator()(HANDLE h) noexcept { assert(h != INVALID_HANDLE_VALUE); if (h) CloseHandle(h); } };
+
+using ScopedHandle = std::unique_ptr<void, handle_closer>;
+
+inline HANDLE safe_handle(HANDLE h) noexcept { return (h == INVALID_HANDLE_VALUE) ? nullptr : h; }
+
+//---------------------------------------------------------------------------------
+struct find_closer { void operator()(HANDLE h) noexcept { assert(h != INVALID_HANDLE_VALUE); if (h) FindClose(h); } };
+
+using ScopedFindHandle = std::unique_ptr<void, find_closer>;
+
+//---------------------------------------------------------------------------------
+class auto_delete_file
+{
+public:
+    auto_delete_file(HANDLE hFile) noexcept : m_handle(hFile) {}
+
+    auto_delete_file(const auto_delete_file&) = delete;
+    auto_delete_file& operator=(const auto_delete_file&) = delete;
+
+    ~auto_delete_file()
+    {
+        if (m_handle)
+        {
+            FILE_DISPOSITION_INFO info = {};
+            info.DeleteFile = TRUE;
+            std::ignore = SetFileInformationByHandle(m_handle, FileDispositionInfo, &info, sizeof(info));
+        }
+    }
+
+    void clear() noexcept { m_handle = nullptr; }
+
+private:
+    HANDLE m_handle;
+};
+
+#endif // WIN32

--- a/DirectXTex/LICENSE
+++ b/DirectXTex/LICENSE
@@ -1,0 +1,21 @@
+    MIT License
+
+    Copyright (c) Microsoft Corporation.
+
+    Permission is hereby granted, free of charge, to any person obtaining a copy
+    of this software and associated documentation files (the "Software"), to deal
+    in the Software without restriction, including without limitation the rights
+    to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+    copies of the Software, and to permit persons to whom the Software is
+    furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in all
+    copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+    SOFTWARE

--- a/FaceGenExporter.h
+++ b/FaceGenExporter.h
@@ -86,15 +86,15 @@ namespace FaceGenExporter {
 			ComPtr<IDirect3DSurface9> pSysMemSurface;
 
 			result = spSourceTexture->GetSurfaceLevel(0, &pOriginalSurface);
-			if (SUCCEEDED(result)) {
+			if (SUCCEEDED(result))
 				result = spWorkingTexture->GetSurfaceLevel(0, &pSysMemSurface);
-				if (SUCCEEDED(result)) {
-					result = pDevice->GetRenderTargetData(pOriginalSurface.Get(), pSysMemSurface.Get());
-					if (FAILED(result)) {
-						_MESSAGE("Failed to update surface - %x", result);
-						return result;
-					}
-				}
+
+			if (SUCCEEDED(result))
+				result = pDevice->GetRenderTargetData(pOriginalSurface.Get(), pSysMemSurface.Get());
+
+			if (FAILED(result)) {
+				_MESSAGE("Failed to update surface - %x", result);
+				return result;
 			}
 		}
 		else {
@@ -140,12 +140,10 @@ namespace FaceGenExporter {
 		DirectX::ScratchImage kScratchMipMapImg;
 
 		// Move the image to a scratch image
-		if (DirectX::IsCompressed(kImg.format)) {
+		if (DirectX::IsCompressed(kImg.format))
 			DirectX::Decompress(kImg, DXGI_FORMAT_UNKNOWN, kScratchImg);
-		}
-		else {
+		else
 			kScratchImg.InitializeFromImage(kImg);
-		}
 
 		// Generate mipmaps
 		DirectX::GenerateMipMaps(kScratchImg.GetImages(), kScratchImg.GetImageCount(), kScratchImg.GetMetadata(), DirectX::TEX_FILTER_TRIANGLE, 0, kScratchMipMapImg);
@@ -161,15 +159,12 @@ namespace FaceGenExporter {
 
 		result = DirectX::SaveToDDSFile(kScratchMipMapImg.GetImages(), kScratchMipMapImg.GetImageCount(), kMetaData, DirectX::DDS_FLAGS_FORCE_DX9_LEGACY | DirectX::DDS_FLAGS_FORCE_RGB, wPath);
 
-		if (FAILED(result)) {
+		if (FAILED(result))
 			_MESSAGE("Failed to save texture to \"%s\" - %x", apPath, result);
-			goto FINISH;
-		}
 
-	FINISH:
 		delete[] kImg.pixels;
 		delete[] wPath;
-		return 0;
+		return S_OK;
 	}
 
 	// Returns a null pointer, so the body texture would be regenerated
@@ -214,7 +209,11 @@ namespace FaceGenExporter {
 			WriteRelCall(addr, (UInt32)FaceGenExporter::SaveTextureImage);
 
 		WriteRelCall(0x587D7F, (UInt32)FaceGenExporter::CreateTextureImage);
+	}
 
+	// Speeds up the process by console output while generating textures
+	// NPCs spam with animation prints at the end which locks down the program
+	static void NoLogging() {
 		// Shortcut
 		WriteRelJump(0x44AB57, UInt32(ObjectWindowF4HotkeyHook));
 		WriteRelCall(0x44AC23, (UInt32)ActionEnd);

--- a/FaceGenExporter.h
+++ b/FaceGenExporter.h
@@ -1,0 +1,185 @@
+#pragma once
+
+#include <string>
+#include <format>
+#include <filesystem>
+#include "DirectXTex/DirectXTex/DirectXTex.h"
+#include <d3d9.h>
+
+#include <Windows.Foundation.h>
+#include <wrl\wrappers\corewrappers.h>
+#include <wrl\client.h>
+#include <NiNodes.h>
+
+namespace fs = std::filesystem;
+
+LRESULT (__cdecl* FooterPrint)(WPARAM, LPARAM) = (LRESULT(__cdecl*)(WPARAM, LPARAM))(0x4657A0);
+
+using namespace ABI::Windows::Foundation;
+using namespace Microsoft::WRL;
+using namespace Microsoft::WRL::Wrappers;
+
+#pragma comment(lib, "DirectXTex/DirectXTex/Lib/DirectXTex.lib")
+
+namespace FaceGenExporter {
+	DXGI_FORMAT D3DToDXGI(D3DFORMAT aeFormat) {
+		switch (aeFormat) {
+		case D3DFMT_A8B8G8R8:
+			return DXGI_FORMAT_R8G8B8A8_UNORM;
+		case D3DFMT_A2B10G10R10:
+			return DXGI_FORMAT_R10G10B10A2_UNORM;
+		case D3DFMT_A8R8G8B8:
+			return DXGI_FORMAT_B8G8R8A8_UNORM;
+		case D3DFMT_X8R8G8B8:
+			return DXGI_FORMAT_B8G8R8X8_UNORM;
+		case D3DFMT_A16B16G16R16:
+			return DXGI_FORMAT_R16G16B16A16_UNORM;
+		case D3DFMT_A16B16G16R16F:
+			return DXGI_FORMAT_R16G16B16A16_FLOAT;
+		case D3DFMT_DXT1:
+			return DXGI_FORMAT_BC1_UNORM;
+		case D3DFMT_DXT3:
+			return DXGI_FORMAT_BC2_UNORM;
+		case D3DFMT_DXT5:
+			return DXGI_FORMAT_BC3_UNORM;
+		default:
+			return DXGI_FORMAT_UNKNOWN;
+		}
+	};
+
+	// Saves the texture as a BGR DDS file
+	static int __fastcall SaveTextureImage(void* apThis, void*, NiTexture* apTexture, const char* apPath, UInt32 aeFormat) {
+		if (apTexture == nullptr) {
+			_MESSAGE("NiTexture is null");
+			return D3DERR_INVALIDCALL;
+		}
+
+		NiDX9TextureData* pData = (NiDX9TextureData*)apTexture->rendererData;
+		ComPtr<IDirect3DTexture9> spSourceTexture = (LPDIRECT3DTEXTURE9)pData->m_pkD3DTexture;
+
+		auto pDevice = NiDX9Renderer::GetSingleton()->GetD3DDevice();
+
+		if (spSourceTexture.Get() == nullptr) {
+			_MESSAGE("D3D Texture is null");
+			return D3DERR_INVALIDCALL;
+		}
+
+
+		// Get texture description
+		D3DSURFACE_DESC kDesc;
+		spSourceTexture->GetLevelDesc(0, &kDesc);
+
+		ComPtr<IDirect3DTexture9> spWorkingTexture;
+		HRESULT result;
+
+		// If the texture is in default pool, create a system memory texture to copy the data to
+		if (kDesc.Pool == D3DPOOL_DEFAULT) {
+			result = pDevice->CreateTexture(kDesc.Width, kDesc.Height, 1, 0, kDesc.Format, D3DPOOL_SYSTEMMEM, spWorkingTexture.GetAddressOf(), nullptr);
+			if (FAILED(result)) {
+				_MESSAGE("Failed to create system memory texture - %x", result);
+				return result;
+			}
+
+			ComPtr<IDirect3DSurface9> pOriginalSurface;
+			ComPtr<IDirect3DSurface9> pSysMemSurface;
+
+			result = spSourceTexture->GetSurfaceLevel(0, &pOriginalSurface);
+			if (SUCCEEDED(result)) {
+				result = spWorkingTexture->GetSurfaceLevel(0, &pSysMemSurface);
+				if (SUCCEEDED(result)) {
+					result = pDevice->GetRenderTargetData(pOriginalSurface.Get(), pSysMemSurface.Get());
+					if (FAILED(result)) {
+						_MESSAGE("Failed to update surface - %x", result);
+						return result;
+					}
+				}
+			}
+		}
+		else {
+			spWorkingTexture = spSourceTexture;
+		}
+
+		// Lock the texture, so we can read its pixel data
+		D3DLOCKED_RECT kLockedRect;
+		result = spWorkingTexture->LockRect(0, &kLockedRect, nullptr, D3DLOCK_READONLY);
+		if (FAILED(result)) {
+			if (result == D3DERR_WASSTILLDRAWING)
+				_MESSAGE("Texture is still drawing");
+			else if (result == D3DERR_INVALIDCALL)
+				_MESSAGE("Invalid call to lock texture");
+			else
+				_MESSAGE("Failed to lock texture - %x", result);
+			return result;
+		}
+
+		if (kLockedRect.pBits == nullptr) {
+			_MESSAGE("Locked bits are null");
+			spWorkingTexture->UnlockRect(0);
+			return result;
+		}
+
+		// Create an image to store the texture data
+		DirectX::Image kImg = {};
+
+		// Copy the pixel data to a new buffer
+		size_t uiSize = kLockedRect.Pitch * kDesc.Height;
+		kImg.pixels = new uint8_t[uiSize];
+		memcpy(kImg.pixels, kLockedRect.pBits, uiSize);
+
+		spWorkingTexture->UnlockRect(0);
+
+		// Fill other image properties
+		kImg.height = kDesc.Height;
+		kImg.width = kDesc.Width;
+		kImg.format = D3DToDXGI(kDesc.Format);
+		DirectX::ComputePitch(kImg.format, kImg.width, kImg.height, kImg.rowPitch, kImg.slicePitch, DirectX::CP_FLAGS_LEGACY_DWORD);
+
+		DirectX::ScratchImage kScratchImg;
+		DirectX::ScratchImage kScratchMipMapImg;
+
+		// Move the image to a scratch image
+		if (DirectX::IsCompressed(kImg.format)) {
+			DirectX::Decompress(kImg, DXGI_FORMAT_UNKNOWN, kScratchImg);
+		}
+		else {
+			kScratchImg.InitializeFromImage(kImg);
+		}
+
+		// Generate mipmaps
+		DirectX::GenerateMipMaps(kScratchImg.GetImages(), kScratchImg.GetImageCount(), kScratchImg.GetMetadata(), DirectX::TEX_FILTER_TRIANGLE, 0, kScratchMipMapImg);
+
+		// Set the alpha mode to opaque (default is unknown)
+		DirectX::TexMetadata kMetaData = kScratchMipMapImg.GetMetadata();
+		kMetaData.SetAlphaMode(DirectX::TEX_ALPHA_MODE_OPAQUE);
+
+		// Convert char to wchar_t
+		size_t size = strlen(apPath) + 1;
+		wchar_t* wPath = new wchar_t[size];
+		mbstowcs_s(nullptr, wPath, size, apPath, size);
+
+		result = DirectX::SaveToDDSFile(kScratchMipMapImg.GetImages(), kScratchMipMapImg.GetImageCount(), kMetaData, DirectX::DDS_FLAGS_FORCE_DX9_LEGACY | DirectX::DDS_FLAGS_FORCE_RGB, wPath);
+
+		if (FAILED(result)) {
+			_MESSAGE("Failed to save texture to \"%s\" - %x", apPath, result);
+			goto FINISH;
+		}
+
+	FINISH:
+		delete[] kImg.pixels;
+		delete[] wPath;
+		return 0;
+	}
+
+	// Returns a null pointer, so the body texture would be regenerated
+	// Vanilla skips generation if the texture already exists
+	void __fastcall CreateTextureImage(void* apThis, void*, const char* apPath, NiSourceTexture* aspTexture, bool abNoFileOK, BOOL abArchiveOnly) {
+		aspTexture = nullptr;
+	}
+
+	static void InitHooks() {
+		for (UInt32 addr : { 0x570C36, 0x570D54, 0x574801, 0x5749F9 })
+			WriteRelCall(addr, (UInt32)FaceGenExporter::SaveTextureImage);
+
+		WriteRelCall(0x587D7F, (UInt32)FaceGenExporter::CreateTextureImage);
+	}
+};

--- a/LogWindow.cpp
+++ b/LogWindow.cpp
@@ -10,6 +10,7 @@
 
 HWND g_ConsoleHwnd;
 extern HWND g_MainHwnd;
+extern bool g_bPauseLogging = false;
 
 void Console_PrintVa(const char* Format, va_list Va)
 {
@@ -30,6 +31,9 @@ void Console_PrintVa(const char* Format, va_list Va)
 
 void Console_Print(const char* Format, ...)
 {
+	if (g_bPauseLogging)
+		return;
+
 	va_list va;
 	va_start(va, Format);
 	Console_PrintVa(Format, va);
@@ -38,6 +42,9 @@ void Console_Print(const char* Format, ...)
 
 int __cdecl Console_Print2(const char* Format, ...)
 {
+	if (g_bPauseLogging)
+		return 0;
+
 	va_list va;
 	va_start(va, Format);
 	Console_PrintVa(Format, va);

--- a/Main.cpp
+++ b/Main.cpp
@@ -643,20 +643,25 @@ bool NVSEPlugin_Load(const NVSEInterface* nvse)
 	// make weapon mods in object window show the same information as misc items
 	SafeWrite8(0x438B94 + kFormType_ItemMod, 0x11);
 
-	if (config.bNoFacegenCompression) {
-		FaceGenExporter::InitHooks();
-		config.bPreventFaceAndBodyModExports = true;
-	}
-	
-	if (config.bPreventFaceAndBodyModExports) {
-		// prevent .tga files when exporting
-		SafeWriteBuf(0x57481B, "\x83\xC4\x0C\x90\x90", 5); // face mods
-		SafeWriteBuf(0x574A0F, "\x83\xC4\x0C\x90\x90", 5); // face mods
+	// Facegen section
+	{
+		// Skips console output from processed actors to speed up the export process
+		FaceGenExporter::NoLogging();
 
-		SafeWriteBuf(0x570D6B, "\x83\xC4\x0C\x90\x90", 5); // body mods
-		SafeWriteBuf(0x570C50, "\x83\xC4\x0C\x90\x90", 5); // body mods
-	}
+		if (config.bNoFacegenCompression) {
+			FaceGenExporter::InitHooks();
+			config.bPreventFaceAndBodyModExports = true;
+		}
 
+		if (config.bPreventFaceAndBodyModExports) {
+			// prevent .tga files when exporting
+			SafeWriteBuf(0x57481B, "\x83\xC4\x0C\x90\x90", 5); // face mods
+			SafeWriteBuf(0x574A0F, "\x83\xC4\x0C\x90\x90", 5); // face mods
+
+			SafeWriteBuf(0x570D6B, "\x83\xC4\x0C\x90\x90", 5); // body mods
+			SafeWriteBuf(0x570C50, "\x83\xC4\x0C\x90\x90", 5); // body mods
+		}
+	}
 	if (config.bIgnoreD3D9)
 	{
 		// ignore the d3d9.dll from the game's folder since dxvk makes the geck super slow

--- a/Main.cpp
+++ b/Main.cpp
@@ -650,7 +650,9 @@ bool NVSEPlugin_Load(const NVSEInterface* nvse)
 	
 	if (config.bPreventFaceAndBodyModExports) {
 		// prevent .tga files when exporting
+		SafeWriteBuf(0x57481B, "\x83\xC4\x0C\x90\x90", 5); // face mods
 		SafeWriteBuf(0x574A0F, "\x83\xC4\x0C\x90\x90", 5); // face mods
+
 		SafeWriteBuf(0x570D6B, "\x83\xC4\x0C\x90\x90", 5); // body mods
 		SafeWriteBuf(0x570C50, "\x83\xC4\x0C\x90\x90", 5); // body mods
 	}

--- a/Main.cpp
+++ b/Main.cpp
@@ -42,6 +42,7 @@
 #include "NavMeshPickPreventer.h"
 #include "CustomRenderWindowHotkeys.h"
 #include "LaunchGame.h"
+#include "FaceGenExporter.h"
 
 #include "Events/EventManager.h"
 #include "Events/Events.h"
@@ -642,8 +643,12 @@ bool NVSEPlugin_Load(const NVSEInterface* nvse)
 	// make weapon mods in object window show the same information as misc items
 	SafeWrite8(0x438B94 + kFormType_ItemMod, 0x11);
 
-	if (config.bPreventFaceAndBodyModExports)
-	{
+	if (config.bNoFacegenCompression) {
+		FaceGenExporter::InitHooks();
+		config.bPreventFaceAndBodyModExports = true;
+	}
+	
+	if (config.bPreventFaceAndBodyModExports) {
 		// prevent .tga files when exporting
 		SafeWriteBuf(0x574A0F, "\x83\xC4\x0C\x90\x90", 5); // face mods
 		SafeWriteBuf(0x570D6B, "\x83\xC4\x0C\x90\x90", 5); // body mods
@@ -676,8 +681,7 @@ bool NVSEPlugin_Load(const NVSEInterface* nvse)
 
 	if (config.bNoRecordCompression) {
 		// Remove record compression
-		XUtil::PatchMemoryNop(0x5726C9, 5); // TESNPC
-		SafeWrite8(0x5726C9, 0xC3);
+		SafeWriteBuf(0x5726C9, "\xC3\x90\x90\x90\x90", 5); // TESNPC
 
 		XUtil::PatchMemoryNop(0x624632, 5); // TESObjectLAND
 	}

--- a/Main.h
+++ b/Main.h
@@ -1845,9 +1845,7 @@ typedef HRESULT(__stdcall* D3DXCreateTextureFromFileInMemoryEx_)(_In_    void* p
 
 enum d3
 {
-	D3DFMT_UNKNOWN = 0,
 	D3DX_DEFAULT = -1,
-	D3DPOOL_DEFAULT = 0
 };
 
 D3DXCreateTextureFromFileInMemoryEx_ D3DXCreateTextureFromFileInMemoryEx;

--- a/Settings.cpp
+++ b/Settings.cpp
@@ -36,6 +36,7 @@ void ReadAllSettings()
 	config.bDisableTextureMirroring = GetOrCreateINIValue("General", "bDisableTextureMirroring", 0, IniPath);
 	config.bObjectWindowOnlyShowEditedByDefault = GetOrCreateINIValue("General", "bObjectWindowOnlyShowEditedForms", 0, IniPath);
 	config.bPreventFaceAndBodyModExports = GetOrCreateINIValue("General", "bFaceBodyExportPreventTGAFiles", 0, IniPath);
+	config.bNoFacegenCompression = GetOrCreateINIValue("General", "bNoFacegenCompression", 1, IniPath);
 	config.bIgnoreD3D9 = GetOrCreateINIValue("General", "bIgnoreD3D9", 1, IniPath);
 	config.bNoRecordCompression = GetOrCreateINIValue("General", "bNoRecordCompression", 1, IniPath);
 	config.bPreserveTimestamps = GetOrCreateINIValue("General", "bPreserveTimestamps", 0, IniPath);

--- a/ZeGaryHax.sln
+++ b/ZeGaryHax.sln
@@ -1,11 +1,16 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 15
-VisualStudioVersion = 15.0.27130.2036
+# Visual Studio Version 17
+VisualStudioVersion = 17.11.34909.67
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "ZeGaryHax", "ZeGaryHax.vcxproj", "{AE7CFEE7-4058-4E3C-ADC2-AE7480EE2028}"
+	ProjectSection(ProjectDependencies) = postProject
+		{371B9FA9-4C90-4AC6-A123-ACED756D6C77} = {371B9FA9-4C90-4AC6-A123-ACED756D6C77}
+	EndProjectSection
 EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "common_vc9", "common\common_vc9.vcxproj", "{20C6411C-596F-4B85-BE4E-8BC91F59D8A6}"
+EndProject
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "DirectXTex", "DirectXTex\DirectXTex\DirectXTex_Desktop_2022_Win10.vcxproj", "{371B9FA9-4C90-4AC6-A123-ACED756D6C77}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -21,6 +26,10 @@ Global
 		{20C6411C-596F-4B85-BE4E-8BC91F59D8A6}.Debug|Win32.Build.0 = Debug|Win32
 		{20C6411C-596F-4B85-BE4E-8BC91F59D8A6}.Release|Win32.ActiveCfg = Release|Win32
 		{20C6411C-596F-4B85-BE4E-8BC91F59D8A6}.Release|Win32.Build.0 = Release|Win32
+		{371B9FA9-4C90-4AC6-A123-ACED756D6C77}.Debug|Win32.ActiveCfg = Debug|Win32
+		{371B9FA9-4C90-4AC6-A123-ACED756D6C77}.Debug|Win32.Build.0 = Debug|Win32
+		{371B9FA9-4C90-4AC6-A123-ACED756D6C77}.Release|Win32.ActiveCfg = Release|Win32
+		{371B9FA9-4C90-4AC6-A123-ACED756D6C77}.Release|Win32.Build.0 = Release|Win32
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/ZeGaryHax.vcxproj
+++ b/ZeGaryHax.vcxproj
@@ -258,6 +258,7 @@ copy "$(TargetDir)$(TargetName).pdb" "$(FalloutNVPath)\Data\NVSE\Plugins\$(Targe
       <SubType>
       </SubType>
     </ClInclude>
+    <ClInclude Include="FaceGenExporter.h" />
     <ClInclude Include="FormSearch.h">
       <SubType>
       </SubType>

--- a/ZeGaryHax.vcxproj.filters
+++ b/ZeGaryHax.vcxproj.filters
@@ -188,6 +188,7 @@
       <Filter>Events</Filter>
     </ClInclude>
     <ClInclude Include="LaunchGame.h" />
+    <ClInclude Include="FaceGenExporter.h" />
   </ItemGroup>
   <ItemGroup>
     <None Include="exports.def" />

--- a/common/IPrefix.h
+++ b/common/IPrefix.h
@@ -9,8 +9,8 @@
 // 4312 - pointer extension
 #pragma warning(disable: 4018 4244 4267 4305 4288 4312 4311)
 
-// winxp and above
-#define _WIN32_WINNT	0x0501
+// Vista and above
+#define _WIN32_WINNT	0x0600
 
 #include <cstdlib>
 #include <cstdio>


### PR DESCRIPTION
Added support for exporting textures as uncompressed (BGR) DDS.
Because of that:
- Had to modify DirectXTex's writer to support BGR writes.
- Bumped up Windows requirement to Vista (DirectXTex requirement).

Also disabled console print for when generating textures to speed up the process a bit.