### PR TITLE
Add ini option to recompile all scripts from a specific mod

### DIFF
--- a/Main.cpp
+++ b/Main.cpp
@@ -1134,6 +1134,13 @@ bool NVSEPlugin_Load(const NVSEInterface* nvse)
 
 	ToggleReferenceMovement::InitHooks();
 
+	// recompiling all scripts will only recompile SCPT forms, optionally only from a specified mod
+	if (config.bRecompileAllScriptsSCPTFormsOnly)
+	{
+		WriteRelJump(0x5C3A56, 0x5C3BC8);
+		WriteRelCall(0x5C397C, UInt32(OnRecompileAllShouldProcessScript));
+	}
+
 #ifdef _DEBUG
 	while(!IsDebuggerPresent())
 	{

--- a/Main.h
+++ b/Main.h
@@ -706,10 +706,30 @@ _declspec(naked) void hk_PreviewWindowCheckForeground() {
 	}
 }
 
+UInt32 recompileAllScriptsModIndex = -1;
+void __fastcall setRecompileAllScriptsModIndex() {
+	if (*config.sRecompileAllScriptsModName && config.bRecompileAllScriptsSCPTFormsOnly)
+	{
+		auto mod = DataHandler::GetSingleton()->LookupModByName(config.sRecompileAllScriptsModName);
+		if (mod)
+		{
+			recompileAllScriptsModIndex = mod->modIndex;
+		}
+		else
+		{
+			Console_Print("Recompile all scripts: Unable to find mod %s", config.sRecompileAllScriptsModName);
+		}
+	}
+}
+
 const char* recompileAllWarning = { "Are you sure you want to recompile every script in every plugin?\nYou should never need to do this." };
 _declspec(naked) void RecompileAllWarningScriptHook() {
 	static const UInt32 retnAddr = 0x5C498A;
 	_asm {
+		pushad
+		call setRecompileAllScriptsModIndex
+		popad
+
 		push 0x104 // change default button to No
 		push 0xD2FA78
 		push recompileAllWarning
@@ -719,6 +739,10 @@ _declspec(naked) void RecompileAllWarningScriptHook() {
 _declspec(naked) void RecompileAllWarningMainHook() {
 	static const UInt32 retnAddr = 0x4442D3;
 	_asm {
+		pushad
+		call setRecompileAllScriptsModIndex
+		popad
+
 		push 0x104 // change default button to No
 		push 0xD2FA78
 		push recompileAllWarning
@@ -4305,4 +4329,15 @@ void __fastcall ObjectWindowNodeData__OnPopulateReputationList(ObjectWindowNodeD
 
 	auto challengesList = reinterpret_cast<tList<TESForm>*>((UInt32)apReputationList + 8); // &DataHandler->reputationList -> &DataHandler->challengesList
 	ThisCall(0x438C70, apNodeData, challengesList, abClear, formal);
+}
+
+bool __stdcall OnRecompileAllShouldProcessScript(Script* script, int iValue)
+{
+	if (recompileAllScriptsModIndex != -1 && script->modIndex != recompileAllScriptsModIndex) 
+	{
+		return false;
+	}
+
+	StdCall(0x5C9800, script, 0);
+	return true;
 }

--- a/Settings.cpp
+++ b/Settings.cpp
@@ -103,6 +103,9 @@ void ReadAllSettings()
 
 	config.uiHeapMaxSizeMB = GetOrCreateINIValue("Heap", "uiHeapMaxSizeMB", 800, IniPath);
 	config.uiHeapInitialSizeMB = GetOrCreateINIValue("Heap", "uiHeapInitialSizeMB", 600, IniPath);
+	
+	config.bRecompileAllScriptsSCPTFormsOnly = GetOrCreateINIValue("Recompile All Scripts", "bRecompileAllScriptsSCPTFormsOnly", 1, IniPath);
+	config.sRecompileAllScriptsModName = GetOrCreateINIValue("Recompile All Scripts", "sModName", "", IniPath);
 }
 
 #define INI_SETTING_NOT_FOUND -1

--- a/Settings.h
+++ b/Settings.h
@@ -101,6 +101,9 @@ struct Settings
 
 	UInt32 uiHeapMaxSizeMB;
 	UInt32 uiHeapInitialSizeMB;
+
+	bool bRecompileAllScriptsSCPTFormsOnly;
+	char* sRecompileAllScriptsModName;
 };
 
 extern Settings config;


### PR DESCRIPTION
Recompiling all scripts will be useful for maintaining mods that make use of the NVSEScript compiler as some updates might require recompilation.

I didn't feel like adding support for package, terminal, perk, or dialogue result scripts since they're irrelevant to the problem, so there's a second ini setting to enable both patches.