### PR TITLE
Landscape editing tweaks

### DIFF
--- a/ExtensionsMenu.cpp
+++ b/ExtensionsMenu.cpp
@@ -12,6 +12,8 @@
 #include "MultiBoundsAdder.h"
 #include "ToggleReferenceMovement.h"
 
+#define UI_MENU_LANDSCAPE_KEY	40190
+#define UI_MENU_LANDSCAPE_BAR	40191
 #define UI_EXTMENU_ID			51001
 #define UI_EXTMENU_SHOWLOG		51002
 #define UI_EXTMENU_CLEARLOG		51003
@@ -416,6 +418,15 @@ LRESULT CALLBACK MainWindowCallback(HWND Hwnd, UINT Message, WPARAM wParam, LPAR
 
 		switch (param)
 		{
+		case UI_MENU_LANDSCAPE_KEY:
+		case UI_MENU_LANDSCAPE_BAR:
+		{
+			// Disallow closing the landscape dialog when painting is in progress.
+			if (RenderWindow::IsLandscapePainting())
+				return 0;
+		}
+		return CallWindowProc(originalMainWindowCallback, Hwnd, Message, wParam, lParam);
+
 		case UI_EXTMENU_SHOWLOG:
 		{
 			ShowWindow(g_ConsoleHwnd, SW_SHOW);

--- a/GECKUtility.h
+++ b/GECKUtility.h
@@ -115,6 +115,8 @@ struct RenderWindow
 	static bool GetMousePos(NiPoint3* aPosOut, NiPoint3* aRotOut = nullptr);
 	static TESObjectCELL* GetCurrentCell();
 	static bool InLandscapeEditingMode();
+	static bool IsLandscapePainting();
+	static void ResetLandscapePainting();
 };
 
 struct ObjectsView

--- a/GeckUtility.cpp
+++ b/GeckUtility.cpp
@@ -155,6 +155,11 @@ bool RenderWindow::GetMousePos(NiPoint3* aPosOut, NiPoint3* aRotOut) {
 
 TESObjectCELL* RenderWindow::GetCurrentCell() { return *(TESObjectCELL**)0xED1174; };
 bool RenderWindow::InLandscapeEditingMode() { return *(bool*)0xED142D; };
+bool RenderWindow::IsLandscapePainting() { return *(bool*)0xED13D8 || *(bool*)0xED13E6; };
+void RenderWindow::ResetLandscapePainting() { 
+	*(bool*)0xED13D8 = false;;
+	*(bool*)0xED13E6 = false;
+}
 
 RenderWindow::SelectedData* RenderWindow::SelectedData::GetSelected() { return *(SelectedData**)0xECFB8C; }
 RenderWindow::SelectedData* RenderWindow::SelectedData::GetClipboard() { return *(SelectedData**)0xECFB90; }

--- a/Main.h
+++ b/Main.h
@@ -1994,6 +1994,11 @@ BOOL __stdcall LandscapeEditCallback(HWND hWnd, UINT Message, WPARAM wParam, LPA
 	{
 		SetWindowPos(hWnd, NULL, savedLandscapeEditPos.x, savedLandscapeEditPos.y, NULL, NULL, SWP_NOSIZE);
 	}
+	else if (Message == WM_COMMAND && wParam == 2) {
+		// Avoid closing window if landscape painting is in progress.
+		if (RenderWindow::IsLandscapePainting())
+			return 0;
+	}
 	return CallWindowProc(originalLandscapeEditCallback, hWnd, Message, wParam, lParam);
 }
 

--- a/Main.h
+++ b/Main.h
@@ -1256,7 +1256,19 @@ BOOL __stdcall RenderWindowCallbackHook(HWND hWnd, UINT msg, WPARAM wParam, LPAR
 	else if (msg == WM_RBUTTONDOWN) {
 		SetFlycamMode(0);
 	}
-	return StdCall<LRESULT>(0x455AA0, hWnd, msg, wParam, lParam);
+	else if (msg == 0x416u && wParam == 0) {
+		// Disabling landscape editing.
+		RenderWindow::ResetLandscapePainting();
+	}
+
+	LRESULT res = StdCall<LRESULT>(0x455AA0, hWnd, msg, wParam, lParam);
+
+	if (msg == 0x416u && wParam == 0 && config.bRenderWindowRefreshAfterLandscapeEdit) {
+		// Refresh render window after landscape editing disabled.
+		StdCall<LRESULT>(0x455AA0, hWnd, WM_KEYDOWN, VK_F5, lParam);
+	}
+
+	return res;
 }
 
 class BGSPrimitive;

--- a/Settings.cpp
+++ b/Settings.cpp
@@ -67,6 +67,7 @@ void ReadAllSettings()
 	config.bAutoLightWarnings = GetOrCreateINIValue("Render Window", "bAutoLightWarnings", 0, IniPath);
 	config.iRenderFOV = GetOrCreateINIValue("Render Window", "iFOV", 90, IniPath);
 	config.bRenderWindowPreventRefMovementByDefault = GetOrCreateINIValue("Render Window", "bPreventRefMovement", 0, IniPath);
+	config.bRenderWindowRefreshAfterLandscapeEdit = GetOrCreateINIValue("Render Window", "bRefreshAfterLandscapeEdit", 1, IniPath);
 
 	config.bSmoothFlycamRotation = GetOrCreateINIValue("Flycam", "bSmoothRotation", 1, IniPath);
 	config.bFlycamUpDownRelativeToWorld = GetOrCreateINIValue("Flycam", "bFlycamUpDownRelativeToWorld", 1, IniPath);

--- a/Settings.h
+++ b/Settings.h
@@ -62,6 +62,7 @@ struct Settings
 	bool bAllowHardDeletionInESMs;
 	bool bAddFilterCtrlBackspace;
 	bool bRenderWindowPreventRefMovementByDefault;
+	bool bRenderWindowRefreshAfterLandscapeEdit;
 
 	int bUseAltShiftMultipliers;
 	float fMovementAltMultiplier;


### PR DESCRIPTION
Two tweaks for landscape editing:

1) Disallow closing the landscape editing settings window when painting is in progress, because the state is not properly reset causing weird issues.
2) Force a full render window refresh when the window is actually closed (configurable). This is because even with 1. there are edge cases when certain terrain chunks get weirdly corrupted after the window is closed.